### PR TITLE
Add unified caching system for embeddings and chat inference

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -95,3 +95,12 @@ Added comprehensive documentation for the !Embeddings tag function, including:
 - Configuration options for OpenAI and Ollama providers
 - Default settings and environment variables
 - Error handling guidelines 
+
+## Embeddings Caching Support
+
+Added configurable caching support for embeddings with both memory and disk-based options.
+
+- Added caching configuration to embeddings settings with none/memory/disk options
+- Implemented memory and disk caching options for embeddings
+- Cache is disabled by default (using "none" type)
+- Configurable cache size and entry limits 

--- a/changelog.md
+++ b/changelog.md
@@ -104,3 +104,12 @@ Added configurable caching support for embeddings with both memory and disk-base
 - Implemented memory and disk caching options for embeddings
 - Cache is disabled by default (using "none" type)
 - Configurable cache size and entry limits 
+
+## Unified Caching Configuration
+
+Standardized caching configuration across embeddings and chat:
+
+- Added consistent caching options (none/memory/disk) for both embeddings and chat
+- Simplified configuration by using cache type to control enabling/disabling
+- Added shared configuration parameters for cache size and entries
+- Cache is disabled by default (using "none" type) 

--- a/pkg/doc/topics/03-caching.md
+++ b/pkg/doc/topics/03-caching.md
@@ -1,0 +1,236 @@
+---
+Title: Caching in Geppetto
+Slug: caching
+Short: Learn how to use and configure caching for both embeddings and chat operations in Geppetto
+Topics:
+- caching
+- embeddings
+- chat
+- configuration
+Commands:
+- none
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+Geppetto provides a unified caching system for both embeddings and chat operations. This helps reduce API calls, improve performance, and manage costs effectively.
+
+## Basic Usage
+
+### Command-Line Flags
+
+For both embeddings and chat operations, caching can be controlled through command-line flags:
+
+#### Embeddings Caching
+
+```bash
+# Enable memory-based caching for embeddings
+--embeddings-cache-type=memory --embeddings-cache-max-entries=1000
+
+# Enable disk-based caching for embeddings
+--embeddings-cache-type=disk --embeddings-cache-max-size=1073741824 --embeddings-cache-directory=/path/to/cache
+```
+
+#### Chat Caching
+
+```bash
+# Enable memory-based caching for chat
+--ai-cache-type=memory --ai-cache-max-entries=1000
+
+# Enable disk-based caching for chat
+--ai-cache-type=disk --ai-cache-max-size=1073741824 --ai-cache-directory=/path/to/cache
+```
+
+### Configuration Parameters
+
+Both embeddings and chat share similar caching parameters:
+
+1. **Cache Type** (`embeddings-cache-type` / `ai-cache-type`)
+   - `none`: Disable caching (default)
+   - `memory`: In-memory LRU cache
+   - `disk`: Persistent disk-based cache
+
+2. **Cache Size** (`embeddings-cache-max-size` / `ai-cache-max-size`)
+   - Maximum size in bytes for disk cache
+   - Default: 1GB (1073741824 bytes)
+
+3. **Cache Entries** (`embeddings-cache-max-entries` / `ai-cache-max-entries`)
+   - Maximum number of entries for memory cache
+   - Default: 1000 entries
+
+4. **Cache Directory** (`embeddings-cache-directory` / `ai-cache-directory`)
+   - Directory for disk cache storage
+   - Default: "" (system temp directory)
+
+## Programmatic Usage
+
+### Embeddings Caching
+
+You can configure caching programmatically when creating embedding providers:
+
+```go
+import (
+    "github.com/go-go-golems/geppetto/pkg/embeddings"
+)
+
+// Create config with caching settings
+config := &embeddings.EmbeddingsConfig{
+    Type:            "openai",
+    Engine:          "text-embedding-3-small",
+    CacheType:       "memory",
+    CacheMaxEntries: 1000,
+}
+
+// Create factory with config
+factory := embeddings.NewSettingsFactory(config)
+
+// Get provider with caching enabled
+provider, err := factory.NewProvider()
+if err != nil {
+    // Handle error
+}
+
+// Use provider as normal
+embedding, err := provider.GenerateEmbedding(ctx, "text to embed")
+```
+
+### Chat Caching
+
+For chat operations, you can wrap chat steps with caching:
+
+```go
+import (
+    "github.com/go-go-golems/geppetto/pkg/steps/ai/chat"
+    "github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
+)
+
+// Create chat settings with caching
+chatSettings := &settings.ChatSettings{
+    CacheType:       "memory",
+    CacheMaxEntries: 1000,
+}
+
+// Create base chat step
+baseStep := chat.NewChatStep(/* ... */)
+
+// Wrap with caching
+cachedStep, err := chatSettings.WrapWithCache(baseStep)
+if err != nil {
+    // Handle error
+}
+
+// Use cached step as normal
+result, err := cachedStep.Start(ctx, conversation)
+```
+
+### Using with Glazed Commands
+
+When building Glazed commands that use caching, you can access the caching settings through the parsed layers:
+
+```go
+type CommandSettings struct {
+    Embeddings *embeddings.EmbeddingsConfig `glazed.layer:"embeddings"`
+    Chat      *settings.ChatSettings       `glazed.layer:"ai-chat"`
+}
+
+func (c *MyCommand) Run(
+    ctx context.Context,
+    parsedLayers *layers.ParsedLayers,
+    gp middlewares.Processor,
+) error {
+    s := &CommandSettings{}
+    
+    // Initialize settings from parsed layers
+    if err := parsedLayers.InitializeStruct("embeddings", &s.Embeddings); err != nil {
+        return err
+    }
+    if err := parsedLayers.InitializeStruct("ai-chat", &s.Chat); err != nil {
+        return err
+    }
+
+    // Create providers/steps with caching
+    provider, err := embeddings.NewSettingsFactory(s.Embeddings).NewProvider()
+    if err != nil {
+        return err
+    }
+
+    baseStep := chat.NewChatStep(/* ... */)
+    cachedStep, err := s.Chat.WrapWithCache(baseStep)
+    if err != nil {
+        return err
+    }
+
+    // Use provider and step as needed
+    return nil
+}
+```
+
+## Cache Behavior
+
+### Memory Cache
+
+- Implements LRU (Least Recently Used) eviction
+- Thread-safe for concurrent access
+- Cleared when process exits
+- Best for high-throughput, short-lived processes
+
+### Disk Cache
+
+- Persistent across process restarts
+- Uses file modification time for LRU eviction
+- Thread-safe through file system locks
+- Best for long-running processes or when persistence is needed
+
+## Error Handling
+
+The caching system handles several types of errors:
+
+1. **Configuration Errors**
+   - Invalid cache type
+   - Missing required parameters
+   - Invalid directory permissions
+
+2. **Runtime Errors**
+   - Cache full/eviction needed
+   - Disk I/O errors
+   - Corrupted cache entries
+
+Example error handling:
+
+```go
+provider, err := factory.NewProvider()
+if err != nil {
+    switch {
+    case strings.Contains(err.Error(), "unsupported cache type"):
+        // Handle invalid configuration
+    case strings.Contains(err.Error(), "permission denied"):
+        // Handle permission issues
+    default:
+        // Handle other errors
+    }
+}
+```
+
+## Best Practices
+
+1. **Cache Type Selection**
+   - Use `memory` for short-lived processes or small datasets
+   - Use `disk` for persistence or large datasets
+   - Use `none` when real-time responses are critical
+
+2. **Cache Sizing**
+   - Set `max-entries` based on expected unique requests
+   - Set `max-size` based on available disk space
+   - Monitor cache hit rates to adjust settings
+
+3. **Directory Management**
+   - Use absolute paths for cache directories
+   - Ensure proper permissions
+   - Implement periodic cleanup for old cache files
+
+4. **Error Handling**
+   - Always check for errors when creating cached providers/steps
+   - Implement fallbacks for cache failures
+   - Log cache-related errors for monitoring 

