### PR TITLE
Improve chat message dispatching to better visualize tools

### DIFF
--- a/pkg/conversation/message.go
+++ b/pkg/conversation/message.go
@@ -70,7 +70,7 @@ func (c *ChatMessageContent) View() string {
 	if strings.HasPrefix(c.Text, "```") {
 		c.Text = "\n" + c.Text
 	}
-	return fmt.Sprintf("[%s]: %s", c.Role, strings.TrimRight(c.Text, "\n"))
+	return fmt.Sprintf("(%s): %s", c.Role, strings.TrimRight(c.Text, "\n"))
 }
 
 var _ MessageContent = (*ChatMessageContent)(nil)

--- a/pkg/events/chat-events.go
+++ b/pkg/events/chat-events.go
@@ -141,10 +141,10 @@ var _ Event = &EventFinal{}
 
 type EventError struct {
 	EventImpl
-	Error_ string `json:"error"`
+	ErrorString string `json:"error_string"`
 }
 
-func NewErrorEvent(metadata EventMetadata, stepMetadata *steps.StepMetadata, err string) *EventError {
+func NewErrorEvent(metadata EventMetadata, stepMetadata *steps.StepMetadata, err error) *EventError {
 	return &EventError{
 		EventImpl: EventImpl{
 			Type_:     EventTypeError,
@@ -152,7 +152,7 @@ func NewErrorEvent(metadata EventMetadata, stepMetadata *steps.StepMetadata, err
 			Metadata_: metadata,
 			payload:   nil,
 		},
-		Error_: err,
+		ErrorString: err.Error(),
 	}
 }
 
@@ -394,7 +394,7 @@ func (e EventFinal) MarshalZerologObject(ev *zerolog.Event) {
 
 func (e EventError) MarshalZerologObject(ev *zerolog.Event) {
 	e.EventImpl.MarshalZerologObject(ev)
-	ev.Str("error", e.Error_)
+	ev.Str("error", e.ErrorString)
 }
 
 func (e EventText) MarshalZerologObject(ev *zerolog.Event) {

--- a/pkg/helpers/log_helpers.go
+++ b/pkg/helpers/log_helpers.go
@@ -1,0 +1,87 @@
+package helpers
+
+import (
+	"context"
+
+	"github.com/ThreeDotsLabs/watermill"
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/lithammer/shortuuid/v3"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+// Most of this code inspired if not copied from https://github.com/ThreeDotsLabs/go-event-driven
+
+type WatermillZerologAdapter struct {
+	logger zerolog.Logger
+}
+
+func (w *WatermillZerologAdapter) Error(msg string, err error, fields watermill.LogFields) {
+	w.logger.Error().Fields(fields).Err(err).Caller(1).Msg(msg)
+}
+
+func (w *WatermillZerologAdapter) Info(msg string, fields watermill.LogFields) {
+	w.logger.Info().Fields(fields).Caller(1).Msg(msg)
+}
+
+func (w *WatermillZerologAdapter) Debug(msg string, fields watermill.LogFields) {
+	e := w.logger.Debug().Fields(fields)
+	e = e.Caller(1)
+	e.Msg(msg)
+}
+
+func (w *WatermillZerologAdapter) Trace(msg string, fields watermill.LogFields) {
+	w.logger.Trace().Fields(fields).Caller(1).Msg(msg)
+}
+
+func (w *WatermillZerologAdapter) With(fields watermill.LogFields) watermill.LoggerAdapter {
+	l := w.logger.With().Fields(fields).Logger()
+	return &WatermillZerologAdapter{logger: l}
+}
+
+func NewWatermill(logger zerolog.Logger) *WatermillZerologAdapter {
+	return &WatermillZerologAdapter{logger: logger}
+}
+
+var _ watermill.LoggerAdapter = &WatermillZerologAdapter{}
+
+const correlationIDMessageMetadataKey = "correlation_id"
+
+type CorrelationPublisherDecorator struct {
+	message.Publisher
+}
+
+type correlationIDKeyType string
+
+const correlationIDKey correlationIDKeyType = "correlation_id"
+
+func ContextWithCorrelationID(ctx context.Context, correlationID string) context.Context {
+	return context.WithValue(ctx, correlationIDKey, correlationID)
+}
+
+func CorrelationIDFromContext(ctx context.Context) string {
+	v, ok := ctx.Value(correlationIDKey).(string)
+	if ok {
+		return v
+	}
+
+	log.Ctx(ctx).Warn().Msg("correlation ID not found in context")
+
+	// add "gen_" prefix to distinguish generated correlation IDs from correlation IDs passed by the client
+	// it's useful to detect if correlation ID was not passed properly
+	return "gen_" + shortuuid.New()
+}
+
+func (c CorrelationPublisherDecorator) Publish(topic string, messages ...*message.Message) error {
+	for i := range messages {
+		// if correlation_id is already set, let's not override
+		if messages[i].Metadata.Get(correlationIDMessageMetadataKey) != "" {
+			continue
+		}
+
+		// correlation_id as const
+		messages[i].Metadata.Set(correlationIDMessageMetadataKey, CorrelationIDFromContext(messages[i].Context()))
+	}
+
+	return c.Publisher.Publish(topic, messages...)
+}

--- a/pkg/steps/ai/chat/steps/echo.go
+++ b/pkg/steps/ai/chat/steps/echo.go
@@ -82,6 +82,8 @@ func (e *EchoStep) Start(ctx context.Context, input conversation.Conversation) (
 			return errors.New("invalid input")
 		}
 
+		e.subscriptionManager.PublishBlind(events.NewStartEvent(metadata, stepMetadata))
+
 		for idx, c_ := range msgContent.Text {
 			select {
 			case <-ctx.Done():

--- a/pkg/steps/ai/claude/chat-step.go
+++ b/pkg/steps/ai/claude/chat-step.go
@@ -215,7 +215,7 @@ func (csf *ChatStep) Start(
 					// TODO(manuel, 2024-07-04) Probably not necessary, the completionMerger probably took care of it
 					response := completionMerger.Response()
 					if response == nil {
-						csf.subscriptionManager.PublishBlind(events2.NewErrorEvent(metadata, stepMetadata, "no response"))
+						csf.subscriptionManager.PublishBlind(events2.NewErrorEvent(metadata, stepMetadata, errors.New("no response")))
 						c <- helpers2.NewErrorResult[*conversation.Message](errors.New("no response"))
 						return
 					}
@@ -241,7 +241,7 @@ func (csf *ChatStep) Start(
 
 				events_, err := completionMerger.Add(event)
 				if err != nil {
-					csf.subscriptionManager.PublishBlind(events2.NewErrorEvent(metadata, stepMetadata, err.Error()))
+					csf.subscriptionManager.PublishBlind(events2.NewErrorEvent(metadata, stepMetadata, err))
 					c <- helpers2.NewErrorResult[*conversation.Message](err)
 					return
 				}

--- a/pkg/steps/ai/claude/content-block-merger.go
+++ b/pkg/steps/ai/claude/content-block-merger.go
@@ -256,7 +256,7 @@ func (cbm *ContentBlockMerger) Add(event api.StreamingEvent) ([]events.Event, er
 			return nil, errors.New("ErrorType event must have an error")
 		}
 		cbm.error = event.Error
-		return []events.Event{events.NewErrorEvent(cbm.metadata, cbm.stepMetadata, event.Error.Message)}, nil
+		return []events.Event{events.NewErrorEvent(cbm.metadata, cbm.stepMetadata, errors.New(event.Error.Message))}, nil
 
 	default:
 		return nil, errors.Errorf("Unknown event type: %s", event.Type)

--- a/pkg/steps/ai/claude/messages-step.go
+++ b/pkg/steps/ai/claude/messages-step.go
@@ -204,7 +204,7 @@ func (csf *MessagesStep) Start(
 					decoded := map[string]interface{}{}
 					err = json.Unmarshal([]byte(event.Data), &decoded)
 					if err != nil {
-						csf.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, ret.GetMetadata(), err.Error()))
+						csf.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, ret.GetMetadata(), err))
 						c <- helpers.NewErrorResult[*conversation.Message](err)
 						return
 					}
@@ -225,7 +225,7 @@ func (csf *MessagesStep) Start(
 		resp, err := client.Complete(&req)
 
 		if err != nil {
-			err = csf.subscriptionManager.Publish(events.NewErrorEvent(metadata, stepMetadata, err.Error()))
+			err = csf.subscriptionManager.Publish(events.NewErrorEvent(metadata, stepMetadata, err))
 			if err != nil {
 				log.Warn().Err(err).Msg("error publishing error event")
 			}

--- a/pkg/steps/ai/ollama/chat.go
+++ b/pkg/steps/ai/ollama/chat.go
@@ -108,7 +108,7 @@ func (ccs *ChatCompletionStep) Start(
 		})
 
 		if err != nil {
-			ccs.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, ret.GetMetadata(), err.Error()))
+			ccs.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, ret.GetMetadata(), err))
 			c <- helpers.NewErrorResult[string](err)
 		}
 	}()

--- a/pkg/steps/ai/openai/chat-execute-tool-step.go
+++ b/pkg/steps/ai/openai/chat-execute-tool-step.go
@@ -149,7 +149,9 @@ func (t *ChatExecuteToolStep) Start(ctx context.Context, input conversation.Conv
 			}))
 			// TODO(manuel, 2024-07-04) Should there be a ToolResult event here?
 			t.subscriptionManager.PublishBlind(events.NewFinalEvent(metadata, stepMetadata, string(s_)))
