### PR TITLE
Fix doubled terminal output when cache is disabled

### DIFF
--- a/pkg/steps/ai/factory.go
+++ b/pkg/steps/ai/factory.go
@@ -80,18 +80,11 @@ func (s *StandardStepFactory) NewStep(
 
 	// Wrap with caching if configured
 	if ret != nil && settings_.Chat != nil {
-		ret, err = settings_.Chat.WrapWithCache(ret)
+		ret, err = settings_.Chat.WrapWithCache(ret, options...)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to wrap step with cache")
 		}
 
-		// Apply step options to the caching step too
-		for _, option := range options {
-			err := option(ret)
-			if err != nil {
-				return nil, err
-			}
-		}
 	}
 
 	return ret, nil

--- a/pkg/steps/ai/settings/settings-chat.go
+++ b/pkg/steps/ai/settings/settings-chat.go
@@ -90,18 +90,22 @@ func NewChatParameterLayer(options ...layers.ParameterLayerOptions) (*ChatParame
 }
 
 // WrapWithCache wraps a chat step with caching if enabled
-func (s *ChatSettings) WrapWithCache(step chat.Step) (chat.Step, error) {
+func (s *ChatSettings) WrapWithCache(step chat.Step, options ...chat.StepOption) (chat.Step, error) {
 	switch s.CacheType {
 	case "none":
 		return step, nil
 	case "memory":
 		return chat.NewMemoryCachingStep(step,
-			chat.WithMemoryMaxSize(s.CacheMaxEntries))
+			chat.WithMemoryMaxSize(s.CacheMaxEntries),
+			chat.WithMemoryStepOptions(options...),
+		)
 	case "disk":
 		return chat.NewCachingStep(step,
 			chat.WithMaxSize(s.CacheMaxSize),
 			chat.WithMaxEntries(s.CacheMaxEntries),
-			chat.WithCacheDirectory(s.CacheDirectory))
+			chat.WithCacheDirectory(s.CacheDirectory),
+			chat.WithStepOptions(options...),
+		)
 	default:
 		return nil, fmt.Errorf("unsupported cache type for chat: %s", s.CacheType)
 	}


### PR DESCRIPTION
Fixes a bug where terminal output was being duplicated when caching was disabled. 
The issue was caused by step options being applied incorrectly when wrapping steps 
with caching.

Changes:
- Apply options during cache wrapper creation instead of after