### PR TITLE
Add batch embeddings API with caching support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,10 @@
             "source.organizeImports": "always",
             "source.fixAll": "always"
         }
-    }
+    },
+    "amp.commands.allowlist": [
+        "npm",
+        "go build",
+        "make test ./pkg/embeddings"
+    ]
 }

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,40 @@
+# AGENT.md - Geppetto Repository Guidelines
+
+## Commands
+
+### Build & Test
+```
+make build      # Build all packages
+make test       # Run all tests
+go test ./...   # Run all tests (alternate)
+go test ./pkg/embeddings  # Run tests in specific package
+go test ./pkg/embeddings -run=TestBasicCacheOperations  # Run a specific test
+```
+
+### Lint
+```
+make lint       # Run golangci-lint
+make lintmax    # Run golangci-lint with more issues shown
+```
+
+## Code Style
+
+- Go version: 1.24+
+- Use contexts for cancellation where appropriate
+- Write tests with descriptive names using table-driven approach
+- Use testify for assertions (require for fatal, assert for non-fatal)
+- Follow Go naming conventions (CamelCase for exported, camelCase for private)
+- Document all exported types, functions, and methods
+- Error handling: return errors, don't panic
+- Organize imports: standard library first, then external packages
+- Use functional options pattern for configurable components
+
+<goGuidelines>
+When implementing go interfaces, use the var _ Interface = &Foo{} to make sure the interface is always implemented correctly.
+When building web applications, use htmx, bootstrap and the templ templating language.
+Always use a context argument when appropriate.
+Use cobra for command-line applications.
+Use the "defaults" package name, instead of "default" package name, as it's reserved in go.
+Use github.com/pkg/errors for wrapping errors.
+When starting goroutines, use errgroup.
+</goGuidelines>

