### PR TITLE
Integrate new layers API in Cobra command setup

### DIFF
--- a/cmd/experiments/agent/main.go
+++ b/cmd/experiments/agent/main.go
@@ -4,8 +4,9 @@ import (
 	clay "github.com/go-go-golems/clay/pkg"
 	"github.com/go-go-golems/geppetto/cmd/experiments/agent/codegen"
 	"github.com/go-go-golems/geppetto/cmd/experiments/agent/tool"
+	"github.com/go-go-golems/geppetto/pkg/cmds"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
-	openai2 "github.com/go-go-golems/geppetto/pkg/steps/ai/settings/openai"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/go-go-golems/glazed/pkg/help"
 	"github.com/spf13/cobra"
 )
@@ -25,37 +26,30 @@ func main() {
 
 	helpSystem.SetupCobraRootCommand(rootCmd)
 
-	err := clay.InitViper("pinocchio", rootCmd)
+	stepSettings := settings.NewStepSettings()
+	geppettoLayers, err := cmds.CreateGeppettoLayers(stepSettings)
+	cobra.CheckErr(err)
+
+	pLayers := layers.NewParameterLayers(layers.WithLayers(geppettoLayers...))
+
+	err = clay.InitViper("pinocchio", rootCmd)
 	cobra.CheckErr(err)
 	err = clay.InitLogger()
 	cobra.CheckErr(err)
 
-	layer, err := openai2.NewParameterLayer()
-	cobra.CheckErr(err)
-	aiLayer, err := settings.NewChatParameterLayer()
-	cobra.CheckErr(err)
-
-	err = layer.AddLayerToCobraCommand(upperCaseCmd)
-	cobra.CheckErr(err)
-	err = aiLayer.AddLayerToCobraCommand(upperCaseCmd)
+	err = pLayers.AddToCobraCommand(upperCaseCmd)
 	cobra.CheckErr(err)
 	rootCmd.AddCommand(upperCaseCmd)
 
-	err = layer.AddLayerToCobraCommand(tool.ToolCallCmd)
-	cobra.CheckErr(err)
-	err = aiLayer.AddLayerToCobraCommand(tool.ToolCallCmd)
+	err = pLayers.AddToCobraCommand(tool.ToolCallCmd)
 	cobra.CheckErr(err)
 	rootCmd.AddCommand(tool.ToolCallCmd)
 
-	err = layer.AddLayerToCobraCommand(codegen.CodegenTestCmd)
-	cobra.CheckErr(err)
-	err = aiLayer.AddLayerToCobraCommand(codegen.CodegenTestCmd)
+	err = pLayers.AddToCobraCommand(codegen.CodegenTestCmd)
 	cobra.CheckErr(err)
 	rootCmd.AddCommand(codegen.CodegenTestCmd)
 
-	err = layer.AddLayerToCobraCommand(codegen.MultiStepCodgenTestCmd)
-	cobra.CheckErr(err)
-	err = aiLayer.AddLayerToCobraCommand(codegen.MultiStepCodgenTestCmd)
+	err = pLayers.AddToCobraCommand(codegen.MultiStepCodgenTestCmd)
 	cobra.CheckErr(err)
 	rootCmd.AddCommand(codegen.MultiStepCodgenTestCmd)
 

--- a/cmd/experiments/agent/tool/tool.go
+++ b/cmd/experiments/agent/tool/tool.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/go-go-golems/geppetto/pkg/cmds"
 	geppetto_context "github.com/go-go-golems/geppetto/pkg/context"
 	helpers2 "github.com/go-go-golems/geppetto/pkg/helpers"
 	"github.com/go-go-golems/geppetto/pkg/steps"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/openai"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
-	openai2 "github.com/go-go-golems/geppetto/pkg/steps/ai/settings/openai"
 	"github.com/go-go-golems/glazed/pkg/cli"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/invopop/jsonschema"
@@ -59,16 +59,13 @@ var ToolCallCmd = &cobra.Command{
 	Use:   "tool-call",
 	Short: "Tool call",
 	Run: func(cmd *cobra.Command, args []string) {
-		layer, err := openai2.NewParameterLayer()
+		stepSettings := settings.NewStepSettings()
+		geppettoLayers, err := cmds.CreateGeppettoLayers(stepSettings)
 		cobra.CheckErr(err)
-		aiLayer, err := settings.NewChatParameterLayer()
-		cobra.CheckErr(err)
-
-		layers_ := layers.NewParameterLayers(layers.WithLayers(layer, aiLayer))
+		layers_ := layers.NewParameterLayers(layers.WithLayers(geppettoLayers...))
 		parsedLayers, err := cli.ParseLayersFromCobraCommand(cmd, layers_)
 		cobra.CheckErr(err)
 
-		stepSettings := settings.NewStepSettings()
 		err = stepSettings.UpdateFromParsedLayers(parsedLayers)
 		cobra.CheckErr(err)
 

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/charmbracelet/lipgloss v0.9.1
 	github.com/dave/jennifer v1.7.0
 	github.com/go-go-golems/bobatea v0.0.1
-	github.com/go-go-golems/clay v0.1.5
-	github.com/go-go-golems/glazed v0.5.1
+	github.com/go-go-golems/clay v0.1.6
+	github.com/go-go-golems/glazed v0.5.3
 	github.com/iancoleman/strcase v0.3.0
 	github.com/invopop/jsonschema v0.12.0
 	github.com/mattn/go-isatty v0.0.19

--- a/go.sum
+++ b/go.sum
@@ -117,10 +117,10 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-go-golems/bobatea v0.0.1 h1:NSiWCtyNlPZj6EEQkgbnfKXcnr9sw2I0QqhpQSWB0Eg=
 github.com/go-go-golems/bobatea v0.0.1/go.mod h1:GYDKAcOQUC/SWPaWxauTQf5JHgYSZr8AOeo25dz9IFk=
-github.com/go-go-golems/clay v0.1.5 h1:K7YwYRQs1XtVUVB6MJd2rac9txT0ZBUGz9JwRFIIvNg=
-github.com/go-go-golems/clay v0.1.5/go.mod h1:RWsRR13123i6/OuW7dYIsQ61vGsFTCSC4zj57Tmvemg=
-github.com/go-go-golems/glazed v0.5.1 h1:8p5hPYXXZZGuyLzX0b8lbn3y1c+1q62I5FLv80cBheU=
-github.com/go-go-golems/glazed v0.5.1/go.mod h1:K1600pUk7xB/LKmvIafRWyfAdxE1sboruqQ9Jia8V9M=
+github.com/go-go-golems/clay v0.1.6 h1:/EeJebwa/RbogE/tQhj3lr26fY4+MrN+80hfSFnt4Uc=
+github.com/go-go-golems/clay v0.1.6/go.mod h1:RWsRR13123i6/OuW7dYIsQ61vGsFTCSC4zj57Tmvemg=
+github.com/go-go-golems/glazed v0.5.3 h1:TIxbbb0U8d7tM71LjkZ61FhvqNezziApuEwTYZ3dWGw=
+github.com/go-go-golems/glazed v0.5.3/go.mod h1:K1600pUk7xB/LKmvIafRWyfAdxE1sboruqQ9Jia8V9M=
 github.com/go-openapi/errors v0.20.3 h1:rz6kiC84sqNQoqrtulzaL/VERgkoCyB6WdEkc2ujzUc=
 github.com/go-openapi/errors v0.20.3/go.mod h1:Z3FlZ4I8jEGxjUK+bugx3on2mIAk4txuAOhlsB1FSgk=
 github.com/go-openapi/strfmt v0.21.7 h1:rspiXgNWgeUzhjo1YU01do6qsahtJNByjLVbPLNHb8k=

--- a/pkg/cmds/loader.go
+++ b/pkg/cmds/loader.go
@@ -54,39 +54,10 @@ func (g *GeppettoCommandLoader) loadGeppettoCommandFromReader(
 		return nil, err
 	}
 
-	chatParameterLayer, err := settings.NewChatParameterLayer(
-		layers.WithDefaults(stepSettings.Chat),
-	)
+	ls, err := CreateGeppettoLayers(stepSettings)
 	if err != nil {
 		return nil, err
 	}
-
-	clientParameterLayer, err := settings.NewClientParameterLayer(
-		layers.WithDefaults(stepSettings.Client),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	claudeParameterLayer, err := claude.NewParameterLayer(
-		layers.WithDefaults(stepSettings.Claude),
-	)
-	if err != nil {
-		return nil, err
-	}
-	openaiParameterLayer, err := openai.NewParameterLayer(
-		layers.WithDefaults(stepSettings.OpenAI),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	helpersLayer, err := NewHelpersParameterLayer()
-	if err != nil {
-		return nil, err
-	}
-
-	ls := append(scd.Layers, helpersLayer, chatParameterLayer, clientParameterLayer, claudeParameterLayer, openaiParameterLayer)
 
 	options_ := []cmds.CommandDescriptionOption{
 		cmds.WithShort(scd.Short),
@@ -120,6 +91,44 @@ func (g *GeppettoCommandLoader) loadGeppettoCommandFromReader(
 	}
 
 	return []cmds.Command{sq}, nil
+}
+
+func CreateGeppettoLayers(stepSettings *settings.StepSettings) ([]layers.ParameterLayer, error) {
+	chatParameterLayer, err := settings.NewChatParameterLayer(
+		layers.WithDefaults(stepSettings.Chat),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	clientParameterLayer, err := settings.NewClientParameterLayer(
+		layers.WithDefaults(stepSettings.Client),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	claudeParameterLayer, err := claude.NewParameterLayer(
+		layers.WithDefaults(stepSettings.Claude),
+	)
+	if err != nil {
+		return nil, err
+	}
+	openaiParameterLayer, err := openai.NewParameterLayer(
+		layers.WithDefaults(stepSettings.OpenAI),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	helpersLayer, err := NewHelpersParameterLayer()
+	if err != nil {
+		return nil, err
+	}
+
+	return []layers.ParameterLayer{
+		helpersLayer, chatParameterLayer, clientParameterLayer, claudeParameterLayer, openaiParameterLayer,
+	}, nil
 }
 
 func (scl *GeppettoCommandLoader) LoadCommands(


### PR DESCRIPTION
This pull request refactors the Cobra command setup to leverage the new layers API.

Changes include:
- Centralized parameter layer creation with `CreateGeppettoLayers`.
- Streamlined Cobra command setup using `AddToCobraCommand` and `NewCobraParserFromLayers`.