### PR TITLE
Rename embeddings disk cache type to file and enhance settings summary

### DIFF
--- a/pkg/embeddings/config/flags/embeddings.yaml
+++ b/pkg/embeddings/config/flags/embeddings.yaml
@@ -22,7 +22,7 @@ flags:
     choices:
       - "none"
       - "memory"
-      - "disk"
+      - "file"
     help: Type of caching to use for embeddings (none, memory, or disk)
     default: none
   - name: embeddings-cache-max-size

--- a/pkg/embeddings/settings_factory.go
+++ b/pkg/embeddings/settings_factory.go
@@ -147,7 +147,7 @@ func (f *SettingsFactory) NewProvider(opts ...ProviderOption) (Provider, error) 
 		return provider, nil
 	case "memory":
 		return NewCachedProvider(provider, f.config.CacheMaxEntries), nil
-	case "disk":
+	case "file":
 		return NewDiskCacheProvider(provider,
 			WithDirectory(f.config.CacheDirectory),
 			WithMaxSize(f.config.CacheMaxSize),

--- a/pkg/embeddings/settings_factory.go
+++ b/pkg/embeddings/settings_factory.go
@@ -153,7 +153,7 @@ func (f *SettingsFactory) NewProvider(opts ...ProviderOption) (Provider, error) 
 			WithMaxSize(f.config.CacheMaxSize),
 			WithMaxEntries(f.config.CacheMaxEntries))
 	default:
-		return nil, fmt.Errorf("unsupported cache type for embeddings: %s", f.config.CacheType)
+		return provider, nil
 	}
 }
 

--- a/pkg/steps/ai/settings/settings-step.go
+++ b/pkg/steps/ai/settings/settings-step.go
@@ -382,6 +382,20 @@ func (ss *StepSettings) GetSummary(verbose bool) string {
 		if ss.Embeddings.Dimensions != 0 {
 			summary.WriteString(fmt.Sprintf("  - Dimensions: %d\n", ss.Embeddings.Dimensions))
 		}
+
+		// Embeddings Cache Settings
+		if ss.Embeddings.CacheType != "" {
+			summary.WriteString(fmt.Sprintf("  - Cache Type: %s\n", ss.Embeddings.CacheType))
+		}
+		if ss.Embeddings.CacheMaxSize != 0 {
+			summary.WriteString(fmt.Sprintf("  - Max Size: %d\n", ss.Embeddings.CacheMaxSize))
+		}
+		if ss.Embeddings.CacheMaxEntries != 0 {
+			summary.WriteString(fmt.Sprintf("  - Max Entries: %d\n", ss.Embeddings.CacheMaxEntries))
+		}
+		if ss.Embeddings.CacheDirectory != "" {
+			summary.WriteString(fmt.Sprintf("  - Cache Directory: %s\n", ss.Embeddings.CacheDirectory))
+		}
 	}
 
 	return summary.String()


### PR DESCRIPTION
⚠️ Breaking Change: Users with configurations using "disk" as cache type will need to
update their settings to use "file" instead.