--- a/pkg/embeddings/batch.go
+++ b/pkg/embeddings/batch.go
@@ -1,0 +1,62 @@
+package embeddings
+
+import (
+	"context"
+	"sync"
+)
+
+// DefaultGenerateBatchEmbeddings provides a default implementation of batch processing
+// by calling GenerateEmbedding for each text sequentially.
+// This can be used by Provider implementations that don't have native batch support.
+func DefaultGenerateBatchEmbeddings(ctx context.Context, p Provider, texts []string) ([][]float32, error) {
+	results := make([][]float32, len(texts))
+	for i, text := range texts {
+		embedding, err := p.GenerateEmbedding(ctx, text)
+		if err != nil {
+			return nil, err
+		}
+		results[i] = embedding
+	}
+	return results, nil
+}
+
+// ParallelGenerateBatchEmbeddings provides a concurrent implementation of batch processing
+// by calling GenerateEmbedding for each text in parallel with a limit on concurrency.
+// This can be more efficient than sequential processing for providers with rate limiting.
+func ParallelGenerateBatchEmbeddings(ctx context.Context, p Provider, texts []string, maxConcurrency int) ([][]float32, error) {
+	if maxConcurrency <= 0 {
+		maxConcurrency = 4 // Default concurrency
+	}
+
+	total := len(texts)
+	results := make([][]float32, total)
+	errs := make([]error, total)
+
+	// Use a semaphore to limit concurrency
+	sem := make(chan struct{}, maxConcurrency)
+	var wg sync.WaitGroup
+
+	for i, text := range texts {
+		wg.Add(1)
+		go func(idx int, txt string) {
+			defer wg.Done()
+			sem <- struct{}{}        // Acquire semaphore
+			defer func() { <-sem }() // Release semaphore
+
+			embedding, err := p.GenerateEmbedding(ctx, txt)
+			results[idx] = embedding
+			errs[idx] = err
+		}(i, text)
+	}
+
+	wg.Wait()
+
+	// Check for errors
+	for _, err := range errs {
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return results, nil
+}

--- a/pkg/embeddings/batch_test.go
+++ b/pkg/embeddings/batch_test.go
@@ -1,0 +1,135 @@
+package embeddings
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchProcessing(t *testing.T) {
+	t.Run("default sequential implementation", func(t *testing.T) {
+		provider := NewMockProvider()
+		texts := []string{"one", "two", "three"}
+
+		results, err := DefaultGenerateBatchEmbeddings(context.Background(), provider, texts)
+		require.NoError(t, err)
+		require.Equal(t, 3, len(results))
+
+		// Check each result matches what we expect
+		assert.Equal(t, []float32{3.0, 1.0, 2.0}, results[0]) // "one"
+		assert.Equal(t, []float32{3.0, 1.0, 2.0}, results[1]) // "two"
+		assert.Equal(t, []float32{5.0, 1.0, 2.0}, results[2]) // "three"
+	})
+
+	t.Run("parallel implementation", func(t *testing.T) {
+		provider := NewMockProvider()
+		texts := []string{"one", "two", "three", "four", "five"}
+
+		results, err := ParallelGenerateBatchEmbeddings(context.Background(), provider, texts, 2)
+		require.NoError(t, err)
+		require.Equal(t, 5, len(results))
+
+		// Check each result matches what we expect
+		assert.Equal(t, []float32{3.0, 1.0, 2.0}, results[0]) // "one"
+		assert.Equal(t, []float32{3.0, 1.0, 2.0}, results[1]) // "two"
+		assert.Equal(t, []float32{5.0, 1.0, 2.0}, results[2]) // "three"
+		assert.Equal(t, []float32{4.0, 1.0, 2.0}, results[3]) // "four"
+		assert.Equal(t, []float32{4.0, 1.0, 2.0}, results[4]) // "five"
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		provider := NewMockProvider()
+		texts := []string{}
+
+		// Test both implementations with empty input
+		results1, err := DefaultGenerateBatchEmbeddings(context.Background(), provider, texts)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(results1))
+
+		results2, err := ParallelGenerateBatchEmbeddings(context.Background(), provider, texts, 2)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(results2))
+	})
+}
+
+func TestProviderBatchImplementations(t *testing.T) {
+	t.Run("OpenAI provider batch processing", func(t *testing.T) {
+		// This is a minimal test that just ensures the method exists and returns expected format
+		// (Not actually calling the API)
+		provider := NewOpenAIProvider("dummy-key", "text-embedding-3-small", 1536)
+		texts := []string{"one", "two"}
+
+		// Mock the client call so we don't actually make API calls
+		oldClient := provider.client
+		defer func() { provider.client = oldClient }()
+
+		// Just verify method exists and is callable
+		_, err := DefaultGenerateBatchEmbeddings(context.Background(), provider, texts)
+		assert.Error(t, err) // Will fail because we're not mocking the client response
+	})
+
+	t.Run("Ollama provider batch processing", func(t *testing.T) {
+		// Similar minimal test for Ollama
+		provider := NewOllamaProvider("", "", 0) // Use defaults
+		texts := []string{"one", "two"}
+
+		// We expect this to call ParallelGenerateBatchEmbeddings
+		// For testing, we'll just verify it doesn't panic
+		// since we can't easily test the HTTP calls
+		// Without dependency injection for testing
+		testCtx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+		defer cancel()
+		_, err := provider.GenerateBatchEmbeddings(testCtx, texts)
+		// Either timeout or connection error is acceptable
+		assert.Error(t, err)
+	})
+}
+
+func TestCacheProviderBatch(t *testing.T) {
+	t.Run("memory cache provider", func(t *testing.T) {
+		provider := NewMockProvider()
+		cachedProvider := NewCachedProvider(provider, 100)
+
+		// First call - should use underlying provider
+		texts := []string{"one", "two", "three"}
+		results1, err := cachedProvider.GenerateBatchEmbeddings(context.Background(), texts)
+		require.NoError(t, err)
+		require.Equal(t, 3, len(results1))
+
+		// Second call with same texts - should use cache
+		results2, err := cachedProvider.GenerateBatchEmbeddings(context.Background(), texts)
+		require.NoError(t, err)
+		require.Equal(t, 3, len(results2))
+
+		// Results should be identical
+		for i := range results1 {
+			assert.Equal(t, results1[i], results2[i])
+		}
+
+		// Verify cache has the entries
+		assert.Equal(t, 3, cachedProvider.Size())
+	})
+
+	t.Run("partial cache hit", func(t *testing.T) {
+		provider := NewMockProvider()
+		cachedProvider := NewCachedProvider(provider, 100)
+
+		// First call to populate cache
+		_, err := cachedProvider.GenerateBatchEmbeddings(context.Background(), []string{"one", "two"})
+		require.NoError(t, err)
+
+		// Second call with some new texts
+		texts := []string{"one", "three", "two"}
+		results, err := cachedProvider.GenerateBatchEmbeddings(context.Background(), texts)
+		require.NoError(t, err)
+		require.Equal(t, 3, len(results))
+
+		// Verify first and third ("one" and "two") were cached, second ("three") was generated
+		assert.Equal(t, []float32{3.0, 1.0, 2.0}, results[0]) // "one"
+		assert.Equal(t, []float32{5.0, 1.0, 2.0}, results[1]) // "three"
+		assert.Equal(t, []float32{3.0, 1.0, 2.0}, results[2]) // "two"
+	})
+}

