### PR TITLE
Refactor event streaming for typed chat UI handler registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ dist
 envs/
 
 .history
+.specstory
 
 __debug*

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23
 toolchain go1.23.7
 
 require (
-	github.com/ThreeDotsLabs/watermill v1.3.7
+	github.com/ThreeDotsLabs/watermill v1.4.6
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/dop251/goja v0.0.0-20241024094426-79f3a7efcdbd
 	github.com/dop251/goja_nodejs v0.0.0-20240728170619-29b559befffc

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZC
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/ThreeDotsLabs/watermill v1.3.7 h1:NV0PSTmuACVEOV4dMxRnmGXrmbz8U83LENOvpHekN7o=
 github.com/ThreeDotsLabs/watermill v1.3.7/go.mod h1:lBnrLbxOjeMRgcJbv+UiZr8Ylz8RkJ4m6i/VN/Nk+to=
+github.com/ThreeDotsLabs/watermill v1.4.6 h1:rWoXlxdBgUyg/bZ3OO0pON+nESVd9r6tnLTgkZ6CYrU=
+github.com/ThreeDotsLabs/watermill v1.4.6/go.mod h1:lBnrLbxOjeMRgcJbv+UiZr8Ylz8RkJ4m6i/VN/Nk+to=
 github.com/adrg/frontmatter v0.2.0 h1:/DgnNe82o03riBd1S+ZDjd43wAmC6W35q67NHeLkPd4=
 github.com/adrg/frontmatter v0.2.0/go.mod h1:93rQCj3z3ZlwyxxpQioRKC1wDLto4aXHrbqIsnH9wmE=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=

--- a/pkg/events/chat-events.go
+++ b/pkg/events/chat-events.go
@@ -1,4 +1,4 @@
-package chat
+package events
 
 import (
 	"encoding/json"

--- a/pkg/events/printer.go
+++ b/pkg/events/printer.go
@@ -1,4 +1,4 @@
-package chat
+package events
 
 import (
 	"encoding/json"

--- a/pkg/events/step-printer-func.go
+++ b/pkg/events/step-printer-func.go
@@ -1,4 +1,4 @@
-package chat
+package events
 
 import (
 	"fmt"

--- a/pkg/steps/ai/chat/step.go
+++ b/pkg/steps/ai/chat/step.go
@@ -1,9 +1,7 @@
 package chat
 
 import (
-	"context"
 	"github.com/ThreeDotsLabs/watermill/message"
-	geppetto_context "github.com/go-go-golems/geppetto/pkg/context"
 	"github.com/go-go-golems/geppetto/pkg/conversation"
 	"github.com/go-go-golems/geppetto/pkg/steps"
 )
@@ -21,36 +19,4 @@ func WithPublishedTopic(publisher message.Publisher, topic string) StepOption {
 
 		return nil
 	}
-}
-
-type AddToHistoryStep struct {
-	manager conversation.Manager
-	role    string
-}
-
-var _ steps.Step[string, string] = &AddToHistoryStep{}
-
-func (a *AddToHistoryStep) Start(ctx context.Context, input string) (steps.StepResult[string], error) {
-	a.manager.AppendMessages(conversation.NewChatMessage(conversation.Role(a.role), input))
-
-	return steps.Resolve(input), nil
-}
-
-func (a *AddToHistoryStep) AddPublishedTopic(publisher message.Publisher, topic string) error {
-	return nil
-}
-
-type RunnableStep struct {
-	c       geppetto_context.GeppettoRunnable
-	manager conversation.Manager
-}
-
-var _ steps.Step[interface{}, *conversation.Message] = &RunnableStep{}
-
-func (r *RunnableStep) Start(ctx context.Context, input interface{}) (steps.StepResult[*conversation.Message], error) {
-	return r.c.RunWithManager(ctx, r.manager)
-}
-
-func (r *RunnableStep) AddPublishedTopic(publisher message.Publisher, topic string) error {
-	return nil
 }

--- a/pkg/steps/ai/chat/steps/add-to-history-step.go
+++ b/pkg/steps/ai/chat/steps/add-to-history-step.go
@@ -1,0 +1,25 @@
+package steps
+
+import (
+	"context"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/go-go-golems/geppetto/pkg/conversation"
+	"github.com/go-go-golems/geppetto/pkg/steps"
+)
+
+type AddToHistoryStep struct {
+	manager conversation.Manager
+	role    string
+}
+
+var _ steps.Step[string, string] = &AddToHistoryStep{}
+
+func (a *AddToHistoryStep) Start(ctx context.Context, input string) (steps.StepResult[string], error) {
+	a.manager.AppendMessages(conversation.NewChatMessage(conversation.Role(a.role), input))
+
+	return steps.Resolve(input), nil
+}
+
+func (a *AddToHistoryStep) AddPublishedTopic(publisher message.Publisher, topic string) error {
+	return nil
+}

--- a/pkg/steps/ai/chat/steps/caching-step_test.go
+++ b/pkg/steps/ai/chat/steps/caching-step_test.go
@@ -1,4 +1,4 @@
-package chat
+package steps
 
 import (
 	"context"

--- a/pkg/steps/ai/chat/steps/mock-step.go
+++ b/pkg/steps/ai/chat/steps/mock-step.go
@@ -1,4 +1,4 @@
-package chat
+package steps
 
 import (
 	"context"

--- a/pkg/steps/ai/chat/steps/mock-step_test.go
+++ b/pkg/steps/ai/chat/steps/mock-step_test.go
@@ -1,4 +1,4 @@
-package chat
+package steps
 
 import (
 	"context"

--- a/pkg/steps/ai/chat/steps/runnable-step.go
+++ b/pkg/steps/ai/chat/steps/runnable-step.go
@@ -1,0 +1,24 @@
+package steps
+
+import (
+	context2 "context"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/go-go-golems/geppetto/pkg/context"
+	"github.com/go-go-golems/geppetto/pkg/conversation"
+	"github.com/go-go-golems/geppetto/pkg/steps"
+)
+
+type RunnableStep struct {
+	c       context.GeppettoRunnable
+	manager conversation.Manager
+}
+
+var _ steps.Step[interface{}, *conversation.Message] = &RunnableStep{}
+
+func (r *RunnableStep) Start(ctx context2.Context, input interface{}) (steps.StepResult[*conversation.Message], error) {
+	return r.c.RunWithManager(ctx, r.manager)
+}
+
+func (r *RunnableStep) AddPublishedTopic(publisher message.Publisher, topic string) error {
+	return nil
+}

--- a/pkg/steps/ai/claude/chat-step.go
+++ b/pkg/steps/ai/claude/chat-step.go
@@ -134,7 +134,7 @@ func (csf *ChatStep) Start(
 		req.TopP = &defaultTopP
 	}
 
-	metadata := chat.EventMetadata{
+	metadata := events2.EventMetadata{
 		ID:       conversation.NewNodeID(),
 		ParentID: csf.parentID,
 		LLMMessageMetadata: conversation.LLMMessageMetadata{
@@ -207,7 +207,7 @@ func (csf *ChatStep) Start(
 			select {
 			case <-cancellableCtx.Done():
 				// TODO(manuel, 2024-07-04) Add tool calls so far
-				csf.subscriptionManager.PublishBlind(chat.NewInterruptEvent(metadata, stepMetadata, completionMerger.Text()))
+				csf.subscriptionManager.PublishBlind(events2.NewInterruptEvent(metadata, stepMetadata, completionMerger.Text()))
 				return
 
 			case event, ok := <-eventCh:
@@ -215,7 +215,7 @@ func (csf *ChatStep) Start(
 					// TODO(manuel, 2024-07-04) Probably not necessary, the completionMerger probably took care of it
 					response := completionMerger.Response()
 					if response == nil {
-						csf.subscriptionManager.PublishBlind(chat.NewErrorEvent(metadata, stepMetadata, "no response"))
+						csf.subscriptionManager.PublishBlind(events2.NewErrorEvent(metadata, stepMetadata, "no response"))
 						c <- helpers2.NewErrorResult[*conversation.Message](errors.New("no response"))
 						return
 					}
@@ -241,7 +241,7 @@ func (csf *ChatStep) Start(
 
 				events_, err := completionMerger.Add(event)
 				if err != nil {
-					csf.subscriptionManager.PublishBlind(chat.NewErrorEvent(metadata, stepMetadata, err.Error()))
+					csf.subscriptionManager.PublishBlind(events2.NewErrorEvent(metadata, stepMetadata, err.Error()))
 					c <- helpers2.NewErrorResult[*conversation.Message](err)
 					return
 				}

--- a/pkg/steps/ai/ollama/chat.go
+++ b/pkg/steps/ai/ollama/chat.go
@@ -6,7 +6,6 @@ import (
 	"github.com/go-go-golems/geppetto/pkg/events"
 	"github.com/go-go-golems/geppetto/pkg/helpers"
 	"github.com/go-go-golems/geppetto/pkg/steps"
-	"github.com/go-go-golems/geppetto/pkg/steps/ai/chat"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
 	"github.com/go-go-golems/glazed/pkg/helpers/maps"
 	"github.com/google/uuid"
@@ -49,7 +48,7 @@ func (ccs *ChatCompletionStep) Start(
 		parentID = parentMessage.ID
 	}
 
-	metadata := chat.EventMetadata{
+	metadata := events.EventMetadata{
 		ID:       conversation.NewNodeID(),
 		ParentID: parentID,
 	}
@@ -96,20 +95,20 @@ func (ccs *ChatCompletionStep) Start(
 			// TODO(manuel, 2024-01-13) Handle metrics
 
 			if resp.Done {
-				ccs.subscriptionManager.PublishBlind(chat.NewFinalEvent(metadata, ret.GetMetadata(), message))
+				ccs.subscriptionManager.PublishBlind(events.NewFinalEvent(metadata, ret.GetMetadata(), message))
 				c <- helpers.NewValueResult[string](resp.Message.Content)
 				return nil
 			}
 
 			message += resp.Message.Content
 
-			ccs.subscriptionManager.PublishBlind(chat.NewPartialCompletionEvent(metadata, ret.GetMetadata(), resp.Message.Content, message))
+			ccs.subscriptionManager.PublishBlind(events.NewPartialCompletionEvent(metadata, ret.GetMetadata(), resp.Message.Content, message))
 
 			return nil
 		})
 
 		if err != nil {
-			ccs.subscriptionManager.PublishBlind(chat.NewErrorEvent(metadata, ret.GetMetadata(), err.Error()))
+			ccs.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, ret.GetMetadata(), err.Error()))
 			c <- helpers.NewErrorResult[string](err)
 		}
 	}()

--- a/pkg/steps/ai/settings/settings-chat.go
+++ b/pkg/steps/ai/settings/settings-chat.go
@@ -3,6 +3,7 @@ package settings
 import (
 	_ "embed"
 	"fmt"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/chat/steps"
 
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/chat"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/types"
@@ -81,16 +82,16 @@ func (s *ChatSettings) WrapWithCache(step chat.Step, options ...chat.StepOption)
 	case "none":
 		return step, nil
 	case "memory":
-		return chat.NewMemoryCachingStep(step,
-			chat.WithMemoryMaxSize(s.CacheMaxEntries),
-			chat.WithMemoryStepOptions(options...),
+		return steps.NewMemoryCachingStep(step,
+			steps.WithMemoryMaxSize(s.CacheMaxEntries),
+			steps.WithMemoryStepOptions(options...),
 		)
 	case "disk":
-		return chat.NewCachingStep(step,
-			chat.WithMaxSize(s.CacheMaxSize),
-			chat.WithMaxEntries(s.CacheMaxEntries),
-			chat.WithCacheDirectory(s.CacheDirectory),
-			chat.WithStepOptions(options...),
+		return steps.NewCachingStep(step,
+			steps.WithMaxSize(s.CacheMaxSize),
+			steps.WithMaxEntries(s.CacheMaxEntries),
+			steps.WithCacheDirectory(s.CacheDirectory),
+			steps.WithStepOptions(options...),
 		)
 	default:
 		return nil, fmt.Errorf("unsupported cache type for chat: %s", s.CacheType)

--- a/ttmp/2025-03-29/01-gemini-step-pubsub-explanation.md
+++ b/ttmp/2025-03-29/01-gemini-step-pubsub-explanation.md
@@ -1,0 +1,39 @@
+# Explanation of Step Publishing and Watermill in Geppetto
+
+This document explains how the `steps.Step` abstraction in Geppetto, particularly AI-related steps, utilizes publishing mechanisms and the role the Watermill library plays in this process.
+
+## 1. Publishing in `steps.Step`
+
+The `steps.Step[T, U]` interface defines a method:
+
+```go
+AddPublishedTopic(publisher message.Publisher, topic string) error
+```
+
+*   **Purpose:** This method allows a `Step` instance to be configured with a `message.Publisher` and a specific `topic` string. The intention is for the step to publish messages (events) related to its execution lifecycle onto this topic using the provided publisher.
+*   **Implementation:** Concrete step implementations (like `openai.ChatStep`, `claude.MessagesStep`, etc.) typically store the provided publisher and topic internally. Often, they use a helper like `events.PublisherManager` to manage multiple potential publisher/topic pairs.
+*   **Usage:** Inside the `Start` method (the core execution logic of a step), the step uses the stored publisher to send messages at various points:
+    *   **Start:** When the step begins processing.
+    *   **Partial Results:** For streaming steps (like AI chat completion), messages indicating partial output delivery.
+    *   **Final Result:** When the step completes successfully, often including the final output.
+    *   **Errors:** If an error occurs during execution.
+    *   **Interrupts:** If the step's context is canceled.
+*   **Example (`openai.ChatStep`):** This step uses its internal `publisherManager` (configured via `AddPublishedTopic`) to publish events like `chat.NewStartEvent`, `chat.NewPartialCompletionEvent`, `chat.NewFinalEvent`, `chat.NewErrorEvent`, and `chat.NewInterruptEvent`. These events contain metadata about the step's execution, settings, and the content being processed or generated.
+
+## 2. Role of Watermill
+
+Watermill (`github.com/ThreeDotsLabs/watermill`) is a Go library for building event-driven applications. It provides the core building blocks for message publishing and subscribing.
+
+*   **Abstraction:** Watermill defines standard interfaces like `message.Publisher` and `message.Subscriber`. This decouples the application logic (like the Geppetto steps) from the specific message broker or transport mechanism (e.g., in-memory, Kafka, RabbitMQ, Google Cloud Pub/Sub).
+*   **Publisher:** The `message.Publisher` interface (passed into `AddPublishedTopic`) is provided by Watermill. Geppetto steps use this interface to send their lifecycle events as `message.Message` objects.
+*   **Message Broker:** Watermill handles the underlying communication. When a step calls `publisher.Publish(topic, message)`, Watermill takes care of routing that message to the appropriate broker configured for that topic.
+*   **Decoupling:** By using Watermill, Geppetto steps don't need to know *how* messages are being sent or *who* is listening. They just need a `message.Publisher` instance. This makes the system flexible and allows different parts (like UI components, logging services, or other steps) to subscribe to step events without the step needing direct knowledge of them.
+
+## Summary
+
+In essence:
+
+1.  The `steps.Step` interface includes `AddPublishedTopic` to enable steps to announce their progress and state.
+2.  AI steps (and others) implement this by storing the provided Watermill `message.Publisher` and `topic`.
+3.  During execution (`Start`), steps use the publisher to send lifecycle events (start, partial, final, error) as `message.Message` objects.
+4.  Watermill provides the `message.Publisher` interface and handles the actual delivery of these messages over the configured transport, decoupling the steps from the subscribers and the underlying pub/sub infrastructure. 

--- a/ttmp/2025-03-29/01-sonnet-3.7-step-pubsub-explanation.md
+++ b/ttmp/2025-03-29/01-sonnet-3.7-step-pubsub-explanation.md
@@ -1,0 +1,118 @@
+# Explanation of Step Publishing and Watermill in Geppetto
+
+This document explains the publisher-subscriber (pub-sub) mechanism in Geppetto's Step abstraction, focusing on how AI steps leverage this architecture to communicate events and the role Watermill plays as the underlying messaging system.
+
+## 1. Steps and Publishing Mechanism
+
+The Geppetto framework is built around the core abstraction of `Step`, which represents a computational unit that performs a particular task, such as generating text with an AI model or processing data. The Step interface includes:
+
+```go
+type Step[T any, U any] interface {
+    Start(ctx context.Context, input T) (StepResult[U], error)
+    AddPublishedTopic(publisher message.Publisher, topic string) error
+}
+```
+
+### How Steps Use Publishers and Topics
+
+1. **Publisher Registration**: Steps receive a publisher and topic through the `AddPublishedTopic` method, which they use to emit events during execution.
+
+2. **Implementation Pattern**: AI steps typically store the publisher and topic in a `PublisherManager`, which manages multiple publisher/topic pairs.
+
+3. **Event Publication**: During execution, steps publish various events (start, progress, completion, errors) to inform subscribers about their state.
+
+4. **Event Types**: AI steps publish events like:
+   - `chat.NewStartEvent`: When processing begins
+   - `chat.NewPartialCompletionEvent`: For streaming partial results
+   - `chat.NewFinalEvent`: When processing completes
+   - `chat.NewErrorEvent`: When errors occur
+   - `chat.NewInterruptEvent`: When processing is interrupted
+
+### Example from OpenAI Chat Step
+
+The OpenAI `ChatStep` implementation demonstrates how an AI step uses publishing:
+
+```go
+// During initialization
+func (csf *ChatStep) AddPublishedTopic(publisher message.Publisher, topic string) error {
+    csf.publisherManager.RegisterPublisher(topic, publisher)
+    return nil
+}
+
+// During execution
+func (csf *ChatStep) Start(ctx context.Context, messages conversation.Conversation) (steps.StepResult[*conversation.Message], error) {
+    // Setup...
+    
+    // Announce start
+    csf.publisherManager.PublishBlind(chat.NewStartEvent(metadata, stepMetadata))
+    
+    // During streaming
+    csf.publisherManager.PublishBlind(
+        chat.NewPartialCompletionEvent(
+            metadata,
+            stepMetadata,
+            delta, message),
+    )
+    
+    // On completion
+    csf.publisherManager.PublishBlind(chat.NewFinalEvent(
+        metadata,
+        stepMetadata,
+        message,
+    ))
+    
+    // On error
+    csf.publisherManager.PublishBlind(chat.NewErrorEvent(metadata, stepMetadata, err.Error()))
+}
+```
+
+## 2. Role of Watermill
+
+Watermill (`github.com/ThreeDotsLabs/watermill`) is a Go library that provides the messaging infrastructure for Geppetto's pub-sub system:
+
+### Key Aspects of Watermill
+
+1. **Abstraction**: Watermill provides standard interfaces like `message.Publisher` and `message.Subscriber`, decoupling steps from specific message transport mechanisms.
+
+2. **Message Formats**: Messages in Watermill consist of:
+   - A UUID
+   - Payload (binary data)
+   - Metadata (key-value pairs)
+
+3. **Transport Agnostic**: Watermill supports various message brokers (Go channels, AMQP, Kafka, etc.), allowing Geppetto to use the most appropriate transport without changing step logic.
+
+4. **Message Routing**: Watermill's router component connects publishers to subscribers based on topic names, handling message delivery.
+
+### How Geppetto Uses Watermill
+
+1. **PublisherManager**: Geppetto wraps Watermill's publisher in a `PublisherManager` class that:
+   - Manages multiple publisher/topic pairs
+   - Serializes event objects to JSON
+   - Adds sequence numbers to messages
+   - Provides error handling
+
+2. **Event Router**: Geppetto's `EventRouter` creates Watermill publishers and subscribers, connects them via topics, and allows components to register handlers for events.
+
+3. **Decoupling**: Using Watermill allows steps to publish events without knowing who is listening or how messages are transported, making the system more flexible and modular.
+
+## 3. Integration Flow
+
+The complete flow from AI step execution to event handling works as follows:
+
+1. A client creates an AI step (like `ChatStep`) and configures it.
+
+2. The client registers a publisher and topic with the step via `AddPublishedTopic`.
+
+3. When executed, the step processes its input and publishes events during key moments (start, progress, completion, errors).
+
+4. Watermill delivers these events to all subscribers of the specified topic.
+
+5. Subscribers (like UIs, loggers, or other steps) receive and process these events, updating displays, logging information, or triggering further actions.
+
+This architecture enables:
+- Real-time streaming of AI outputs
+- Monitoring of AI processing
+- Loose coupling between components
+- Flexible handling of events by multiple subscribers
+
+For example, a web UI might subscribe to these events to show typing animations, a logger might record them for auditing, and another component might collect metrics—all without the AI step needing to know about any of these consumers. 

--- a/ttmp/2025-03-29/02-gemini-2.5-step-pubsub-explanation.md
+++ b/ttmp/2025-03-29/02-gemini-2.5-step-pubsub-explanation.md
@@ -1,0 +1,45 @@
+# Explanation of Step Publishing and Watermill in Geppetto
+
+This document explains how the `steps.Step` abstraction in Geppetto, particularly AI-related steps, utilizes publishing mechanisms via the `AddPublishedTopic` method and the role the Watermill library plays in this process.
+
+## 1. Publishing in `steps.Step` via `AddPublishedTopic`
+
+The `steps.Step[T, U]` interface (defined in `geppetto/pkg/steps/step.go`) includes the method:
+
+```go
+AddPublishedTopic(publisher message.Publisher, topic string) error
+```
+
+*   **Purpose:** This method serves as an injection point. It allows the system coordinating the steps to provide a specific `message.Publisher` instance (from the Watermill library) and a `topic` string to a `Step`. The step is then expected to use this publisher to broadcast events related to its execution lifecycle onto the given topic.
+*   **Implementation Strategy:** Concrete step implementations, especially AI steps like `openai.ChatStep`, `claude.MessagesStep`, and various caching/utility steps, implement this method. They typically don't use the provided `publisher` and `topic` directly within the method. Instead, they often delegate the registration to an internal helper object, commonly an `events.PublisherManager` (from `geppetto/pkg/events/publish.go`).
+    ```go
+    // Example from openai.ChatStep
+    func (csf *ChatStep) AddPublishedTopic(publisher message.Publisher, topic string) error {
+        csf.publisherManager.RegisterPublisher(topic, publisher) // Delegate registration
+        return nil
+    }
+    ```
+*   **Event Emission:** The core logic happens within the step's `Start` method. During execution, the step uses its internal `PublisherManager` (which now holds the registered publishers/topics) to publish various lifecycle events. It calls methods like `publisherManager.Publish(eventPayload)` or `publisherManager.PublishBlind(eventPayload)`.
+*   **Event Types:** Steps publish events corresponding to different stages of their execution:
+    *   **Start:** Indicates the step has begun processing (e.g., `chat.NewStartEvent`).
+    *   **Partial Results:** For steps that stream output (like AI chat), events containing chunks of the result (e.g., `chat.NewPartialCompletionEvent`).
+    *   **Final Result:** Signifies successful completion, often containing the final output (e.g., `chat.NewFinalEvent`).
+    *   **Errors:** Published when an error occurs during execution (e.g., `chat.NewErrorEvent`).
+    *   **Interrupts:** Emitted if the step's execution context is canceled (e.g., `chat.NewInterruptEvent`).
+    These events usually encapsulate metadata about the step, its inputs/outputs, timestamps, and the specific payload for that event type.
+
+## 2. Role of Watermill
+
+Watermill (`github.com/ThreeDotsLabs/watermill`) is a fundamental Go library used by Geppetto for building event-driven applications. It provides the core pub/sub infrastructure.
+
+*   **Abstraction Layer:** Watermill's primary role here is to provide standard interfaces like `message.Publisher` and `message.Subscriber`. This decouples the application logic (the Geppetto steps) from the underlying message transport mechanism. Geppetto steps don't need to know if messages are being sent via in-memory channels, Kafka, RabbitMQ, or another system; they just interact with the Watermill interface.
+*   **Publisher Interface:** The `message.Publisher` type required by `AddPublishedTopic` comes directly from Watermill.
+*   **Message Handling:** When a step calls `publisher.Publish(topic, message)` (usually indirectly via the `PublisherManager`), Watermill takes over. It handles constructing the `message.Message` object (often adding metadata like UUIDs) and routes it through the configured backend (e.g., the `gochannel` pubsub for in-memory communication, as configured in `geppetto/pkg/events/event-router.go`).
+*   **Decoupling:** The use of Watermill is key to Geppetto's modularity. Steps (publishers) are decoupled from the services or components that consume their events (subscribers). A UI component, a logging service, or another analytical tool can subscribe to step events using a Watermill `message.Subscriber` without the step needing any direct reference to them.
+
+## Summary
+
+1.  The `AddPublishedTopic` method on `steps.Step` allows steps to be configured with a destination (topic) and a means (Watermill `message.Publisher`) to announce their status.
+2.  AI steps implement this, often using an `events.PublisherManager` to store these configurations.
+3.  During their `Start` execution, steps publish lifecycle events (start, partial, final, error, interrupt) using the manager.
+4.  Watermill provides the core `message.Publisher` interface and handles the actual message transport, decoupling event producers (steps) from event consumers and the specific pub/sub technology used. 

--- a/ttmp/2025-03-29/02-gemini-step-documentation.md
+++ b/ttmp/2025-03-29/02-gemini-step-documentation.md
@@ -1,0 +1,49 @@
+# Explanation of Step Pub/Sub Mechanism in Geppetto
+
+This document explains how the `Step` abstraction in Geppetto, particularly AI steps, leverages the publisher/topic mechanism, and the role Watermill plays.
+
+## The `Step` Interface and `AddPublishedTopic`
+
+The core `Step` interface in `pkg/steps/step.go` defines the contract for individual processing units within Geppetto:
+
+```go
+// geppetto/pkg/steps/step.go
+type Step[T any, U any] interface {
+	// Start gets called multiple times for the same Step, once per incoming value,
+	// since StepResult is also the list monad (ie., supports multiple values)
+	Start(ctx context.Context, input T) (StepResult[U], error)
+	// XXX this needs to be replaced as a step that creates a stream of PartialCompletionEvent etc...
+	AddPublishedTopic(publisher message.Publisher, topic string) error
+}
+```
+
+The key method for understanding the pub/sub integration is `AddPublishedTopic`. This method allows a `Step` instance to be configured with:
+
+1.  A `message.Publisher`: This is an interface provided by the Watermill library, representing the capability to publish messages.
+2.  A `topic`: A string identifying the destination channel or queue where messages should be sent.
+
+By calling `AddPublishedTopic`, a step is essentially given the ability and destination to publish messages related to its execution. The comment `// XXX this needs to be replaced as a step that creates a stream of PartialCompletionEvent etc...` indicates that this mechanism is likely intended for publishing events *during* the step's execution, such as partial results or status updates, although the current implementation might be simpler.
+
+## How Steps Leverage Publishing
+
+A `Step`, once configured with a publisher and topic via `AddPublishedTopic`, can use the `publisher.Publish(topic, message)` method (from the Watermill library) internally within its `Start` method logic.
+
+Here's how different steps, especially AI steps, might leverage this:
+
+1.  **Intermediate Results / Streaming:** For AI steps involving interactions with Large Language Models (LLMs) that support streaming (returning results token by token or chunk by chunk), the step could publish each chunk as a separate message to the configured topic. Downstream consumers could then listen to this topic to process the results incrementally. The `XXX` comment strongly suggests this is a primary intended use case.
+2.  **Status Updates:** A step could publish messages indicating its current state (e.g., "Started processing", "API call initiated", "Parsing response", "Completed successfully", "Encountered error"). This provides observability into the workflow.
+3.  **Final Results:** While the primary return mechanism is the `StepResult`, a step *could* also publish its final result(s) as messages. This might be useful for broadcasting results to multiple independent consumers who aren't directly part of the sequential step chain.
+4.  **Events and Notifications:** Steps could publish specific events, like "Threshold exceeded" or "Pattern detected," which might trigger other processes or alerts elsewhere in the system.
+5.  **Debugging and Logging:** Published messages can serve as a detailed, structured log stream for debugging complex sequences of steps.
+
+## Role of Watermill
+
+Watermill (`github.com/ThreeDotsLabs/watermill`) is the underlying library that provides the pub/sub messaging infrastructure. Geppetto uses Watermill's abstractions, primarily:
+
+1.  `message.Publisher`: The interface used by steps to send messages.
+2.  `message.Subscriber`: (Implicitly used elsewhere in Geppetto, likely where steps are orchestrated or workflows are defined) The interface used to receive messages.
+3.  `message.Message`: The structure representing the data being sent, containing a payload and metadata.
+
+Watermill handles the complexities of message passing. It provides adapters for various messaging systems (like Kafka, RabbitMQ, NATS, Google Cloud Pub/Sub, or even simple in-memory channels for testing). This means Geppetto's core step logic doesn't need to know the specifics of the underlying message broker; it just interacts with the Watermill `Publisher` interface.
+
+In essence, Watermill acts as the message bus or backbone, enabling decoupling between steps and allowing for event-driven communication patterns within Geppetto workflows. The `AddPublishedTopic` mechanism hooks individual steps into this broader messaging system.

--- a/ttmp/2025-03-29/03-gemini-step-documentation.md
+++ b/ttmp/2025-03-29/03-gemini-step-documentation.md
@@ -1,0 +1,84 @@
+Okay, I will create the explanation document as requested.
+
+First, I need to understand the context of the `Step` interface and its `AddPublishedTopic` method. I'll read the relevant section of the `geppetto/pkg/steps/step.go` file.
+
+Read file: geppetto/pkg/steps/step.go
+Okay, I understand. To provide an accurate explanation, I first need to see how the `AddPublishedTopic` method is actually used within the `geppetto` codebase, particularly in AI-related steps. I'll search for implementations and usages of this method.
+
+Search files...
+
+Read file: geppetto/pkg/events/publish.go
+Okay, I have examined the code, including the `Step` interface, implementations in various AI steps (`openai.ChatStep`, `claude.MessagesStep`, `chat.CachingStep`), and the `events.PublisherManager`.
+
+Here's the explanation:
+
+1.  **Purpose of `AddPublishedTopic`:** The `Step` interface defines `AddPublishedTopic(publisher message.Publisher, topic string) error`. This method allows external code (like the system wiring the steps together) to provide a `message.Publisher` and a specific `topic` to a `Step` instance. The intention is for the step to use this publisher to send messages (events) related to its execution progress and results onto the specified topic.
+
+2.  **How AI Steps Use It:**
+    *   Most AI step implementations (e.g., `openai.ChatStep`, `claude.MessagesStep`, `chat.CachingStep`, `chat.MemoryCachingStep`, `chat.EchoStep`, `openai.ExecuteToolStep`) implement `AddPublishedTopic`.
+    *   They typically don't use the publisher directly but delegate the registration to an internal `events.PublisherManager` instance (e.g., `csf.subscriptionManager.RegisterPublisher(topic, publisher)`).
+    *   This `PublisherManager` (from `geppetto/pkg/events/publish.go`) holds a map of topics to lists of publishers.
+    *   During the step's execution (within the `Start` method), the step calls methods like `Publish` or `PublishBlind` on its `PublisherManager`.
+    *   The `PublisherManager` then iterates through all registered publishers for the relevant topics and calls their respective `Publish` methods, effectively broadcasting the event.
+    *   AI steps publish various lifecycle events: start of execution, streaming partial results, final results, errors, and interruptions. These events are often structured types defined within the `chat` package (e.g., `chat.NewStartEvent`, `chat.NewPartialEvent`).
+
+3.  **Role of Watermill:**
+    *   Watermill (`github.com/ThreeDotsLabs/watermill`) is the underlying library providing the pub/sub functionality.
+    *   The `message.Publisher` interface passed into `AddPublishedTopic` is defined by Watermill. It abstracts the details of *how* messages are published.
+    *   Watermill provides various implementations (Pub/Subs) like Go channels, Kafka, RabbitMQ, etc. Geppetto primarily seems to use the `gochannel` Pub/Sub for in-memory event routing (as seen in `geppetto/pkg/events/event-router.go`).
+    *   When a step (via `PublisherManager`) calls `publisher.Publish(topic, msg)`, it's invoking Watermill's mechanism. Watermill handles creating the `message.Message` (adding UUIDs, etc.) and sending it through the configured transport for that publisher/topic.
+    *   This decouples the steps (event producers) from the event consumers (subscribers, which could be UI elements, loggers, or other systems). Steps only need to know about the Watermill `message.Publisher` interface, not the specific implementation or the subscribers listening on the other end.
+
+I will now create the explanation document `geppetto/ttmp/2025-03-29/02-gemini-2.5-step-pubsub-explanation.md`.
+
+```markdown:geppetto/ttmp/2025-03-29/02-gemini-2.5-step-pubsub-explanation.md
+# Explanation of Step Publishing and Watermill in Geppetto
+
+This document explains how the `steps.Step` abstraction in Geppetto, particularly AI-related steps, utilizes publishing mechanisms via the `AddPublishedTopic` method and the role the Watermill library plays in this process.
+
+## 1. Publishing in `steps.Step` via `AddPublishedTopic`
+
+The `steps.Step[T, U]` interface (defined in `geppetto/pkg/steps/step.go`) includes the method:
+
+```go
+AddPublishedTopic(publisher message.Publisher, topic string) error
+```
+
+*   **Purpose:** This method serves as an injection point. It allows the system coordinating the steps to provide a specific `message.Publisher` instance (from the Watermill library) and a `topic` string to a `Step`. The step is then expected to use this publisher to broadcast events related to its execution lifecycle onto the given topic.
+*   **Implementation Strategy:** Concrete step implementations, especially AI steps like `openai.ChatStep`, `claude.MessagesStep`, and various caching/utility steps, implement this method. They typically don't use the provided `publisher` and `topic` directly within the method. Instead, they often delegate the registration to an internal helper object, commonly an `events.PublisherManager` (from `geppetto/pkg/events/publish.go`).
+    ```go
+    // Example from openai.ChatStep
+    func (csf *ChatStep) AddPublishedTopic(publisher message.Publisher, topic string) error {
+        csf.publisherManager.RegisterPublisher(topic, publisher) // Delegate registration
+        return nil
+    }
+    ```
+*   **Event Emission:** The core logic happens within the step's `Start` method. During execution, the step uses its internal `PublisherManager` (which now holds the registered publishers/topics) to publish various lifecycle events. It calls methods like `publisherManager.Publish(eventPayload)` or `publisherManager.PublishBlind(eventPayload)`.
+*   **Event Types:** Steps publish events corresponding to different stages of their execution:
+    *   **Start:** Indicates the step has begun processing (e.g., `chat.NewStartEvent`).
+    *   **Partial Results:** For steps that stream output (like AI chat), events containing chunks of the result (e.g., `chat.NewPartialCompletionEvent`).
+    *   **Final Result:** Signifies successful completion, often containing the final output (e.g., `chat.NewFinalEvent`).
+    *   **Errors:** Published when an error occurs during execution (e.g., `chat.NewErrorEvent`).
+    *   **Interrupts:** Emitted if the step's execution context is canceled (e.g., `chat.NewInterruptEvent`).
+    These events usually encapsulate metadata about the step, its inputs/outputs, timestamps, and the specific payload for that event type.
+
+## 2. Role of Watermill
+
+Watermill (`github.com/ThreeDotsLabs/watermill`) is a fundamental Go library used by Geppetto for building event-driven applications. It provides the core pub/sub infrastructure.
+
+*   **Abstraction Layer:** Watermill's primary role here is to provide standard interfaces like `message.Publisher` and `message.Subscriber`. This decouples the application logic (the Geppetto steps) from the underlying message transport mechanism. Geppetto steps don't need to know if messages are being sent via in-memory channels, Kafka, RabbitMQ, or another system; they just interact with the Watermill interface.
+*   **Publisher Interface:** The `message.Publisher` type required by `AddPublishedTopic` comes directly from Watermill.
+*   **Message Handling:** When a step calls `publisher.Publish(topic, message)` (usually indirectly via the `PublisherManager`), Watermill takes over. It handles constructing the `message.Message` object (often adding metadata like UUIDs) and routes it through the configured backend (e.g., the `gochannel` pubsub for in-memory communication, as configured in `geppetto/pkg/events/event-router.go`).
+*   **Decoupling:** The use of Watermill is key to Geppetto's modularity. Steps (publishers) are decoupled from the services or components that consume their events (subscribers). A UI component, a logging service, or another analytical tool can subscribe to step events using a Watermill `message.Subscriber` without the step needing any direct reference to them.
+
+## Summary
+
+1.  The `AddPublishedTopic` method on `steps.Step` allows steps to be configured with a destination (topic) and a means (Watermill `message.Publisher`) to announce their status.
+2.  AI steps implement this, often using an `events.PublisherManager` to store these configurations.
+3.  During their `Start` execution, steps publish lifecycle events (start, partial, final, error, interrupt) using the manager.
+4.  Watermill provides the core `message.Publisher` interface and handles the actual message transport, decoupling event producers (steps) from event consumers and the specific pub/sub technology used.
+
+```
+OK, I have created the document `geppetto/ttmp/2025-03-29/02-gemini-2.5-step-pubsub-explanation.md` explaining how steps, particularly AI steps, use the publisher/topic mechanism via `AddPublishedTopic` and the role Watermill plays in this process.
+
+Let me know if you'd like any refinements or further details added to the explanation!

--- a/ttmp/2025-03-29/06-sonnet-3.7-step-pubsub-explanation.md
+++ b/ttmp/2025-03-29/06-sonnet-3.7-step-pubsub-explanation.md
@@ -1,0 +1,284 @@
+# Steps, PubSub, and Watermill in Geppetto
+
+This document explains how the step abstraction in Geppetto leverages publishers and topics, with a focus on AI steps, and the role that the Watermill library plays in this architecture.
+
+## Step Abstraction and Publisher/Topic System
+
+### Core Step Interface
+
+The Step interface in Geppetto is defined as a generic interface with two type parameters:
+
+```go
+type Step[T any, U any] interface {
+    Start(ctx context.Context, input T) (StepResult[U], error)
+    AddPublishedTopic(publisher message.Publisher, topic string) error
+}
+```
+
+Every Step implementation must provide an `AddPublishedTopic` method, which allows the step to publish events to subscribers. This method associates a Watermill publisher with a specific topic, enabling event-driven communication.
+
+### StepResult - The Return Monad
+
+The `StepResult` interface represents the computation result:
+
+```go
+type StepResult[T any] interface {
+    Return() []helpers.Result[T]
+    GetChannel() <-chan helpers.Result[T]
+    Cancel()
+    GetMetadata() *StepMetadata
+}
+```
+
+This interface embodies several monadic patterns:
+
+1. **List Monad**: It can contain multiple results via the channel
+2. **Maybe Monad**: Results can be values or errors (via `helpers.Result`)
+3. **Cancellation Monad**: Operations can be cancelled
+4. **Metadata Monad**: Carries metadata about the computation
+
+The key insight is that while `StepResult` handles the *value* flow through its channel, the *event* flow happens via the publisher/topic system, creating two parallel communication paths.
+
+### How Steps Use Publishers and Topics
+
+Steps use publishers and topics to:
+
+1. Broadcast their internal state changes
+2. Report progress during execution
+3. Stream partial results
+4. Notify about completion or errors
+
+The `AddPublishedTopic` method provides a way for external code to inject a publisher and topic into a step, establishing a channel for the step to communicate its progress and results outside of its primary return value.
+
+### Step Composition with Bind
+
+Steps are designed for composition using the `Bind` function, which implements the monadic bind operator:
+
+```go
+func Bind[T any, U any](
+    ctx context.Context,
+    m StepResult[T],
+    step Step[T, U],
+) StepResult[U] {
+    // Implementation handles chaining steps together
+}
+```
+
+This function enables complex pipelines by:
+1. Taking the result of one step
+2. Feeding it into another step
+3. Propagating cancellation
+4. Handling errors
+
+While values flow through binding, events from each step still flow independently through the publisher system, allowing consumers to observe every step in the chain.
+
+## Context Cancellation and Event Flow
+
+Steps handle context cancellation in a consistent way:
+
+```go
+func (csf *ChatStep) Start(ctx context.Context, input conversation.Conversation) (steps.StepResult[*conversation.Message], error) {
+    var cancel context.CancelFunc
+    cancellableCtx, cancel := context.WithCancel(ctx)
+    go func() {
+        <-ctx.Done()
+        cancel()
+    }()
+    
+    // ... step implementation ...
+    
+    // When cancellation occurs:
+    csf.publisherManager.PublishBlind(chat.NewInterruptEvent(metadata, stepMetadata, message))
+}
+```
+
+This ensures:
+1. Cancellation propagates to child operations
+2. Cancellation events are published to subscribers
+3. Resources are properly released
+4. Long-running steps like AI completions terminate gracefully
+
+## AI Steps and Event Publishing
+
+AI steps (like OpenAI and Claude integrations) make extensive use of the publisher/topic system to stream their execution progress. This is particularly important for several reasons:
+
+1. **Streaming Responses**: AI completions can take time, and streaming allows for progressive rendering of responses
+2. **Tool Calling**: AI steps that use tools need to publish when tools are called and when results are returned
+3. **Monitoring**: Steps publish metadata about token usage, engines, and other parameters
+4. **Caching**: Cached responses need to publish events that mimic what the original execution would have published
+
+### Event Types for AI Steps
+
+AI steps publish a variety of event types:
+
+- `EventTypeStart`: When the step begins execution
+- `EventTypePartialCompletion`: During streaming, as chunks of the response arrive
+- `EventTypeToolCall`: When an AI model calls a tool
+- `EventTypeToolResult`: When a tool returns a result
+- `EventTypeFinal`: When the step has completed
+- `EventTypeInterrupt`: When the step is interrupted
+- `EventTypeError`: When an error occurs
+
+### Implementation in AI Steps
+
+Looking at the OpenAI chat step implementation as an example:
+
+```go
+func (csf *ChatStep) AddPublishedTopic(publisher message.Publisher, topic string) error {
+    csf.publisherManager.RegisterPublisher(topic, publisher)
+    return nil
+}
+```
+
+AI steps typically use a `PublisherManager` to handle multiple publishers and topics. When streaming a response:
+
+```go
+// Publish the start event
+csf.publisherManager.PublishBlind(chat.NewStartEvent(metadata, stepMetadata))
+
+// Stream a response
+for {
+    // ...process response chunk...
+    
+    // Publish partial completion
+    csf.publisherManager.PublishBlind(
+        chat.NewPartialCompletionEvent(
+            metadata,
+            stepMetadata,
+            delta, message),
+    )
+}
+
+// Publish completion
+csf.publisherManager.PublishBlind(chat.NewFinalEvent(metadata, stepMetadata, message))
+```
+
+This pattern allows for realtime updates of AI processing status, critical for interactive applications.
+
+## Event Flow Architecture
+
+The full event flow in Geppetto follows this pattern:
+
+1. **Step Creation**: A step is created with a `PublisherManager`
+2. **Registration**: Publishers are registered for topics via `AddPublishedTopic`
+3. **Execution**: The step is started with input
+4. **Event Publishing**: During execution, events are published to all registered topics
+5. **Event Routing**: Events are routed to subscribers via Watermill
+6. **Consumption**: Subscribers (UI components, loggers, etc.) consume events
+7. **Result Return**: Separately, the step returns values through its `StepResult`
+
+This dual-flow architecture (events and values) enables:
+- Immediate feedback even for long-running operations
+- Detailed monitoring and logging
+- Clean separation of control flow and status reporting
+- Composition of complex pipelines while maintaining observability
+
+## Watermill's Role
+
+[Watermill](https://github.com/ThreeDotsLabs/watermill) is a Go library for working with message streams. It provides abstractions for:
+
+1. Publishing messages
+2. Subscribing to messages
+3. Routing messages between publishers and subscribers
+
+### Key Watermill Components Used in Geppetto
+
+#### Publishers and Subscribers
+
+In Geppetto, Watermill provides the publisher and subscriber interfaces:
+
+```go
+type Publisher interface {
+    Publish(topic string, messages ...*Message) error
+    Close() error
+}
+
+type Subscriber interface {
+    Subscribe(ctx context.Context, topic string) (<-chan *Message, error)
+    Close() error
+}
+```
+
+These interfaces allow for different message transport implementations (in-memory Go channels, NATS, Kafka, etc.) with a consistent API.
+
+#### Message Router
+
+Geppetto uses Watermill's message router for connecting publishers to subscribers:
+
+```go
+func (e *EventRouter) AddHandler(name string, topic string, f func(msg *message.Message) error) {
+    e.router.AddNoPublisherHandler(name, topic, e.Subscriber, f)
+}
+```
+
+The router manages the flow of messages and provides features like middleware, metrics, and recovery.
+
+### PublisherManager
+
+Geppetto extends Watermill with a `PublisherManager` that manages multiple publishers for different topics:
+
+```go
+type PublisherManager struct {
+    Publishers     map[string][]message.Publisher
+    sequenceNumber uint64
+    mutex          sync.Mutex
+}
+```
+
+The manager:
+1. Allows registering publishers for specific topics
+2. Adds sequence numbers to messages for ordering
+3. Broadcasts messages to all relevant publishers
+4. Handles serialization of event payloads to JSON
+
+#### Sequence Numbers
+
+The `PublisherManager` adds sequence numbers to each message:
+
+```go
+msg := message.NewMessage(watermill.NewUUID(), b)
+msg.Metadata.Set("sequence_number", fmt.Sprintf("%d", s.sequenceNumber))
+s.sequenceNumber++
+```
+
+This ensures that consumers can reconstruct the order of events even when they arrive out of order, critical for displaying streamed content correctly.
+
+## Practical Examples
+
+### Streaming Chat Completion
+
+When an OpenAI chat step is executed with streaming enabled:
+
+1. The step is initialized with a `PublisherManager`
+2. External code calls `AddPublishedTopic` to register a publisher and topic
+3. When `Start` is called, the step publishes a `StartEvent`
+4. As chunks of the response arrive, the step publishes `PartialCompletionEvent`s
+5. When complete, the step publishes a `FinalEvent`
+
+This allows a UI or other consumer to display the AI response as it's generated, rather than waiting for the entire response.
+
+### Tool Calling
+
+For AI steps that support tool calling:
+
+1. When the AI decides to call a tool, a `ToolCallEvent` is published
+2. The tool executes and a `ToolResultEvent` is published
+3. The AI continues processing with the tool result
+
+This enables monitoring of the entire tool calling flow.
+
+### Composing AI Steps with Tools
+
+When composing an AI step with tool execution:
+
+1. An AI step starts and generates content or tool calls
+2. Tool calls are captured and published as events
+3. Another step executes the tools
+4. Tool results are passed back to the original AI step
+5. The AI continues processing with the tool results
+6. Events from all steps flow independently to subscribers
+
+This composition is possible because:
+- The value flow is handled by the Step/StepResult system
+- The event flow is handled by the publisher/topic system
+- Context cancellation propagates correctly through the entire chain

--- a/ttmp/2025-03-29/07-deepseek-step-explanation.md
+++ b/ttmp/2025-03-29/07-deepseek-step-explanation.md
@@ -1,0 +1,164 @@
+# Step Abstraction Pub/Sub Architecture with Watermill
+
+## Core Components Interaction
+
+![Architecture Diagram]
+(Note: ASCII art placeholder - recommend generating actual diagram later)
+
+1. **Step Implementation** (e.g. `ChatStep`)
+2. **PublisherManager** (events/publish.go)
+3. **Watermill** (message.Publisher interface)
+4. **Event Types** (chat/events.go)
+
+## Key Implementation Points
+
+### 1. Event Publishing in Steps (`chat-step.go`)
+
+The AI steps use a three-layer publishing system:
+
+```go
+// Simplified flow from chat-step.go
+func (csf *ChatStep) Start(...) {
+    // 1. Create metadata
+    metadata := chat.EventMetadata{...}
+    
+    // 2. Publish start event
+    csf.publisherManager.PublishBlind(
+        chat.NewStartEvent(metadata, stepMetadata)
+    )
+    
+    // 3. During streaming:
+    csf.publisherManager.PublishBlind(
+        chat.NewPartialCompletionEvent(...)
+    )
+}
+```
+
+### 2. PublisherManager Mechanics (`publish.go`)
+
+The PublisherManager acts as a multiplexer:
+
+```go
+// Registration flow
+func (s *PublisherManager) RegisterPublisher(topic string, sub message.Publisher) {
+    s.Publishers[topic] = append(s.Publishers[topic], sub)
+}
+
+// Publishing sequence numbers
+func (s *PublisherManager) Publish(payload interface{}) error {
+    s.sequenceNumber++
+    msg := message.NewMessage(..., b)
+    msg.Metadata.Set("sequence_number", ...)
+    
+    for topic, subs := range s.Publishers {
+        for _, sub := range subs {
+            sub.Publish(topic, msg) // Watermill call
+        }
+    }
+}
+```
+
+### 3. Watermill's Role
+
+Watermill provides:
+- Message routing backbone
+- Publisher/subscriber interfaces
+- Serialization/deserialization
+- At-least-once delivery guarantees
+- Pluggable backends (e.g. Kafka, Pub/Sub, NATS)
+
+Critical integration points:
+```go
+// Step interface requires Watermill publisher
+type Step interface {
+    AddPublishedTopic(publisher message.Publisher, topic string) error
+}
+
+// Event serialization uses Watermill messages
+msg := message.NewMessage(watermill.NewUUID(), b)
+```
+
+## Event Types and Flow (`events.go`)
+
+The event system follows a state machine pattern:
+
+```
+Start → [PartialCompletion]* → (Final|Error|Interrupt)
+       ↘ [ToolCall → ToolResult]*
+```
+
+Key event properties:
+- Strong typing with `EventType` enum
+- Zerolog integration for structured logging
+- Watermill message metadata propagation
+
+## Why This Architecture?
+
+1. **Decoupling**: Steps don't know about subscribers
+2. **Observability**: Sequence numbers enable event replay
+3. **Extensibility**: New consumers can tap into existing streams
+4. **Error Resilience**: Blind publishing prevents step failures from breaking event flow
+
+## Typical Deployment Scenario
+
+```mermaid
+graph LR
+    Step[ChatStep] --> PublisherManager
+    PublisherManager -->|topic1| WatermillPubSub[(Watermill)]
+    PublisherManager -->|topic2| WatermillPubSub
+    WatermillPubSub --> Subscriber1[UI WebSocket]
+    WatermillPubSub --> Subscriber2[Monitoring]
+    WatermillPubSub --> Subscriber3[Audit Log]
+```
+
+## Key Design Decisions
+
+1. **Double Metadata**:
+   - `StepMetadata` for execution context
+   - `EventMetadata` for conversation tracking
+
+2. **Sequence Numbers**:
+   - Enable ordered processing despite async nature
+   - Critical for replay/debugging
+
+3. **Blind Publishing**:
+   - Errors logged but don't abort step execution
+   - Prevents cascading failures
+
+## Common Patterns
+
+**Adding a New Subscriber:**
+```go
+// In initialization code
+step.AddPublishedTopic(watermillPublisher, "chat_events")
+
+// Elsewhere in consumer
+messages, _ := subscriber.Subscribe(ctx, "chat_events")
+for msg := range messages {
+    event, _ := chat.NewEventFromJson(msg.Payload)
+    // Handle event...
+    msg.Ack()
+}
+```
+
+**Correlating Events:**
+```go
+// Using metadata fields
+event.Metadata().ID          // Message correlation ID
+event.StepMetadata().StepID  // Execution instance ID
+msg.Metadata["sequence_number"] // Global ordering
+```
+
+## Limitations and Considerations
+
+1. **Event Size**: Large messages may need chunking
+2. **Backpressure**: No built-in flow control
+3. **Serialization**: JSON-only without versioning
+4. **Ordering Guarantees**: Only per-topic sequencing
+```
+
+This document combines analysis from:
+- `chat-step.go` event publishing patterns
+- `publish.go` multiplexing logic
+- `events.go` type system
+- `step.md` architectural concepts

--- a/ttmp/2025-03-29/08-deepseek-write-more.md
+++ b/ttmp/2025-03-29/08-deepseek-write-more.md
@@ -1,0 +1,261 @@
+# Geppetto Step Abstraction: Pub/Sub Architecture with Watermill Integration
+
+## Architectural Overview
+
+The Geppetto framework uses a sophisticated publish-subscribe pattern combined with monadic step processing to handle AI operations. This system enables:
+
+1. **Asynchronous processing** of LLM interactions
+2. **Real-time event streaming** for UI updates and monitoring
+3. **Decoupled architecture** for extensibility
+
+### Core Components
+
+![Architecture Diagram](https://mermaid.ink/svg/pako:eNpVkE1PwzAMhv9KlNd1H5u0aRMSEhKHgTjAYRzSJm5Hk7ZJN6GE-O9x-4F0suX3eZ_tVHY4QmM7VJqG4A1qKqXCd3zBwQeHlalx8BZf8QkHqXG0HXZQ4wQdDlDhCBYq_MQ3fMZeaqyNw8k5_MIX7KTCSrfYW4uT7fEDX1FLhY1usTcWR9viO75hKxU2psXeWBxsix_4iq1U2JoWe2NxsC1-4gu2UmFnWuyNxcG2-IHP2EmFvWmxNxYH2-I7PmEnFQ6mxd5YHGyLb_iIrVQ4mhZ7Y3GwLb7hA7ZS4WRa7I3Fwbb4ivfYSIWzabE3Fgfb4gveYSMVLqbF3lgcbIsveIu1VLiaFntjcbAtvuANVlLhZlrsjcXBtviM11hKhbtpsTcWB9viE15hIRUepsXeWBxsi494gblUeJoWe2NxsC0-4DlmUuFlWuyNxcG2eI9nmEqFt2mxNxYH2-IpniBS4QN6HGyH_1uLfwc5bSU)
+
+**Key Elements:**
+1. `ChatStep` (AI operation handler)
+2. `PublisherManager` (Event multiplexer)
+3. Watermill (Message bus)
+4. Event Consumers (UI, Monitoring, etc.)
+
+## Implementation Deep Dive
+
+### 1. Event Publishing in AI Steps (`chat-step.go`)
+
+AI steps like `ChatStep` leverage the publisher system through three key phases:
+
+```go
+func (csf *ChatStep) Start(ctx context.Context, messages conversation.Conversation) (steps.StepResult[*conversation.Message], error) {
+    // Phase 1: Event initialization
+    metadata := chat.EventMetadata{
+        ID:       conversation.NewNodeID(),
+        ParentID: parentID,
+        LLMMessageMetadata: conversation.LLMMessageMetadata{
+            Engine: string(*csf.Settings.Chat.Engine),
+        },
+    }
+    
+    // Phase 2: Event publishing
+    csf.publisherManager.PublishBlind(chat.NewStartEvent(metadata, stepMetadata))
+    
+    // Phase 3: Streaming handling
+    for {
+        response, err := stream.Recv()
+        if err == io.EOF {
+            csf.publisherManager.PublishBlind(chat.NewFinalEvent(...))
+            break
+        }
+        csf.publisherManager.PublishBlind(chat.NewPartialCompletionEvent(...))
+    }
+}
+```
+
+**Key Features:**
+- Strong typing with `EventMetadata` and `StepMetadata`
+- Context-aware cancellation propagation
+- Automatic error handling and event sequencing
+
+### 2. PublisherManager Mechanics (`publish.go`)
+
+The `PublisherManager` acts as a smart router:
+
+```go
+// Registration example
+pm := events.NewPublisherManager()
+pm.RegisterPublisher("chat_events", watermillPublisher)
+
+// Publishing logic
+func (s *PublisherManager) Publish(payload interface{}) error {
+    s.mutex.Lock()
+    defer s.mutex.Unlock()
+    
+    // Serialization
+    b, _ := json.Marshal(payload)
+    
+    // Watermill message creation
+    msg := message.NewMessage(watermill.NewUUID(), b)
+    msg.Metadata.Set("sequence_number", fmt.Sprintf("%d", s.sequenceNumber))
+    
+    // Fan-out to all registered publishers
+    for topic, subs := range s.Publishers {
+        for _, sub := range subs {
+            sub.Publish(topic, msg) // Watermill interface
+        }
+    }
+    
+    s.sequenceNumber++
+    return nil
+}
+```
+
+**Critical Features:**
+- Automatic sequence numbering for event ordering
+- Thread-safe publisher registration
+- Blind publishing pattern (fire-and-forget with error logging)
+
+### 3. Watermill Integration
+
+Watermill serves as the messaging backbone through:
+
+1. **Standardized Interface**
+```go
+type Step interface {
+    AddPublishedTopic(publisher message.Publisher, topic string) error
+}
+```
+
+2. **Message Structure**
+```go
+msg := message.NewMessage(
+    watermill.NewUUID(),      // Unique message ID
+    serializedPayload,        // JSON-encoded event
+)
+msg.Metadata.Set("sequence_number", "123") // Ordered delivery
+```
+
+3. **Pluggable Transports**
+```yaml
+# Example configuration
+pubsub:
+  redis:
+    client: "default"
+    marshaler: "json"
+```
+
+**Supported Backends:**
+- Redis Streams
+- Google Cloud Pub/Sub
+- NATS
+- Kafka
+- In-memory (for testing)
+
+### 4. Event Type System (`events.go`)
+
+The event hierarchy enables complex state tracking:
+
+```go
+type Event interface {
+    Type() EventType
+    Metadata() EventMetadata
+    StepMetadata() *steps.StepMetadata
+}
+
+// Example concrete type
+type EventPartialCompletion struct {
+    EventImpl
+    Delta       string `json:"delta"`
+    Completion  string `json:"completion"`
+}
+```
+
+**Event Lifecycle:**
+1. `Start` → Initializes conversation
+2. `PartialCompletion` (0..n) → Streaming updates
+3. Terminal Event:
+   - `Final` → Successful completion
+   - `Error` → Operation failure
+   - `Interrupt` → User cancellation
+
+## Why This Architecture?
+
+### Benefits
+1. **Observability**
+   - Sequence numbers enable event replay
+   - Structured logging via zerolog integration
+   ```go
+   func (e EventPartialCompletion) MarshalZerologObject(ev *zerolog.Event) {
+       e.EventImpl.MarshalZerologObject(ev)
+       ev.Str("delta", e.Delta)
+          .Str("completion", e.Completion)
+   }
+   ```
+
+2. **Extensibility**
+   - Add new consumers without modifying steps
+   - Example: Add monitoring subscriber
+   ```go
+   pm.RegisterPublisher("chat_events", monitoringPublisher)
+   ```
+
+3. **Error Resilience**
+   - Blind publishing prevents event system failures from crashing steps
+   - Automatic context cancellation propagation
+
+4. **Multi-modal Support**
+   - Handle text and tool calls simultaneously
+   ```go
+   type EventToolCall struct {
+       EventImpl
+       ToolCall ToolCall `json:"tool_call"`
+   }
+   ```
+
+### Tradeoffs
+1. **Eventual Consistency**
+   - No strict ordering across topics
+   - Limited transactional guarantees
+
+2. **Performance Considerations**
+   - JSON serialization overhead
+   - Watermill middleware chain adds latency
+
+3. **Memory Management**
+   - Care required with channel buffer sizes
+   - Potential for goroutine leaks if not properly managed
+
+## Typical Usage Pattern
+
+**1. Step Initialization**
+```go
+chatStep := openai.NewStep(
+    settings,
+    openai.WithSubscriptionManager(pm),
+)
+```
+
+**2. Event Consumption**
+```go
+messages, _ := subscriber.Subscribe(ctx, "chat_events")
+for msg := range messages {
+    event, err := chat.NewEventFromJson(msg.Payload)
+    if err != nil {
+        msg.Nack()
+        continue
+    }
+    
+    switch e := event.(type) {
+    case *chat.EventPartialCompletion:
+        fmt.Printf("Delta: %s\n", e.Delta)
+    case *chat.EventFinal:
+        fmt.Printf("Final output: %s\n", e.Text)
+    }
+    
+    msg.Ack()
+}
+```
+
+**3. Monitoring Integration**
+```go
+pm.RegisterPublisher("chat_events", prometheusAdapter)
+pm.RegisterPublisher("chat_events", elasticsearchAdapter)
+```
+
+## Debugging Tips
+
+1. **Sequence Inspection**
+```bash
+watermill inspect --metadata sequence_number
+```
+
+2. **Event Replay**
+```go
+// Replay last 100 events
+subscriber.Subscribe(ctx, "chat_events", watermill.WithReplay(100))
+```
+
+3. **Context Tracing**
+```go
+msg.Metadata.Set("trace_id", traceID) // Propagate across services
+```
+
+This architecture enables Geppetto to handle complex AI workflows while maintaining observability and extensibility. The Watermill integration provides enterprise-grade messaging capabilities without locking into specific infrastructure choices.

--- a/ttmp/2025-03-29/08-sonnet-3.7-pubsub-web-ui-explanation.md
+++ b/ttmp/2025-03-29/08-sonnet-3.7-pubsub-web-ui-explanation.md
@@ -1,0 +1,315 @@
+# Web UI Server for Geppetto: Leveraging PubSub with Server-Sent Events
+
+This document explains how the web-ui server in Pinocchio leverages the Watermill PubSub architecture to provide a real-time chat interface using Server-Sent Events (SSE).
+
+## Architecture Overview
+
+The web-ui server combines several components:
+
+1. **Server**: Handles HTTP requests and SSE connections
+2. **ChatClient**: Represents a connected client and manages its conversation state
+3. **EventRouter**: Routes events from AI steps to connected clients
+4. **Templ Components**: Render HTML for the web interface
+
+The architecture follows an event-driven design where:
+- User messages trigger AI step execution
+- Events from steps are published to topic streams
+- Server-Sent Events push real-time updates to the browser
+
+## Server Component
+
+The `Server` struct is the central component that:
+- Manages HTTP routes
+- Maintains a registry of connected clients
+- Handles SSE connections
+- Processes user messages
+
+```go
+type Server struct {
+    router     *events.EventRouter
+    clients    map[string]*client.ChatClient
+    clientsMux sync.RWMutex
+    logger     zerolog.Logger
+}
+```
+
+### Client Management
+
+The server maintains a map of connected clients identified by unique IDs:
+
+```go
+func (s *Server) RegisterClient(client *client.ChatClient) {
+    s.clientsMux.Lock()
+    defer s.clientsMux.Unlock()
+    s.clients[client.ID] = client
+    s.logger.Info().Str("client_id", client.ID).Msg("Registered new client")
+}
+```
+
+When clients disconnect, they are properly unregistered:
+
+```go
+func (s *Server) UnregisterClient(clientID string) {
+    s.clientsMux.Lock()
+    defer s.clientsMux.Unlock()
+    if client, ok := s.clients[clientID]; ok {
+        close(client.MessageChan)
+        close(client.DisconnectCh)
+        delete(s.clients, clientID)
+        s.logger.Info().Str("client_id", clientID).Msg("Unregistered client")
+    }
+}
+```
+
+### HTTP Endpoints
+
+The server registers three main HTTP endpoints:
+
+1. **/** - Index page that displays the chat interface
+2. **/events** - SSE endpoint that streams events to clients
+3. **/chat** - Endpoint for submitting chat messages
+
+## SSE Integration with PubSub
+
+The key integration between the PubSub system and the web UI happens through the Server-Sent Events endpoint:
+
+```go
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+    // Set SSE headers
+    w.Header().Set("Content-Type", "text/event-stream")
+    w.Header().Set("Cache-Control", "no-cache")
+    w.Header().Set("Connection", "keep-alive")
+    w.Header().Set("Access-Control-Allow-Origin", "*")
+    
+    // Get client by ID
+    clientID := r.URL.Query().Get("client_id")
+    client_ := s.clients[clientID] // (simplified)
+    
+    // Stream events
+    for {
+        select {
+        case <-r.Context().Done():
+            // Client disconnected
+            return
+        case msg, ok := <-client_.MessageChan:
+            // Send message to client
+            fmt.Fprintf(w, "event: message\n")
+            for _, line := range strings.Split(msg, "\n") {
+                fmt.Fprintf(w, "data: %s\n", line)
+            }
+            fmt.Fprintf(w, "\n")
+            flusher.Flush()
+        case <-time.After(30 * time.Second):
+            // Heartbeat
+            fmt.Fprintf(w, "event: heartbeat\ndata: ping\n\n")
+            flusher.Flush()
+        }
+    }
+}
+```
+
+This endpoint creates a long-lived HTTP connection that:
+1. Receives messages from the client's message channel
+2. Formats them as SSE events
+3. Sends them to the browser in real-time
+
+## ChatClient: The Bridge Between PubSub and SSE
+
+The `ChatClient` is the critical component that bridges the PubSub system with the SSE stream:
+
+```go
+type ChatClient struct {
+    ID           string
+    MessageChan  chan string
+    DisconnectCh chan struct{}
+    router       *events.EventRouter
+    manager      conversation.Manager
+    step         chat.Step
+    stepResult   steps.StepResult[*conversation.Message]
+    mu           sync.RWMutex
+    logger       zerolog.Logger
+}
+```
+
+### Event Subscription
+
+When a new `ChatClient` is created, it subscribes to events on a dedicated topic:
+
+```go
+topic := fmt.Sprintf("chat-%s", id)
+if err := client.step.AddPublishedTopic(router.Publisher, topic); err != nil {
+    client.logger.Error().Err(err).Msg("Failed to setup event publishing")
+    return client
+}
+
+// Add handler for this client's events
+router.AddHandler(
+    topic,
+    topic,
+    func(msg *message.Message) error {
+        // Parse event from JSON
+        e, err := chat.NewEventFromJson(msg.Payload)
+        
+        // Convert event to HTML
+        html, err := client.EventToHTML(e)
+        
+        // Send HTML to message channel for SSE
+        client.MessageChan <- html
+        return nil
+    },
+)
+```
+
+This handler:
+1. Receives events published by the AI step
+2. Converts them to HTML using templ components
+3. Sends the HTML through the message channel to the SSE endpoint
+
+### Message Processing
+
+When a user sends a message, `SendUserMessage` is called:
+
+```go
+func (c *ChatClient) SendUserMessage(ctx context.Context, message string) error {
+    // Add user message to conversation
+    userMsg := conversation.NewChatMessage(conversation.RoleUser, message)
+    c.manager.AppendMessages(userMsg)
+    
+    // Cancel existing step if running
+    if c.stepResult != nil {
+        c.stepResult.Cancel()
+    }
+    
+    // Start chat step with conversation
+    result, err := c.step.Start(ctx, c.manager.GetConversation())
+    
+    // Process results in background
+    go func() {
+        for result := range result.GetChannel() {
+            // Process result (error handling, etc.)
+        }
+    }()
+    
+    return nil
+}
+```
+
+This function:
+1. Updates the conversation with the user message
+2. Starts an AI step with the entire conversation history
+3. Sets up a goroutine to monitor the step results
+
+## Event Processing Chain
+
+The complete event flow from user input to UI update is:
+
+1. User submits a message through the `/chat` endpoint
+2. Server processes the message and calls `SendUserMessage` on the client
+3. Client starts the AI step with the conversation
+4. Step processes the conversation and publishes events to the client's topic
+5. Client's event handler converts events to HTML
+6. HTML is sent through the message channel to the SSE endpoint
+7. Browser receives the SSE events and updates the UI in real-time
+
+## Conversation Model for Web
+
+For web display, the system converts the internal conversation model to a web-friendly format:
+
+```go
+func ConvertConversation(conv conversation.Conversation) (*WebConversation, error) {
+    webConv := &WebConversation{
+        Messages: make([]*WebMessage, 0, len(conv)),
+    }
+
+    for _, msg := range conv {
+        webMsg, err := ConvertMessage(msg)
+        if err != nil {
+            return nil, err
+        }
+        webConv.Messages = append(webConv.Messages, webMsg)
+    }
+
+    return webConv, nil
+}
+```
+
+This conversion handles different message types:
+- Chat messages (user and assistant)
+- Tool use messages
+- Tool result messages
+
+## UI Components with HTMX
+
+The UI is built with HTMX for interactivity:
+
+1. **EventContainer**: Sets up the SSE connection and displays streaming events
+   ```html
+   <div id="events" hx-ext="sse" sse-connect="/events?client_id=...">
+       <div class="assistant-response" sse-swap="message"></div>
+   </div>
+   ```
+
+2. **ChatInput**: Submits messages via AJAX
+   ```html
+   <form hx-post="/chat" hx-swap="outerHTML">
+       <input type="hidden" name="client_id" value="..."/>
+       <input type="text" name="message" class="form-control"/>
+       <button type="submit" class="btn btn-primary">Send</button>
+   </form>
+   ```
+
+3. **ConversationHistory**: Displays the conversation history
+   ```html
+   <div id="conversation-history" hx-swap-oob="#conversation-history">
+       <!-- Message components -->
+   </div>
+   ```
+
+## Event Conversion to HTML
+
+The `EventToHTML` method converts chat events to HTML:
+
+```go
+func (c *ChatClient) EventToHTML(e chat.Event) (string, error) {
+    var buf strings.Builder
+    
+    switch e_ := e.(type) {
+    case *chat.EventPartialCompletion:
+        // Render partial completion for streaming
+        components.AssistantMessage(time.Now(), e_.Completion).Render(context.Background(), &buf)
+    case *chat.EventFinal:
+        // Add message to conversation and render full history
+        c.manager.AppendMessages(conversation.NewChatMessage(conversation.RoleAssistant, e_.Text))
+        conv := c.manager.GetConversation()
+        webConv, err := web_conversation.ConvertConversation(conv)
+        components.ConversationHistory(webConv, true).Render(context.Background(), &buf)
+    case *chat.EventError:
+        // Render error
+        // ...
+    }
+    
+    return buf.String(), nil
+}
+```
+
+This method handles different event types:
+- Partial completions for streaming responses
+- Final messages that update the conversation history
+- Error messages
+
+## Conclusion
+
+The web-ui server demonstrates how the PubSub architecture in Geppetto can be leveraged to create responsive web interfaces:
+
+1. Steps publish events through the Watermill event router
+2. Chat clients subscribe to these events and convert them to HTML
+3. Server-Sent Events stream the HTML to the browser
+4. HTMX updates the UI in real-time without full page reloads
+
+This architecture enables:
+- Real-time streaming of AI responses
+- Tool call visualization
+- Stateful conversation management
+- Clean separation of concerns between AI processing and UI updates
+
+The event-driven design allows for scalability and flexibility, as new features can be added by introducing new event types and corresponding UI components. 

--- a/ttmp/2025-03-29/09-sonnet-event-router-investigation.md
+++ b/ttmp/2025-03-29/09-sonnet-event-router-investigation.md
@@ -1,0 +1,801 @@
+# EventRouter: In-Depth Investigation and Refactoring Suggestions
+
+This document explores the `EventRouter` component within Geppetto, examining how it integrates with Watermill, its handler management capabilities, and proposing refactoring suggestions to address some design issues.
+
+## 1. EventRouter Overview
+
+The `EventRouter` is a critical component in Geppetto's event-driven architecture that serves as a wrapper around the Watermill library's message routing capabilities:
+
+```go
+type EventRouter struct {
+    logger     watermill.LoggerAdapter
+    Publisher  message.Publisher
+    Subscriber message.Subscriber
+    router     *message.Router
+    verbose    bool
+}
+```
+
+### Core Responsibilities
+
+1. **Event Routing**: Connects publishers (event sources) with subscribers (event handlers)
+2. **Handler Management**: Registers functions to process events from specific topics
+3. **Lifecycle Management**: Controls the starting and stopping of the router
+
+### Initialization
+
+The `EventRouter` is created using a functional options pattern:
+
+```go
+func NewEventRouter(options ...EventRouterOption) (*EventRouter, error) {
+    ret := &EventRouter{
+        logger: watermill.NopLogger{},
+    }
+    
+    for _, o := range options {
+        o(ret)
+    }
+    
+    // Create a Go channel-based pub/sub by default
+    goPubSub := gochannel.NewGoChannel(gochannel.Config{
+        BlockPublishUntilSubscriberAck: true,
+    }, ret.logger)
+    ret.Publisher = goPubSub
+    ret.Subscriber = goPubSub
+    
+    // Create the Watermill router
+    router, err := message.NewRouter(message.RouterConfig{}, ret.logger)
+    if err != nil {
+        return nil, err
+    }
+    
+    ret.router = router
+    
+    return ret, nil
+}
+```
+
+This initialization:
+1. Creates a default in-memory pub/sub system using Watermill's `gochannel`
+2. Configures the underlying Watermill router
+3. Applies any provided options to customize behavior
+
+## 2. Understanding Watermill and Its Router
+
+Before diving deeper into `EventRouter`, it's important to understand how Watermill is designed, examining the actual implementation in `router.go`.
+
+### Watermill's Core Philosophy
+
+According to Watermill's documentation, it was designed with a simple goal:
+
+> "Watermill is a Go library for working efficiently with message streams. It is intended for building event driven applications, enabling event sourcing, RPC over messages, sagas and basically whatever else comes to your mind."
+
+Watermill's design philosophy focuses on:
+
+1. **Simplicity**: Providing a clean, consistent API across different message brokers
+2. **Composability**: Building higher-level abstractions from simple primitives
+3. **Flexibility**: Supporting various messaging patterns and use cases
+
+### Watermill's Architecture
+
+Watermill has a layered architecture:
+
+1. **Messages**: The core data structure (`message.Message`)
+2. **Publisher/Subscriber**: Low-level interfaces for sending and receiving messages
+3. **Router**: Connects publishers and subscribers with handlers
+4. **Middleware**: Enhances handlers with additional functionality
+5. **Higher-level components**: CQRS, Saga, etc.
+
+### The Router in Watermill
+
+Looking at the actual implementation in `router.go`, the Watermill Router is a sophisticated component with multiple capabilities:
+
+```go
+type Router struct {
+    config RouterConfig
+
+    middlewares     []middleware
+    middlewaresLock *sync.RWMutex
+
+    plugins []RouterPlugin
+
+    handlers     map[string]*handler
+    handlersLock *sync.RWMutex
+
+    handlersWg *sync.WaitGroup
+
+    runningHandlersWg     *sync.WaitGroup
+    runningHandlersWgLock *sync.Mutex
+
+    handlerAdded chan struct{}
+
+    closingInProgressCh chan struct{}
+    closedCh            chan struct{}
+    closed              bool
+    closedLock          sync.Mutex
+
+    logger watermill.LoggerAdapter
+
+    publisherDecorators  []PublisherDecorator
+    subscriberDecorators []SubscriberDecorator
+
+    isRunning bool
+    running   chan struct{}
+}
+```
+
+The Router offers these key features:
+
+1. **Concurrent Handler Execution**: Handlers are executed in parallel for multiple incoming messages
+2. **Middleware Support**: Both router-level and handler-level middleware can be added
+3. **Graceful Shutdown**: Router can be closed with proper cleanup of resources
+4. **Handler Management**: Handlers can be added, started and stopped individually 
+5. **Decorators**: Publishers and Subscribers can be wrapped with additional functionality
+6. **Recovery from Panics**: Handler execution is protected with panic recovery
+7. **Pluggable Design**: Plugins can be added to enhance router functionality
+
+## 3. Connection to Watermill's Router
+
+The `EventRouter` primarily serves as a simplified interface to Watermill's more complex `message.Router`. Key connections include:
+
+### Router Delegation
+
+Most of the `EventRouter` methods directly delegate to Watermill's router:
+
+```go
+func (e *EventRouter) Run(ctx context.Context) error {
+    return e.router.Run(ctx)
+}
+
+func (e *EventRouter) RunHandlers(ctx context.Context) error {
+    return e.router.RunHandlers(ctx)
+}
+
+func (e *EventRouter) Running() chan struct{} {
+    return e.router.Running()
+}
+```
+
+### Handler Registration
+
+The `AddHandler` method wraps Watermill's `AddNoPublisherHandler` to simplify the handler registration process:
+
+```go
+func (e *EventRouter) AddHandler(name string, topic string, f func(msg *message.Message) error) {
+    e.router.AddNoPublisherHandler(name, topic, e.Subscriber, f)
+}
+```
+
+This method simplifies the Watermill API by:
+1. Only requiring the handler name, topic, and function
+2. Automatically using the router's preconfigured subscriber
+3. Using a simpler function signature (no message publishing)
+
+### Simplification Choices
+
+The `EventRouter` makes specific simplifications to Watermill's full capabilities:
+
+1. **No Message Publishing from Handlers**: Uses `AddNoPublisherHandler` instead of Watermill's full `AddHandler` which would allow returning messages from handlers. In Watermill's implementation, handlers can return messages to be published:
+
+   ```go
+   // From watermill/message/router.go
+   type HandlerFunc func(msg *Message) ([]*Message, error)
+   ```
+
+2. **Single Pub/Sub Backend**: Uses a single publisher/subscriber pair compared to Watermill's flexibility to mix and match different implementations.
+
+3. **Limited Configuration Options**: Exposes only a subset of Watermill's configuration parameters. For example, Watermill's router supports configuration like `CloseTimeout` which is not exposed in `EventRouter`.
+
+4. **No Decorator Support**: Watermill Router supports decorating publishers and subscribers:
+
+   ```go
+   // From watermill/message/router.go
+   func (r *Router) AddPublisherDecorators(dec ...PublisherDecorator) {
+       r.publisherDecorators = append(r.publisherDecorators, dec...)
+   }
+   ```
+
+5. **No Plugin Support**: Watermill's plugin system is not exposed through `EventRouter`:
+
+   ```go
+   // From watermill/message/router.go
+   func (r *Router) AddPlugin(p ...RouterPlugin) {
+       r.plugins = append(r.plugins, p...)
+   }
+   ```
+
+### Missing Router Close Implementation
+
+An important observation is that `EventRouter.Close()` doesn't properly close the underlying Watermill router:
+
+```go
+func (e *EventRouter) Close() error {
+    err := e.Publisher.Close()
+    if err != nil {
+        log.Error().Err(err).Msg("Failed to close pubsub")
+        // not returning just yet
+    }
+
+    return nil
+}
+```
+
+This method only closes the publisher but not the router itself, which could lead to resource leaks. Looking at Watermill's implementation, the router's `Close()` method does much more:
+
+```go
+// From watermill/message/router.go
+func (r *Router) Close() error {
+    r.closedLock.Lock()
+    defer r.closedLock.Unlock()
+
+    r.handlersLock.Lock()
+    defer r.handlersLock.Unlock()
+
+    if r.closed {
+        return nil
+    }
+    r.closed = true
+
+    r.logger.Info("Closing router", nil)
+    defer r.logger.Info("Router closed", nil)
+
+    close(r.closingInProgressCh)
+    defer close(r.closedCh)
+
+    timeouted := r.waitForHandlers()
+    if timeouted {
+        return errors.New("router close timeout")
+    }
+
+    return nil
+}
+```
+
+This implementation properly waits for handlers to finish processing, respecting the configured timeout. A proper `EventRouter.Close()` should call `e.router.Close()`.
+
+## 4. Handler Management
+
+### Adding Handlers
+
+Handlers can be added using the `AddHandler` method:
+
+```go
+router.AddHandler("ui-stdout", "ui", func(msg *message.Message) error {
+    // Process the message
+    return nil
+})
+```
+
+Each handler:
+1. Must have a unique name across the router
+2. Subscribes to a specific topic
+3. Processes messages using a provided function
+
+When a handler is added in Watermill, it returns a `Handler` struct that can be used to control it:
+
+```go
+// From watermill/message/router.go
+func (r *Router) AddHandler(
+    handlerName string,
+    subscribeTopic string,
+    subscriber Subscriber,
+    publishTopic string,
+    publisher Publisher,
+    handlerFunc HandlerFunc,
+) *Handler {
+    // ...implementation...
+    
+    return &Handler{
+        router:  r,
+        handler: newHandler,
+    }
+}
+```
+
+However, `EventRouter.AddHandler` doesn't return this handler, limiting control options:
+
+```go
+// EventRouter.AddHandler doesn't return the handler
+func (e *EventRouter) AddHandler(name string, topic string, f func(msg *message.Message) error) {
+    e.router.AddNoPublisherHandler(name, topic, e.Subscriber, f)
+}
+```
+
+### Removing Handlers
+
+**Current Limitation**: The `EventRouter` does not provide a method to remove handlers once they're added.
+
+Watermill provides a way to stop individual handlers using the `Handler.Stop()` method:
+
+```go
+// From watermill/message/router.go
+// Stop stops the handler.
+// Stop is asynchronous.
+// You can check if handler was stopped with Stopped() function.
+func (h *Handler) Stop() {
+    if !h.handler.started {
+        panic("handler is not started")
+    }
+
+    h.handler.stopFn()
+}
+```
+
+Since `EventRouter.AddHandler` doesn't return the handler object, there's no way to access this functionality through the `EventRouter` API.
+
+### Handler Execution
+
+Looking at the Watermill implementation, each handler is executed in its own goroutine for each incoming message:
+
+```go
+// From watermill/message/router.go
+func (h *handler) run(ctx context.Context, middlewares []middleware) {
+    // ...
+
+    for msg := range h.messagesCh {
+        h.runningHandlersWgLock.Lock()
+        h.runningHandlersWg.Add(1)
+        h.runningHandlersWgLock.Unlock()
+
+        go h.handleMessage(msg, middlewareHandler)
+    }
+
+    // ...
+}
+```
+
+This concurrent execution model allows for high throughput processing of messages. The `EventRouter` preserves this behavior by delegating to Watermill's router.
+
+### Handler Context and Metadata
+
+Watermill's Router adds context values to messages processed by handlers:
+
+```go
+// From watermill/message/router.go
+func (h *handler) addHandlerContext(messages ...*Message) {
+    for i, msg := range messages {
+        ctx := msg.Context()
+
+        if h.name != "" {
+            ctx = context.WithValue(ctx, handlerNameKey, h.name)
+        }
+        if h.publisherName != "" {
+            ctx = context.WithValue(ctx, publisherNameKey, h.publisherName)
+        }
+        // ... more context values ...
+        
+        messages[i].SetContext(ctx)
+    }
+}
+```
+
+These context values can be useful for debugging and tracing, but are not directly accessible through the `EventRouter` API.
+
+## 5. Middleware Capabilities in Watermill
+
+One of the most powerful features of Watermill's Router is its support for middleware. Looking at the implementation, Watermill supports both router-level and handler-level middleware:
+
+```go
+// From watermill/message/router.go
+func (r *Router) AddMiddleware(m ...HandlerMiddleware) {
+    r.logger.Debug("Adding middleware", watermill.LogFields{"count": fmt.Sprintf("%d", len(m))})
+    r.addRouterLevelMiddleware(m...)
+}
+
+// From watermill/message/router.go
+func (h *Handler) AddMiddleware(m ...HandlerMiddleware) {
+    handler := h.handler
+    handler.logger.Debug("Adding middleware to handler", watermill.LogFields{
+        "count":       fmt.Sprintf("%d", len(m)),
+        "handlerName": handler.name,
+    })
+
+    h.router.addHandlerLevelMiddleware(handler.name, m...)
+}
+```
+
+Middleware in Watermill follows a decorator pattern:
+
+```go
+// From watermill/message/router.go
+type HandlerMiddleware func(h HandlerFunc) HandlerFunc
+```
+
+This allows for powerful composability of handler behavior. Middlewares are applied in order, with the first middleware wrapping the outermost layer:
+
+```go
+// From watermill/message/router.go
+middlewareHandler := h.handlerFunc
+// first added middlewares should be executed first (so should be at the top of call stack)
+for i := len(middlewares) - 1; i >= 0; i-- {
+    currentMiddleware := middlewares[i]
+    isValidHandlerLevelMiddleware := currentMiddleware.HandlerName == h.name
+    if currentMiddleware.IsRouterLevel || isValidHandlerLevelMiddleware {
+        middlewareHandler = currentMiddleware.Handler(middlewareHandler)
+    }
+}
+```
+
+The `EventRouter` doesn't expose this middleware capability at all, missing out on a key feature of Watermill.
+
+## 6. Real-World Usage in Geppetto
+
+### Web UI Server
+
+In the web UI server, the `EventRouter` connects AI processing steps with the web frontend:
+
+```go
+// Create and configure router
+router, err := events.NewEventRouter(events.WithVerbose(true))
+
+// Create server with router
+server := NewServer(router)
+
+// Each client registers its own topic and handler
+topic := fmt.Sprintf("chat-%s", clientID)
+router.AddHandler(topic, topic, func(msg *message.Message) error {
+    // Parse event and convert to HTML
+    e, err := chat.NewEventFromJson(msg.Payload)
+    html, err := client.EventToHTML(e)
+    client.MessageChan <- html
+    return nil
+})
+
+// Connect Step's events to the topic
+client.step.AddPublishedTopic(router.Publisher, topic)
+```
+
+This pattern enables:
+1. Unique topics per client/conversation
+2. Dynamic handler registration as clients connect
+3. Streaming events from AI steps to web UI
+
+### Tool UI
+
+The tool UI demonstrates how the `EventRouter` handles different event types:
+
+```go
+t.eventRouter.AddHandler("raw-events-stdout", "ui", t.eventRouter.DumpRawEvents)
+t.eventRouter.AddHandler("ui-stdout", "ui", func(msg *message.Message) error {
+    // Process different event types
+    e, _ := chat.NewEventFromJson(msg.Payload)
+    switch e_ := e.(type) {
+    case *chat.EventPartialCompletion:
+        // Handle streaming completion
+    case *chat.EventToolCall:
+        // Handle tool calls
+    // ...other event types
+    }
+    return nil
+})
+```
+
+## 7. Limitations of the Current Design
+
+After examining the actual Watermill router implementation, several limitations of the `EventRouter` become even more apparent:
+
+### 1. No Handler Removal
+
+As mentioned, handlers cannot be removed dynamically, which could lead to resource leaks in long-running applications. While Watermill supports stopping individual handlers via `Handler.Stop()`, `EventRouter` doesn't expose this functionality.
+
+### 2. Name Confusion
+
+The name `EventRouter` doesn't clearly reflect its full responsibility as both a router and a pub/sub factory. Watermill itself makes a clearer distinction between the router and the pub/sub components.
+
+### 3. Limited Configuration
+
+The `EventRouter` enforces a 1:1 relationship between Publisher and Subscriber, which may not fit all use cases. Watermill's router is designed to work with multiple different pub/sub implementations simultaneously, which is not exposed in `EventRouter`.
+
+### 4. Mixing of Concerns
+
+The `EventRouter` combines:
+- Pub/Sub creation and management
+- Message routing
+- Event handling
+- Serialization/deserialization (via the `DumpRawEvents` method)
+
+This contrasts with Watermill's cleaner separation of concerns.
+
+### 5. Inconsistent Relationship with PublisherManager
+
+A separate `PublisherManager` exists which overlaps with some `EventRouter` responsibilities, creating confusion:
+
+```go
+// From events/publish.go
+// NOTE(manuel, 2024-03-24) This might be worth moving / integrating into the event router
+// It sounds also logical that this is the thing that would add sequence numbers to events?
+type PublisherManager struct {
+    Publishers     map[string][]message.Publisher
+    sequenceNumber uint64
+    mutex          sync.Mutex
+}
+```
+
+### 6. Missing Middleware Support
+
+Watermill has powerful middleware capabilities that allow for:
+- Correlation ID tracking
+- Error handling/retries
+- Metrics/logging
+- Rate limiting
+- Poison queue handling
+
+`EventRouter` doesn't expose this functionality, limiting its extensibility.
+
+### 7. No Decorator Support
+
+Watermill's publisher and subscriber decorator capabilities are not exposed:
+
+```go
+// From watermill/message/router.go
+func (r *Router) AddPublisherDecorators(dec ...PublisherDecorator) {
+    r.publisherDecorators = append(r.publisherDecorators, dec...)
+}
+
+func (r *Router) AddSubscriberDecorators(dec ...SubscriberDecorator) {
+    r.subscriberDecorators = append(r.subscriberDecorators, dec...)
+}
+```
+
+These decorators could be used to add functionality like metrics, logging, or retries to all publishers and subscribers.
+
+### 8. No Plugin Support
+
+Watermill's plugin system is not exposed through `EventRouter`:
+
+```go
+// From watermill/message/router.go
+func (r *Router) AddPlugin(p ...RouterPlugin) {
+    r.plugins = append(r.plugins, p...)
+}
+```
+
+Plugins can provide additional functionality like signal handling or health checks.
+
+### 9. Incomplete Close Method
+
+As noted earlier, `EventRouter.Close()` doesn't close the underlying Watermill router, potentially leading to resource leaks.
+
+## 8. Refactoring Suggestions
+
+Based on the analysis of Watermill's actual implementation, here are refined refactoring suggestions:
+
+### 1. Separate Pub/Sub Creation from Routing
+
+```go
+// Proposed new types
+type EventBus interface {
+    Publisher() message.Publisher
+    Subscriber() message.Subscriber
+    Close() error
+}
+
+type EventDispatcher interface {
+    AddHandler(name, topic string, handler HandlerFunc) *Handler
+    RunHandlers(ctx context.Context) error
+    Run(ctx context.Context) error
+    Close() error
+    
+    // Expose additional Watermill functionality
+    AddMiddleware(middleware HandlerMiddleware)
+    AddPlugin(plugin RouterPlugin)
+    AddPublisherDecorators(decorators ...PublisherDecorator)
+    AddSubscriberDecorators(decorators ...SubscriberDecorator)
+}
+```
+
+### 2. Return Handlers and Add Handler Removal Support
+
+Leverage Watermill's existing handler control mechanisms by directly returning the handler object:
+
+```go
+// Return the handler from AddHandler
+func (d *EventDispatcher) AddHandler(name, topic string, handlerFunc HandlerFunc) *Handler {
+    return d.router.AddNoPublisherHandler(name, topic, d.subscriber, adaptHandlerFunc(handlerFunc))
+}
+
+// Example usage
+handler := dispatcher.AddHandler("my-handler", "topic", myHandlerFunc)
+
+// Later, stop the handler when needed
+handler.Stop()
+
+// You can also check if handler has stopped
+<-handler.Stopped()
+```
+
+### 3. Rename Components for Clarity
+
+Proposed new naming:
+- `EventRouter` → `EventDispatcher` (for routing functionality)
+- `PublisherManager` → `TopicPublisher` (for publishing to multiple subscribers)
+- Add `EventBus` (for pub/sub creation and management)
+
+### 4. Expose Full Router Configuration
+
+Allow configuration of all Watermill router options:
+
+```go
+type EventDispatcherConfig struct {
+    // Forward Watermill's router config
+    RouterConfig message.RouterConfig
+    
+    // Additional Geppetto-specific config
+    SequenceNumbering bool
+    VerboseLogging    bool
+}
+
+func NewEventDispatcher(bus EventBus, config EventDispatcherConfig) (*EventDispatcher, error) {
+    router, err := message.NewRouter(config.RouterConfig, bus.Logger())
+    if err != nil {
+        return nil, err
+    }
+    
+    // ...
+}
+```
+
+### 5. Integrate PublisherManager
+
+Merge the functionality of `PublisherManager` into the core event system, preserving sequence numbering:
+
+```go
+type TopicPublisher struct {
+    publisher message.Publisher
+    seqNum    atomic.Uint64
+    mu        sync.Mutex
+}
+
+func (p *TopicPublisher) PublishEvent(topic string, event Event) error {
+    // Add sequence number
+    seqNum := p.seqNum.Add(1)
+    event.SetSequenceNumber(seqNum)
+    
+    // Serialize event
+    payload, err := json.Marshal(event)
+    if err != nil {
+        return err
+    }
+    
+    // Create Watermill message
+    msg := message.NewMessage(watermill.NewUUID(), payload)
+    msg.Metadata.Set("sequence_number", fmt.Sprintf("%d", seqNum))
+    
+    // Publish through Watermill
+    return p.publisher.Publish(topic, msg)
+}
+```
+
+### 6. Add Full Middleware Support
+
+Expose Watermill's middleware capabilities:
+
+```go
+// Add global middleware
+func (d *EventDispatcher) AddMiddleware(m HandlerMiddleware) {
+    d.router.AddMiddleware(m)
+}
+
+// Example usage with Watermill's built-in middleware
+dispatcher.AddMiddleware(middleware.Recoverer)
+dispatcher.AddMiddleware(middleware.Retry{
+    MaxRetries:      3,
+    InitialInterval: time.Second,
+    MaxInterval:     time.Minute,
+}.Middleware)
+
+// Example handler-specific middleware
+handler := dispatcher.AddHandler("my-handler", "topic", myHandlerFunc)
+handler.AddMiddleware(middleware.Throttle(10).Middleware)
+```
+
+### 7. Add Support for Publisher Decorators and Plugins
+
+Expose Watermill's plugin and decorator systems:
+
+```go
+// Add plugin
+func (d *EventDispatcher) AddPlugin(p RouterPlugin) {
+    d.router.AddPlugin(p)
+}
+
+// Add publisher decorator
+func (d *EventDispatcher) AddPublisherDecorators(decorators ...PublisherDecorator) {
+    d.router.AddPublisherDecorators(decorators...)
+}
+
+// Add subscriber decorator
+func (d *EventDispatcher) AddSubscriberDecorators(decorators ...SubscriberDecorator) {
+    d.router.AddSubscriberDecorators(decorators...)
+}
+
+// Example usage
+dispatcher.AddPlugin(plugins.SignalsHandler)
+dispatcher.AddPublisherDecorators(metrics.PublisherDecorator("my_app"))
+```
+
+### 8. Fix the Close Method
+
+Ensure proper resource cleanup by delegating to Watermill's router:
+
+```go
+func (d *EventDispatcher) Close() error {
+    // First close the router
+    if err := d.router.Close(); err != nil {
+        return fmt.Errorf("failed to close router: %w", err)
+    }
+    
+    return nil
+}
+```
+
+### 9. Support for Multiple Publisher Handlers
+
+Support handlers that can publish messages, by using Watermill's full `AddHandler` method:
+
+```go
+func (d *EventDispatcher) AddPublishingHandler(
+    name string,
+    subscribeTopic string,
+    publishTopic string,
+    handler func(msg *message.Message) ([]*message.Message, error),
+) *Handler {
+    return d.router.AddHandler(
+        name,
+        subscribeTopic,
+        d.subscriber,
+        publishTopic,
+        d.publisher,
+        handler,
+    )
+}
+
+// Example usage
+dispatcher.AddPublishingHandler(
+    "transform-handler",
+    "input-topic",
+    "output-topic",
+    func(msg *message.Message) ([]*message.Message, error) {
+        // Transform message
+        transformed := message.NewMessage(
+            watermill.NewUUID(),
+            []byte("Transformed: " + string(msg.Payload)),
+        )
+        return []*message.Message{transformed}, nil
+    },
+)
+```
+
+## 9. Implementation Plan
+
+A phased approach to implementation:
+
+1. **Phase 1**: Create new interfaces without changing existing code
+   - Define `EventBus`, `EventDispatcher`, etc.
+   - Implement new components alongside existing ones
+
+2. **Phase 2**: Create a compatibility layer
+   - Implement new components that work with existing code
+   - Provide adapters for smooth migration
+
+3. **Phase 3**: Gradually migrate client code to new interfaces
+   - Update services one by one
+   - Test and validate each migration step
+
+4. **Phase 4**: Deprecate old interfaces
+   - Mark old components as deprecated
+   - Provide migration guides
+
+5. **Phase 5**: Remove deprecated code
+   - Remove old components after sufficient migration time
+   - Finalize new API
+
+This approach ensures backward compatibility while improving the design.
+
+## Conclusion
+
+The `EventRouter` provides essential functionality for Geppetto's event-driven architecture but has several design limitations compared to the full capabilities of Watermill's Router. By refactoring it into more specialized components with clearer responsibilities, we can improve maintainability, flexibility, and usability.
+
+The proposed changes would better align with the single responsibility principle and provide a more intuitive API for event handling while maintaining compatibility with Watermill's robust messaging infrastructure. By properly exposing Watermill's capabilities like middleware, decorators, and plugins while adding Geppetto-specific requirements like sequence numbering, we can create a more powerful and flexible event system.
+
+A well-designed event system will make it easier to add new features and debug issues in Geppetto's event-driven architecture. 

--- a/ttmp/2025-03-29/10-sonnet-refactor-publisher-manager-analysis.md
+++ b/ttmp/2025-03-29/10-sonnet-refactor-publisher-manager-analysis.md
@@ -1,0 +1,261 @@
+# PublisherManager: Analysis and Integration with EventRouter
+
+## 1. Purpose and Responsibility
+
+The `PublisherManager` is a component in Geppetto's event system that serves as a message distribution hub. Its primary responsibilities are:
+
+1. **Topic-based Message Distribution**: It routes messages to multiple publishers based on topics
+2. **Sequence Numbering**: It maintains a global sequence number for all outgoing messages
+3. **Payload Serialization**: It handles serializing event payloads to JSON format
+4. **Error Handling**: It provides blind publishing that ignores errors
+
+```go
+type PublisherManager struct {
+    Publishers     map[string][]message.Publisher
+    sequenceNumber uint64
+    mutex          sync.Mutex
+}
+```
+
+The core purpose of `PublisherManager` is to allow a single event source to broadcast events to multiple destinations registered for specific topics, while maintaining message ordering through sequence numbers.
+
+## 2. Current Usage Pattern
+
+### Who Uses PublisherManager?
+
+The primary consumers of `PublisherManager` are AI step implementations:
+
+- **OpenAI Steps**: `openai.ChatStep`, `openai.ExecuteToolStep`, `openai.ChatWithToolsStep`
+- **Claude Steps**: `claude.ChatStep`, `claude.MessagesStep`
+- **Other AI Steps**: `chat.EchoStep`, `chat.CachingStep`, `chat.MemoryCachingStep`, `ollama.ChatStep`
+
+### Usage Pattern
+
+The typical usage pattern is:
+
+1. **Initialization**: Each step creates its own `PublisherManager` during construction
+   ```go
+   publisherManager: events.NewPublisherManager(),
+   ```
+
+2. **Registration**: The step implements `AddPublishedTopic` by delegating to its manager
+   ```go
+   func (csf *ChatStep) AddPublishedTopic(publisher message.Publisher, topic string) error {
+       csf.publisherManager.RegisterPublisher(topic, publisher)
+       return nil
+   }
+   ```
+
+3. **Publishing**: During step execution, the step publishes events through the manager
+   ```go
+   csf.publisherManager.PublishBlind(chat.NewStartEvent(metadata, stepMetadata))
+   // ...
+   csf.publisherManager.PublishBlind(chat.NewPartialCompletionEvent(metadata, stepMetadata, delta, message))
+   // ...
+   csf.publisherManager.PublishBlind(chat.NewFinalEvent(metadata, stepMetadata, message))
+   ```
+
+### Key Behaviors
+
+1. **Multi-topic Publishing**: When `Publish` is called, the manager distributes the message to all publishers across all topics
+   ```go
+   for topic, subs := range s.Publishers {
+       for _, sub := range subs {
+           err = sub.Publish(topic, msg)
+           // error handling...
+       }
+   }
+   ```
+
+2. **Sequence Numbering**: Each message is assigned a monotonically increasing sequence number
+   ```go
+   msg.Metadata.Set("sequence_number", fmt.Sprintf("%d", s.sequenceNumber))
+   s.sequenceNumber++
+   ```
+
+3. **Payload Serialization**: Converts arbitrary objects to JSON
+   ```go
+   b, err := json.Marshal(payload)
+   if err != nil {
+       return err
+   }
+   ```
+
+## 3. Relationship with EventRouter
+
+The relationship between `PublisherManager` and `EventRouter` is currently inconsistent:
+
+1. **Overlapping Responsibilities**: Both manage message publishers
+2. **Different Abstractions**: 
+   - `EventRouter` wraps Watermill's router with pub/sub capabilities
+   - `PublisherManager` is purely about message distribution
+
+3. **Integration Point**: Steps typically connect to an `EventRouter` through their `PublisherManager`:
+   ```go
+   // In web UI server initialization
+   router, err := events.NewEventRouter()
+   
+   // When creating a client
+   client.step.AddPublishedTopic(router.Publisher, topic)
+   ```
+
+4. **Missing Features**: `PublisherManager` implements sequence numbering that `EventRouter` doesn't provide, while `EventRouter` provides routing capabilities missing from `PublisherManager`
+
+## 4. Design Issues with Current Approach
+
+1. **Sequence Number Isolation**: Each `PublisherManager` has its own sequence counter, making global ordering impossible
+2. **Redundant Publishers**: The same publisher may be registered with multiple managers
+3. **Inefficient Distribution**: Messages are published to all topics regardless of content
+4. **Inconsistent Error Handling**: Some components use `Publish` (returns errors), others use `PublishBlind` (ignores errors)
+5. **Non-integrated Components**: `EventRouter` and `PublisherManager` should be part of a cohesive system
+6. **Missing Router Close**: As noted in the investigation document, `EventRouter.Close()` doesn't properly close the router
+
+## 5. Integration Strategies
+
+Several approaches could integrate `PublisherManager` with `EventRouter`:
+
+### Option 1: Embed PublisherManager in EventRouter
+
+```go
+type EventRouter struct {
+    logger      watermill.LoggerAdapter
+    router      *message.Router
+    publisher   message.Publisher
+    subscriber  message.Subscriber
+    topicManager *PublisherManager
+    verbose     bool
+}
+```
+
+This would allow `EventRouter` to delegate topic-based publishing to `PublisherManager` while maintaining the routing capabilities.
+
+### Option 2: Replace PublisherManager with Enhanced EventRouter
+
+Enhance `EventRouter` to include sequence numbering and topic-based distribution:
+
+```go
+func (e *EventRouter) RegisterTopicPublisher(topic string, publisher message.Publisher) {
+    // Add to internal map similar to PublisherManager
+}
+
+func (e *EventRouter) Publish(topic string, payload interface{}) error {
+    // Serialize, add sequence number, and publish
+}
+```
+
+### Option 3: Create a New TopicPublisher Component (Recommended)
+
+Following the suggestions in the investigation document, create a new `TopicPublisher` component:
+
+```go
+type TopicPublisher struct {
+    publisher    message.Publisher
+    seqNum       atomic.Uint64
+    mu           sync.Mutex
+    eventRouter  *EventRouter
+}
+
+func (p *TopicPublisher) PublishEvent(topic string, event Event) error {
+    // Add sequence number, serialize, and publish
+}
+```
+
+This could be a middleware or decorator on top of Watermill's publisher.
+
+## 6. Recommended Refactoring Plan
+
+Based on the analysis, I recommend the following refactoring approach:
+
+### 1. Define a Clear Event System Architecture
+
+Create a layered architecture with clear responsibilities:
+
+- **EventBus**: Low-level message transport (Watermill's pub/sub)
+- **EventDispatcher**: Message routing and middleware (Watermill's router)
+- **TopicPublisher**: Topic-based distribution and sequence numbering (replacing `PublisherManager`)
+
+### 2. Implement TopicPublisher
+
+Refactor `PublisherManager` into a new `TopicPublisher` that:
+
+1. Uses a single Watermill publisher (from `EventBus`)
+2. Maintains global sequence numbering
+3. Provides the same API as `PublisherManager` for backward compatibility
+4. Is integrated with `EventDispatcher` (renamed from `EventRouter`)
+
+```go
+type TopicPublisher struct {
+    publisher     message.Publisher
+    sequenceNum   atomic.Uint64
+    topicHandlers map[string][]TopicHandler
+    mu            sync.RWMutex
+}
+
+func NewTopicPublisher(publisher message.Publisher) *TopicPublisher {
+    return &TopicPublisher{
+        publisher:     publisher,
+        topicHandlers: make(map[string][]TopicHandler),
+    }
+}
+
+func (tp *TopicPublisher) RegisterTopic(topic string, handler TopicHandler) {
+    tp.mu.Lock()
+    defer tp.mu.Unlock()
+    tp.topicHandlers[topic] = append(tp.topicHandlers[topic], handler)
+}
+
+func (tp *TopicPublisher) Publish(payload interface{}) error {
+    // Similar to current PublisherManager.Publish
+}
+```
+
+### 3. Enhance EventRouter (Renamed to EventDispatcher)
+
+Refactor `EventRouter` to:
+
+1. Properly close its router
+2. Expose Watermill's middleware capabilities
+3. Return handlers from `AddHandler` for better control
+4. Integrate with `TopicPublisher`
+
+```go
+type EventDispatcher struct {
+    router         *message.Router
+    publisher      message.Publisher
+    subscriber     message.Subscriber
+    topicPublisher *TopicPublisher
+    logger         watermill.LoggerAdapter
+}
+
+func (ed *EventDispatcher) Close() error {
+    // Close router and publishers properly
+}
+
+func (ed *EventDispatcher) AddHandler(name, topic string, handler HandlerFunc) *Handler {
+    // Return the handler for better control
+}
+```
+
+### 4. Provide Backward Compatibility
+
+To maintain backward compatibility:
+
+1. Keep the current `PublisherManager` API for existing code
+2. Add an adapter that routes `PublisherManager` calls to `TopicPublisher`
+3. Gradually migrate step implementations to use the new API
+
+## 7. Implementation Strategy
+
+The recommended implementation strategy is:
+
+1. **Phase 1**: Create new `TopicPublisher` component without changing existing code
+2. **Phase 2**: Enhance `EventRouter` to work with `TopicPublisher`
+3. **Phase 3**: Add backward compatibility layer for `PublisherManager`
+4. **Phase 4**: Update one step implementation as a proof of concept
+5. **Phase 5**: Gradually migrate remaining step implementations
+
+## Conclusion
+
+The current design with separate `PublisherManager` and `EventRouter` components has led to inconsistencies and limitations in Geppetto's event system. By refactoring into a more integrated architecture with clear component responsibilities, we can address these issues while preserving the existing functionality and sequence numbering capabilities.
+
+The recommended approach is to create a new `TopicPublisher` component to replace `PublisherManager`, enhance `EventRouter` (renamed to `EventDispatcher`) to better leverage Watermill's capabilities, and provide backward compatibility for existing code. This will result in a more maintainable, flexible, and cohesive event system for Geppetto. 

--- a/ttmp/2025-03-30/01-refactor-events-for-web-ui.md
+++ b/ttmp/2025-03-30/01-refactor-events-for-web-ui.md
@@ -18,9 +18,15 @@ Here's how we could introduce it to @client.go:
        err = c.registerChatHandler(ctx)
       RunHandlers
    }
-  - registerChatHandler shoudl be able to return an error, so that Start also handles errors
+  - [x] registerChatHandler shoudl be able to return an error, so that Start also handles errors
 
-- move the callback function in registerHandler out to something reusable
+- [x] move the callback function in registerHandler out to something reusable
 
-- move all that chatEventHandler and callback and registering to the router entirely to @event-router.go so that all we do is  call
+- [x] move all that chatEventHandler and callback and registering to the router entirely to @event-router.go so that all we do is  call
 eventRouter.RegisterChatEventHandler(chatClient)
+
+## Next steps
+
+- refactor pinocchio and other experiments to use the new the UI callback handler
+- make a simple we bapplication that is not chat to showcase how to spin up a step and use its inference
+- add the possibility to dispatch tool call events

--- a/ttmp/2025-03-30/01-refactor-events-for-web-ui.md
+++ b/ttmp/2025-03-30/01-refactor-events-for-web-ui.md
@@ -1,0 +1,26 @@
+What I want to do as part of this refactor:
+
+- rename publishermanager as EventBroadcaster. It is actually of no relevance to the user of geppetto, it's internal to steps
+
+The goal is to refactor handling streaming events from the chat step in a more typed fashion. 
+
+Here's how we could introduce it to @client.go:
+
+- [x] helper function to register a chateventhandler/callback instead of having to register a topic and a watermill router by myself
+  - [x] helper function (later maybe a method on EventRouter)
+     - [x] RegisterChatHandler(step, id, chatEventHandler)
+       - [x] step.AddPublishedTopic(chat-%s, id)
+       - [x] router AddHandler(chat-%s, id, func message() { switch message type and then: dispatchToHandler })
+     - [x] chatEventHandler: an interface that handles  the chat messages HandleXMessage etc...
+       - [x] concrete implementation for chatClient in our case
+
+- RegisterChatHandler could maybe be called func (c *ChatClient) Start(ctx)  err { 
+       err = c.registerChatHandler(ctx)
+      RunHandlers
+   }
+  - registerChatHandler shoudl be able to return an error, so that Start also handles errors
+
+- move the callback function in registerHandler out to something reusable
+
+- move all that chatEventHandler and callback and registering to the router entirely to @event-router.go so that all we do is  call
+eventRouter.RegisterChatEventHandler(chatClient)


### PR DESCRIPTION
This PR refactors the streaming of UI events to make it easier to register 
typed chat UI handlers.

Key changes:

* Move chat events to the `events` package for better organization
* Add `ChatEventHandler` interface with typed methods for different event types
* Implement `RegisterChatEventHandler` method on `EventRouter` to streamline
  registration of chat handlers
* Fix `EventRouter.Close()` to properly close the underlying Watermill router

This refactoring makes it much simpler to implement UI components that consume
chat events by providing a structured, type-safe interface rather than having
to manually parse message payloads and dispatch to the right handlers.

The changes are backward compatible as all existing functionality remains
available, but new code can take advantage of the simplified registration
process.