### PR TITLE
Fix missing UI updates in chat caching system

### DIFF
--- a/pkg/conversation/message.go
+++ b/pkg/conversation/message.go
@@ -239,7 +239,7 @@ type Message struct {
 
 	Content            MessageContent         `json:"content"`
 	Metadata           map[string]interface{} `json:"metadata"` // Flexible metadata field
-	LLMMessageMetadata *LLMMessageMetadata    `json:"llm_message_metadata"`
+	LLMMessageMetadata *LLMMessageMetadata    `json:"llm_message_metadata,omitempty" yaml:"llm_message_metadata,omitempty" mapstructure:"llm_message_metadata,omitempty"`
 
 	// TODO(manuel, 2024-04-07) Add Parent and Sibling lists
 	// omit in json
@@ -340,6 +340,14 @@ func (messages Conversation) GetSinglePrompt() string {
 		}
 	}
 
+	return prompt
+}
+
+func (conversation Conversation) ToString() string {
+	prompt := ""
+	for _, message := range conversation {
+		prompt += message.Content.String() + "\n"
+	}
 	return prompt
 }
 

--- a/pkg/steps/ai/chat/printer.go
+++ b/pkg/steps/ai/chat/printer.go
@@ -236,10 +236,17 @@ func extractImportantMetadata(e Event) map[string]interface{} {
 			"type": stepMetadata.Type,
 		}
 
-		if metadata.Usage.InputTokens != 0 || metadata.Usage.OutputTokens != 0 {
+		if metadata.Usage != nil {
+			if metadata.Usage.InputTokens != 0 || metadata.Usage.OutputTokens != 0 {
+				result["tokens"] = map[string]interface{}{
+					"in":  metadata.Usage.InputTokens,
+					"out": metadata.Usage.OutputTokens,
+				}
+			}
+		} else {
 			result["tokens"] = map[string]interface{}{
-				"in":  metadata.Usage.InputTokens,
-				"out": metadata.Usage.OutputTokens,
+				"in":  0,
+				"out": 0,
 			}
 		}
 

--- a/pkg/steps/ai/factory.go
+++ b/pkg/steps/ai/factory.go
@@ -84,6 +84,14 @@ func (s *StandardStepFactory) NewStep(
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to wrap step with cache")
 		}
+
+		// Apply step options to the caching step too
+		for _, option := range options {
+			err := option(ret)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	return ret, nil


### PR DESCRIPTION
Adds proper UI event publishing for cached chat responses. Main changes:

* Add subscription manager to both disk and memory caching steps
* Emit UI events for cache hits and writes
* Include metadata about cache type and timing
* Fix token counting for cached responses
* Add conversation string conversion helper
* Propagate step options to caching wrappers

The changes ensure that cached responses trigger the same UI update events as 
live responses, maintaining consistent user feedback whether results come from 
cache or not.