### PR TITLE
Implement Environment Override for AI Engine Setting

### DIFF
--- a/pkg/steps/ai/settings/settings-chat.go
+++ b/pkg/steps/ai/settings/settings-chat.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/spf13/viper"
 )
 
 type ChatSettings struct {
@@ -55,7 +56,14 @@ func (s *ChatSettings) UpdateFromParsedLayer(layer *layers.ParsedParameterLayer)
 		}
 	}
 
+	// order of precedence: layer parameters, then viper, then step defaults
+	engine := viper.GetString("ai-engine")
+	if engine != "" {
+		s.Engine = &engine
+	}
+
 	err := parameters.InitializeStructFromParameters(s, layer.Parameters)
+
 	return err
 }
 


### PR DESCRIPTION
In `settings-chat.go`, the AI engine setting can now be overridden by the
environment. This is achieved by using the `viper.GetString("ai-engine")`
function to get the AI engine setting from the environment. If an AI engine
setting is found in the environment, it is used to override the current setting.