--- a/pkg/doc/topics/03-caching.md
+++ b/pkg/doc/topics/03-caching.md
@@ -125,6 +125,41 @@ if err != nil {
 result, err := cachedStep.Start(ctx, conversation)
 ```
 
+### Using with StandardStepFactory
+
+The recommended way to create chat steps is using the `StandardStepFactory`, which automatically handles caching based on settings:
+
+```go
+import (
+    "github.com/go-go-golems/geppetto/pkg/steps/ai"
+    "github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
+)
+
+// Create settings with caching configuration
+stepSettings := &settings.StepSettings{
+    Chat: &settings.ChatSettings{
+        Engine:          &engine,
+        ApiType:         &apiType,
+        CacheType:       "memory",
+        CacheMaxEntries: 1000,
+    },
+}
+
+// Create factory
+factory := &ai.StandardStepFactory{
+    Settings: stepSettings,
+}
+
+// Create step (will automatically be wrapped with caching)
+step, err := factory.NewStep()
+if err != nil {
+    // Handle error
+}
+
+// Use step as normal
+result, err := step.Start(ctx, conversation)
+```
+
 ### Using with Glazed Commands
 
 When building Glazed commands that use caching, you can access the caching settings through the parsed layers:

--- a/pkg/embeddings/flags/embeddings.yaml
+++ b/pkg/embeddings/flags/embeddings.yaml
@@ -33,3 +33,23 @@ flags:
     type: string
     help: The API key to use for Ollama embeddings
     default: ""
+  - name: embeddings-cache-type
+    type: choice
+    choices:
+      - "none"
+      - "memory"
+      - "disk"
+    help: Type of caching to use for embeddings (none, memory, or disk)
+    default: none
+  - name: embeddings-cache-max-size
+    type: int64
+    help: Maximum size of cache in bytes (for disk cache)
+    default: 1073741824  # 1GB
+  - name: embeddings-cache-max-entries
+    type: int
+    help: Maximum number of entries in cache (for memory cache)
+    default: 1000
+  - name: embeddings-cache-directory
+    type: string
+    help: Directory to store cache files (for disk cache)
+    default: ""

--- a/pkg/steps/ai/chat/caching-step.go
+++ b/pkg/steps/ai/chat/caching-step.go
@@ -36,7 +36,9 @@ type Option func(*CachingStep)
 
 func WithCacheDirectory(dir string) Option {
 	return func(p *CachingStep) {
-		p.directory = dir
+		if dir != "" {
+			p.directory = dir
+		}
 	}
 }
 
@@ -72,7 +74,7 @@ func NewCachingStep(step Step, opts ...Option) (*CachingStep, error) {
 	}
 
 	if err := os.MkdirAll(s.directory, 0755); err != nil {
-		return nil, fmt.Errorf("failed to create cache directory: %w", err)
+		return nil, fmt.Errorf("failed to create cache directory %s: %w", s.directory, err)
 	}
 
 	return s, nil

--- a/pkg/steps/ai/factory.go
+++ b/pkg/steps/ai/factory.go
@@ -52,7 +52,6 @@ func (s *StandardStepFactory) NewStep(
 		}
 
 	} else {
-
 		switch {
 		case openai.IsOpenAiEngine(*settings_.Chat.Engine):
 			apiType := settings.ApiTypeOpenAI
@@ -71,10 +70,19 @@ func (s *StandardStepFactory) NewStep(
 		}
 	}
 
+	// Apply step options
 	for _, option := range options {
 		err := option(ret)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	// Wrap with caching if configured
+	if ret != nil && settings_.Chat != nil {
+		ret, err = settings_.Chat.WrapWithCache(ret)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to wrap step with cache")
 		}
 	}
 

--- a/pkg/steps/ai/settings/flags/chat.yaml
+++ b/pkg/steps/ai/settings/flags/chat.yaml
@@ -1,38 +1,61 @@
 slug: ai-chat
-name: AI chat completion API flags, shared by OpenAI and Claude
-description: Settings for the AI chat completion API
+name: AI Chat settings
+description: Settings for AI chat operations
 flags:
   - name: ai-engine
     type: string
-    help: AI chat completion engine
-    default: "gpt-4o"
+    help: The model to use for chat
+    default: "gpt-4"
   - name: ai-api-type
     type: choice
     choices:
       - "openai"
+      - "anyscale"
+      - "fireworks"
       - "claude"
       - "ollama"
-      - "anyscale"
       - "mistral"
       - "perplexity"
-    help: AI chat completion API type
+      - "cohere"
+    help: The provider type to use for chat
     default: openai
-  - name: ai-temperature
-    type: float
-    help: AI chat completion temperature
-    default: 0.2
   - name: ai-max-response-tokens
     type: int
-    help: AI chat completion max response tokens
-  - name: ai-stream
-    type: bool
-    help: AI chat completion stream
-    default: true
-  - name: ai-stop
-    type: stringList
-    help: AI chat completion stop
-    default: []
+    help: Maximum number of tokens in the response
+    default: 1000
   - name: ai-top-p
     type: float
-    help: AI chat completion top p
-    default: 0.9
+    help: Top-p sampling value
+    default: 1.0
+  - name: ai-temperature
+    type: float
+    help: Temperature for response generation
+    default: 0.7
+  - name: ai-stop
+    type: stringList
+    help: Stop sequences for response generation
+    default: []
+  - name: ai-stream
+    type: bool
+    help: Whether to stream responses
+    default: false
+  - name: ai-cache-type
+    type: choice
+    choices:
+      - "none"
+      - "memory"
+      - "disk"
+    help: Type of caching to use for chat responses (none, memory, or disk)
+    default: none
+  - name: ai-cache-max-size
+    type: int64
+    help: Maximum size of cache in bytes (for disk cache)
+    default: 1073741824  # 1GB
+  - name: ai-cache-max-entries
+    type: int
+    help: Maximum number of entries in cache (for memory cache)
+    default: 1000
+  - name: ai-cache-directory
+    type: string
+    help: Directory to store cache files (for disk cache)
+    default: ""

--- a/pkg/steps/ai/settings/flags/chat.yaml
+++ b/pkg/steps/ai/settings/flags/chat.yaml
@@ -48,7 +48,7 @@ flags:
     help: Type of caching to use for chat responses (none, memory, or disk)
     default: none
   - name: ai-cache-max-size
-    type: int64
+    type: int
     help: Maximum size of cache in bytes (for disk cache)
     default: 1073741824  # 1GB
   - name: ai-cache-max-entries


### PR DESCRIPTION
Adds a configurable caching system for both embeddings and chat inference with 
memory and disk-based options.

Configuration:
- Cache type: none (default), memory, disk
- Memory cache: configurable max entries (default 1000)
- Disk cache: configurable max size (default 1GB) and directory
- Thread-safe implementation for concurrent access

Command line flags:
- embeddings-cache-type / ai-cache-type
- embeddings-cache-max-entries / ai-cache-max-entries 
- embeddings-cache-max-size / ai-cache-max-size
- embeddings-cache-directory / ai-cache-directory