-			return helpers.NewValueResult[*conversation.Message](conversation.NewChatMessage(conversation.RoleTool, string(s_), nil))
+			return helpers.NewValueResult[*conversation.Message](
+				conversation.NewChatMessage(conversation.RoleTool, string(s_)),
+			)
 		},
 	}
 	stringResult := steps.Bind[[]events.ToolResult, *conversation.Message](cancellableCtx, execResult, responseToStringStep)

--- a/pkg/steps/ai/openai/chat-step.go
+++ b/pkg/steps/ai/openai/chat-step.go
@@ -194,7 +194,7 @@ func (csf *ChatStep) Start(
 							return
 						}
 
-						csf.publisherManager.PublishBlind(events.NewErrorEvent(metadata, stepMetadata, err.Error()))
+						csf.publisherManager.PublishBlind(events.NewErrorEvent(metadata, stepMetadata, err))
 						c <- helpers.NewErrorResult[*conversation.Message](err)
 						return
 					}
@@ -239,7 +239,7 @@ func (csf *ChatStep) Start(
 		}
 
 		if err != nil {
-			csf.publisherManager.PublishBlind(events.NewErrorEvent(metadata, stepMetadata, err.Error()))
+			csf.publisherManager.PublishBlind(events.NewErrorEvent(metadata, stepMetadata, err))
 			return steps.Reject[*conversation.Message](err, steps.WithMetadata[*conversation.Message](stepMetadata)), nil
 		}
 

