### PR TITLE
Add settings summary helper method with verbose output option

### DIFF
--- a/pkg/steps/ai/settings/settings-step.go
+++ b/pkg/steps/ai/settings/settings-step.go
@@ -1,13 +1,16 @@
 package settings
 
 import (
+	"fmt"
+	"io"
+	"strings"
+
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings/claude"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings/ollama"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings/openai"
 	"github.com/go-go-golems/glazed/pkg/cmds/layers"
 	"github.com/huandu/go-clone"
 	"gopkg.in/yaml.v3"
-	"io"
 )
 
 type factoryConfigFileWrapper struct {
@@ -247,4 +250,138 @@ func (ss *StepSettings) UpdateFromParsedLayers(parsedLayers *layers.ParsedLayers
 	}
 
 	return nil
+}
+
+func (ss *StepSettings) GetSummary(verbose bool) string {
+	var summary strings.Builder
+
+	// API Settings
+	if ss.API != nil {
+		summary.WriteString("API Settings:\n")
+		for apiType, key := range ss.API.APIKeys {
+			if key != "" {
+				// Show only first 4 and last 4 characters of API key
+				maskedKey := key
+				if len(key) > 8 {
+					maskedKey = key[:4] + "..." + key[len(key)-4:]
+				}
+				summary.WriteString(fmt.Sprintf("  - %s API Key: %s\n", apiType, maskedKey))
+			}
+		}
+		for apiType, url := range ss.API.BaseUrls {
+			if url != "" {
+				summary.WriteString(fmt.Sprintf("  - %s Base URL: %s\n", apiType, url))
+			}
+		}
+	}
+
+	// Chat Settings
+	if ss.Chat != nil {
+		summary.WriteString("\nChat Settings:\n")
+		if ss.Chat.Engine != nil {
+			summary.WriteString(fmt.Sprintf("  - Engine: %s\n", *ss.Chat.Engine))
+		}
+		if ss.Chat.ApiType != nil {
+			summary.WriteString(fmt.Sprintf("  - API Type: %s\n", *ss.Chat.ApiType))
+		}
+		if ss.Chat.MaxResponseTokens != nil {
+			summary.WriteString(fmt.Sprintf("  - Max Response Tokens: %d\n", *ss.Chat.MaxResponseTokens))
+		}
+		if ss.Chat.Temperature != nil {
+			summary.WriteString(fmt.Sprintf("  - Temperature: %.2f\n", *ss.Chat.Temperature))
+		}
+		if verbose {
+			if ss.Chat.TopP != nil {
+				summary.WriteString(fmt.Sprintf("  - Top P: %.2f\n", *ss.Chat.TopP))
+			}
+			if len(ss.Chat.Stop) > 0 {
+				summary.WriteString(fmt.Sprintf("  - Stop Sequences: %v\n", ss.Chat.Stop))
+			}
+			summary.WriteString(fmt.Sprintf("  - Stream: %v\n", ss.Chat.Stream))
+		}
+	}
+
+	// OpenAI Settings
+	if ss.OpenAI != nil && verbose {
+		summary.WriteString("\nOpenAI Settings:\n")
+		if ss.OpenAI.N != nil {
+			summary.WriteString(fmt.Sprintf("  - N: %d\n", *ss.OpenAI.N))
+		}
+		if ss.OpenAI.PresencePenalty != nil {
+			summary.WriteString(fmt.Sprintf("  - Presence Penalty: %.2f\n", *ss.OpenAI.PresencePenalty))
+		}
+		if ss.OpenAI.FrequencyPenalty != nil {
+			summary.WriteString(fmt.Sprintf("  - Frequency Penalty: %.2f\n", *ss.OpenAI.FrequencyPenalty))
+		}
+		if len(ss.OpenAI.LogitBias) > 0 {
+			summary.WriteString("  - Logit Bias:\n")
+			for token, bias := range ss.OpenAI.LogitBias {
+				summary.WriteString(fmt.Sprintf("    %s: %s\n", token, bias))
+			}
+		}
+	}
+
+	// Client Settings
+	if ss.Client != nil && verbose {
+		summary.WriteString("\nClient Settings:\n")
+		if ss.Client.Timeout != nil {
+			summary.WriteString(fmt.Sprintf("  - Timeout: %s\n", ss.Client.Timeout))
+		}
+		if ss.Client.TimeoutSeconds != nil {
+			summary.WriteString(fmt.Sprintf("  - Timeout Seconds: %d\n", *ss.Client.TimeoutSeconds))
+		}
+		if ss.Client.Organization != nil && *ss.Client.Organization != "" {
+			summary.WriteString(fmt.Sprintf("  - Organization: %s\n", *ss.Client.Organization))
+		}
+		if ss.Client.UserAgent != nil {
+			summary.WriteString(fmt.Sprintf("  - User Agent: %s\n", *ss.Client.UserAgent))
+		}
+	}
+
+	// Claude Settings
+	if ss.Claude != nil && verbose {
+		summary.WriteString("\nClaude Settings:\n")
+		if ss.Claude.TopK != nil {
+			summary.WriteString(fmt.Sprintf("  - Top K: %d\n", *ss.Claude.TopK))
+		}
+		if ss.Claude.UserID != nil && *ss.Claude.UserID != "" {
+			summary.WriteString(fmt.Sprintf("  - User ID: %s\n", *ss.Claude.UserID))
+		}
+	}
+
+	// Ollama Settings
+	if ss.Ollama != nil && verbose {
+		summary.WriteString("\nOllama Settings:\n")
+		if ss.Ollama.Temperature != nil {
+			summary.WriteString(fmt.Sprintf("  - Temperature: %.2f\n", *ss.Ollama.Temperature))
+		}
+		if ss.Ollama.Seed != nil {
+			summary.WriteString(fmt.Sprintf("  - Seed: %d\n", *ss.Ollama.Seed))
+		}
+		if len(ss.Ollama.Stop) > 0 {
+			summary.WriteString(fmt.Sprintf("  - Stop Sequences: %v\n", ss.Ollama.Stop))
+		}
+		if ss.Ollama.TopK != nil {
+			summary.WriteString(fmt.Sprintf("  - Top K: %d\n", *ss.Ollama.TopK))
+		}
+		if ss.Ollama.TopP != nil {
+			summary.WriteString(fmt.Sprintf("  - Top P: %.2f\n", *ss.Ollama.TopP))
+		}
+	}
+
+	// Embeddings Settings
+	if ss.Embeddings != nil {
+		summary.WriteString("\nEmbeddings Settings:\n")
+		if ss.Embeddings.Engine != nil {
+			summary.WriteString(fmt.Sprintf("  - Engine: %s\n", *ss.Embeddings.Engine))
+		}
+		if ss.Embeddings.Type != nil {
+			summary.WriteString(fmt.Sprintf("  - Type: %s\n", *ss.Embeddings.Type))
+		}
+		if ss.Embeddings.Dimensions != nil {
+			summary.WriteString(fmt.Sprintf("  - Dimensions: %d\n", *ss.Embeddings.Dimensions))
+		}
+	}
+
+	return summary.String()
 }


### PR DESCRIPTION
Adds a new GetSummary() method to StepSettings that generates a formatted summary of 
all configured settings.

Key features:
- Takes a verbose flag to control detail level
- Masks API keys for security (shows only first/last 4 chars)
- Groups settings by category (API, Chat, OpenAI, etc)
- Only shows non-empty/non-nil values
- Formats output with proper indentation

Default output includes:
- API keys (masked) and base URLs
- Core chat settings (engine, API type, tokens, temperature)
- Embeddings configuration

Verbose output adds:
- Additional chat parameters (top_p, stop sequences, streaming)
- OpenAI-specific settings
- Client configuration
- Claude settings
- Ollama parameters