### PR TITLE
Fix conversation message type handling in steps

### DIFF
--- a/pkg/context/run.go
+++ b/pkg/context/run.go
@@ -9,7 +9,7 @@ import (
 )
 
 type GeppettoRunnable interface {
-	RunWithManager(ctx context2.Context, manager conversation.Manager) (steps.StepResult[string], error)
+	RunWithManager(ctx context2.Context, manager conversation.Manager) (steps.StepResult[*conversation.Message], error)
 }
 
 func RunIntoWriter(
@@ -37,7 +37,7 @@ func RunIntoWriter(
 			if err != nil {
 				return err
 			}
-			_, err = w.Write([]byte(s))
+			_, err = w.Write([]byte(s.Content.String()))
 			if err != nil {
 				return err
 			}

--- a/pkg/steps/ai/chat/step.go
+++ b/pkg/steps/ai/chat/step.go
@@ -45,9 +45,9 @@ type RunnableStep struct {
 	manager conversation.Manager
 }
 
-var _ steps.Step[interface{}, string] = &RunnableStep{}
+var _ steps.Step[interface{}, *conversation.Message] = &RunnableStep{}
 
-func (r *RunnableStep) Start(ctx context.Context, input interface{}) (steps.StepResult[string], error) {
+func (r *RunnableStep) Start(ctx context.Context, input interface{}) (steps.StepResult[*conversation.Message], error) {
 	return r.c.RunWithManager(ctx, r.manager)
 }
 

--- a/pkg/steps/utils/merge.go
+++ b/pkg/steps/utils/merge.go
@@ -6,21 +6,20 @@ import (
 	"github.com/go-go-golems/geppetto/pkg/steps"
 )
 
-func NewMergeStep(manager conversation.Manager, prepend bool) steps.Step[string, conversation.Conversation] {
+func NewMergeStep(manager conversation.Manager, prepend bool) steps.Step[*conversation.Message, conversation.Conversation] {
 	// TODO(manuel, 2024-01-13) This should actually create an entirely new "conversation"
 	// with the messages parentIds changed up. But this wouldn't be a manager nor maybe a single conversation?
 	// Or maybe this just stays a conversation, linearly, with parentIds of the heads changed up
 	//
 	// This is currently only used in the codegen test anyway, so maybe this is a step that is not even going to be really used.
-	mergeStep := &LambdaStep[string, conversation.Conversation]{
-		Function: func(input string) helpers.Result[conversation.Conversation] {
+	mergeStep := &LambdaStep[*conversation.Message, conversation.Conversation]{
+		Function: func(input *conversation.Message) helpers.Result[conversation.Conversation] {
 			if prepend {
-				// TODO(manuel, 2024-01-13) Hack for now because I'm not out to refactor the conversation manager interface yet
-				// FIXME
-				manager.(*conversation.ManagerImpl).PrependMessages(conversation.NewChatMessage(conversation.RoleUser, input))
+				manager.(*conversation.ManagerImpl).PrependMessages(input)
+			} else {
+				manager.(*conversation.ManagerImpl).AppendMessages(input)
 			}
 
-			manager.AppendMessages(conversation.NewChatMessage(conversation.RoleAssistant, input))
 			return helpers.NewValueResult[conversation.Conversation](manager.GetConversation())
 		},
 	}


### PR DESCRIPTION
* Change step result type from string to *conversation.Message for consistency
* Update merge step to handle Message objects directly instead of raw strings
* Fix message content writing to use proper String() method