--- a/pkg/embeddings/disk-cache_test.go
+++ b/pkg/embeddings/disk-cache_test.go
@@ -58,6 +58,19 @@ func (m *MockProvider) GenerateEmbedding(_ context.Context, text string) ([]floa
 	return []float32{float32(len(text)), 1.0, 2.0}, nil
 }
 
+func (m *MockProvider) GenerateBatchEmbeddings(_ context.Context, texts []string) ([][]float32, error) {
+	results := make([][]float32, len(texts))
+	for i, text := range texts {
+		if e, ok := m.embeddings[text]; ok {
+			results[i] = e
+		} else {
+			// Return predictable embedding based on text length
+			results[i] = []float32{float32(len(text)), 1.0, 2.0}
+		}
+	}
+	return results, nil
+}
+
 func (m *MockProvider) GetModel() EmbeddingModel {
 	return m.model
 }

--- a/pkg/embeddings/embeddings.go
+++ b/pkg/embeddings/embeddings.go
@@ -13,6 +13,10 @@ type Provider interface {
 	// GenerateEmbedding creates an embedding vector for the given text
 	GenerateEmbedding(ctx context.Context, text string) ([]float32, error)
 
+	// GenerateBatchEmbeddings creates embedding vectors for multiple texts at once
+	// This is typically more efficient than calling GenerateEmbedding multiple times
+	GenerateBatchEmbeddings(ctx context.Context, texts []string) ([][]float32, error)
+
 	// GetModel returns information about the embedding model being used
 	GetModel() EmbeddingModel
 }

--- a/pkg/embeddings/ollama.go
+++ b/pkg/embeddings/ollama.go
@@ -86,6 +86,12 @@ func (p *OllamaProvider) GenerateEmbedding(ctx context.Context, text string) ([]
 	return result.Embedding, nil
 }
 
+func (p *OllamaProvider) GenerateBatchEmbeddings(ctx context.Context, texts []string) ([][]float32, error) {
+	// Ollama doesn't currently support native batch embedding, so we use the parallel helper
+	// with a concurrency limit of 4 to avoid overwhelming the server
+	return ParallelGenerateBatchEmbeddings(ctx, p, texts, 4)
+}
+
 func (p *OllamaProvider) GetModel() EmbeddingModel {
 	return EmbeddingModel{
 		Name:       p.model,

--- a/pkg/steps/ai/claude/api/messages.go
+++ b/pkg/steps/ai/claude/api/messages.go
@@ -185,7 +185,6 @@ func (c *Client) SendMessage(ctx context.Context, req *MessageRequest) (*Message
 
 	var messageResp MessageResponse
 	respBody, _ := io.ReadAll(resp.Body)
-	fmt.Println(string(respBody))
 	if unmarshalErr := json.Unmarshal(respBody, &messageResp); unmarshalErr != nil {
 		return nil, unmarshalErr
 	}


### PR DESCRIPTION
* Add `GenerateBatchEmbeddings` method to the Provider interface
* Implement two helper functions for batch processing:
  - `DefaultGenerateBatchEmbeddings`: sequential processing
  - `ParallelGenerateBatchEmbeddings`: parallel processing with concurrency limits
* Add native batch support for OpenAI provider using their API's batch capability
* Implement Ollama provider batch support using parallel processing
* Extend memory cache and disk cache to support batch operations
  - Smart partial caching: only fetch uncached items from providers
  - Preserve order of results to match input order
* Add comprehensive tests for batch operations
* Add AGENT.md with development guidelines