### PR TITLE
Refactor commands for new glazed API

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ builds:
   - env:
       - CGO_ENABLED=0
     main: ./cmd/pinocchio
-    binary: program
+    binary: pinocchio
     goos:
       - linux
 # I am not able to test windows at the time

--- a/cmd/pinocchio/main.go
+++ b/cmd/pinocchio/main.go
@@ -90,7 +90,7 @@ func loadRepositoryCommands(helpSystem *help.HelpSystem) ([]*geppetto_cmds.Geppe
 			log.Warn().Msgf("Repository %s is not a directory", repository)
 		} else {
 			docDir := fmt.Sprintf("%s/doc", repository)
-			commands_, aliases_, err := glazed_cmds.LoadCommandsFromDirectory(loader, repository, repository)
+			commands_, aliases_, err := glazed_cmds.LoadCommandsFromFS(loader, os.DirFS(repository), "file", ".", repository)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -163,7 +163,7 @@ func initCommands(
 
 	loader := &geppetto_cmds.GeppettoCommandLoader{}
 	var commands []*geppetto_cmds.GeppettoCommand
-	commands_, aliases, err := glazed_cmds.LoadCommandsFromEmbedFS(loader, promptsFS, ".", "prompts/")
+	commands_, aliases, err := glazed_cmds.LoadCommandsFromFS(loader, promptsFS, "embed", ".", "prompts/")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/pinocchio/main.go
+++ b/cmd/pinocchio/main.go
@@ -106,7 +106,7 @@ func loadRepositoryCommands(helpSystem *help.HelpSystem) ([]*geppetto_cmds.Geppe
 				log.Debug().Err(err).Msgf("Error while checking directory %s", docDir)
 				continue
 			}
-			err = helpSystem.LoadSectionsFromDirectory(docDir)
+			err = helpSystem.LoadSectionsFromFS(os.DirFS(docDir), "/")
 			if err != nil {
 				log.Warn().Err(err).Msgf("Error while loading help sections from directory %s", repository)
 				continue
@@ -171,7 +171,7 @@ func initCommands(
 		commands = append(commands, command.(*geppetto_cmds.GeppettoCommand))
 	}
 
-	err = helpSystem.LoadSectionsFromEmbedFS(promptsFS, "prompts/doc")
+	err = helpSystem.LoadSectionsFromFS(promptsFS, "prompts/doc")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -248,7 +248,7 @@ func main() {
 
 func init() {
 	helpSystem := help.NewHelpSystem()
-	err := helpSystem.LoadSectionsFromEmbedFS(docFS, ".")
+	err := helpSystem.LoadSectionsFromFS(docFS, ".")
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/charmbracelet/bubbles v0.15.0
 	github.com/charmbracelet/bubbletea v0.23.1
 	github.com/charmbracelet/lipgloss v0.6.0
-	github.com/go-go-golems/glazed v0.2.3
+	github.com/go-go-golems/glazed v0.2.4
 	github.com/mb0/glob v0.0.0-20160210091149-1eb79d2de6c4
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-go-golems/glazed v0.2.3 h1:XwiGqv1z3p6LlmBx79327iYrm16lqKya8Gv88dYlO2E=
 github.com/go-go-golems/glazed v0.2.3/go.mod h1:lGQ+K9u8+YQdAd8EiYBsOjrZAAdZvV/0tW0TlmZII5s=
+github.com/go-go-golems/glazed v0.2.4 h1:8MC376ff0rRuykSlww7M+sgpBcC0FCqbOmIQWAGiwWs=
+github.com/go-go-golems/glazed v0.2.4/go.mod h1:lGQ+K9u8+YQdAd8EiYBsOjrZAAdZvV/0tW0TlmZII5s=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
See: 
- https://github.com/go-go-golems/glazed/pull/118
- https://github.com/go-go-golems/glazed/issues/115

```
 _______  _______    _______  _______    _______  _______
|       ||       |  |       ||       |  |       ||       |
|    ___||   _   |  |    ___||   _   |  |    ___||   _   |
|   | __ |  | |  |  |   | __ |  | |  |  |   | __ |  | |  |
|   ||  ||  |_|  |  |   ||  ||  |_|  |  |   ||  ||  |_|  |
|   |_| ||       |  |   |_| ||       |  |   |_| ||       |
|_______||_______|  |_______||_______|  |_______||_______|
 _______  _______  __   __  __   __  _______  __    _  ______   _______
|       ||       ||  |_|  ||  |_|  ||   _   ||  |  | ||      | |       |
|       ||   _   ||       ||       ||  |_|  ||   |_| ||  _    ||  _____|
|       ||  | |  ||       ||       ||       ||       || | |   || |_____
|      _||  |_|  ||       ||       ||       ||  _    || |_|   ||_____  |
|     |_ |       || ||_|| || ||_|| ||   _   || | |   ||       | _____| |
|_______||_______||_|   |_||_|   |_||__| |__||_|  |__||______| |_______|
```


- :art: Update goreleaser for proper binary name
- :art: :recycle: Refactor to remove use of embed.FS
- :recycle: Refactor to load commands from FS using a single function