--- a/pkg/steps/ai/openai/chat-with-tools-step.go
+++ b/pkg/steps/ai/openai/chat-with-tools-step.go
@@ -145,6 +145,7 @@ func (csf *ChatWithToolsStep) Start(
 	if stream {
 		stream_, err := client.CreateChatCompletionStream(ctx_, *req)
 		if err != nil {
+			csf.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, stepMetadata, err))
 			return steps.Reject[ToolCompletionResponse](err), nil
 		}
 		c := make(chan helpers.Result[ToolCompletionResponse])
@@ -203,7 +204,7 @@ func (csf *ChatWithToolsStep) Start(
 						return
 					}
 					if err != nil {
-						csf.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, stepMetadata, err.Error()))
+						csf.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, stepMetadata, err))
 						c <- helpers.NewErrorResult[ToolCompletionResponse](err)
 						return
 					}
@@ -240,7 +241,7 @@ func (csf *ChatWithToolsStep) Start(
 		}
 
 		if err != nil {
-			csf.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, stepMetadata, err.Error()))
+			csf.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, stepMetadata, err))
 			return steps.Reject[ToolCompletionResponse](err), nil
 		}
 

--- a/pkg/steps/ai/openai/execute-tool-step.go
+++ b/pkg/steps/ai/openai/execute-tool-step.go
@@ -129,7 +129,7 @@ func (e *ExecuteToolStep) Start(
 		tool := e.Tools[toolCall.Function.Name]
 		if tool == nil {
 			errorString := fmt.Sprintf("could not find tool %s", toolCall.Function.Name)
-			e.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, stepMetadata, errorString))
+			e.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, stepMetadata, errors.New(errorString)))
 			return steps.Reject[[]events.ToolResult](
 				errors.Errorf("could not find tool %s", toolCall.Function.Name),
 				steps.WithMetadata[[]events.ToolResult](stepMetadata),
@@ -139,7 +139,7 @@ func (e *ExecuteToolStep) Start(
 		var v interface{}
 		err := json.Unmarshal([]byte(toolCall.Function.Arguments), &v)
 		if err != nil {
-			e.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, stepMetadata, err.Error()))
+			e.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, stepMetadata, err))
 			return steps.Reject[[]events.ToolResult](
 				err,
 				steps.WithMetadata[[]events.ToolResult](stepMetadata),
@@ -148,7 +148,7 @@ func (e *ExecuteToolStep) Start(
 
 		vs_, err := helpers.CallFunctionFromJson(tool, v)
 		if err != nil {
-			e.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, stepMetadata, err.Error()))
+			e.subscriptionManager.PublishBlind(events.NewErrorEvent(metadata, stepMetadata, err))
 			return steps.Reject[[]events.ToolResult](
 				err,
 				steps.WithMetadata[[]events.ToolResult](stepMetadata),

--- a/pkg/steps/ai/settings/settings-step.go
+++ b/pkg/steps/ai/settings/settings-step.go
@@ -97,6 +97,20 @@ func NewStepSettingsFromYAML(s io.Reader) (*StepSettings, error) {
 	return settings_.Factories, nil
 }
 
+func NewStepSettingsFromParsedLayers(parsedLayers *layers.ParsedLayers) (*StepSettings, error) {
+	stepSettings, err := NewStepSettings()
+	if err != nil {
+		return nil, err
+	}
+
+	err = stepSettings.UpdateFromParsedLayers(parsedLayers)
+	if err != nil {
+		return nil, err
+	}
+
+	return stepSettings, nil
+}
+
 func (ss *StepSettings) GetMetadata() map[string]interface{} {
 	metadata := make(map[string]interface{})
 


### PR DESCRIPTION
This PR enhances the event handling system for chat messages to improve
visibility of tool calls and error reporting:

- Change error event handling to accept error objects directly instead of strings
- Improve chat message formatting for better readability (parentheses instead of
  brackets)
- Fix tool call handling in OpenAI chat implementation
- Add proper logging for event router with detailed debug messages
- Add new Watermill logger adapter for better integration with zerolog
- Add IsRunning() method to event router for better state checking
- Fix potential nil pointer issue in chat-with-tools-step when no choices are
  returned
- Add helper for creating step settings from parsed layers

These changes make it easier to visualize and debug tool calls during chat
sessions.