### PR TITLE
Add streaming blocks for thinking and web search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ envs/
 .specstory/
 
 __debug*
+thirdparty/

--- a/pkg/steps/ai/claude/api/streaming.go
+++ b/pkg/steps/ai/claude/api/streaming.go
@@ -30,6 +30,9 @@ type StreamingDeltaType string
 const (
 	TextDeltaType      StreamingDeltaType = "text_delta"
 	InputJSONDeltaType StreamingDeltaType = "input_json_delta"
+	CitationsDeltaType StreamingDeltaType = "citations_delta"
+	ThinkingDeltaType  StreamingDeltaType = "thinking_delta"
+	SignatureDeltaType StreamingDeltaType = "signature_delta"
 )
 
 type StreamingEvent struct {
@@ -73,11 +76,15 @@ func (s StreamingEvent) MarshalZerologObject(e *zerolog.Event) {
 var _ zerolog.LogObjectMarshaler = StreamingEvent{}
 
 type ContentBlock struct {
-	Type  ContentType `json:"type"`
-	ID    string      `json:"id,omitempty"`
-	Name  string      `json:"name,omitempty"`
-	Input string      `json:"input,omitempty"`
-	Text  string      `json:"text,omitempty"`
+	Type      ContentType     `json:"type"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     string          `json:"input,omitempty"`
+	Text      string          `json:"text,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"`
+	Thinking  string          `json:"thinking,omitempty"`
+	Signature string          `json:"signature,omitempty"`
 }
 
 type Error struct {
@@ -91,6 +98,8 @@ type Delta struct {
 	PartialJSON  string             `json:"partial_json"`
 	StopReason   string             `json:"stop_reason,omitempty"`
 	StopSequence string             `json:"stop_sequence,omitempty"`
+	Thinking     string             `json:"thinking,omitempty"`
+	Signature    string             `json:"signature,omitempty"`
 }
 
 func (cb ContentBlock) MarshalZerologObject(e *zerolog.Event) {
@@ -106,6 +115,18 @@ func (cb ContentBlock) MarshalZerologObject(e *zerolog.Event) {
 	}
 	if cb.Text != "" {
 		e.Str("text", cb.Text)
+	}
+	if cb.ToolUseID != "" {
+		e.Str("tool_use_id", cb.ToolUseID)
+	}
+	if len(cb.Content) > 0 {
+		e.RawJSON("content", cb.Content)
+	}
+	if cb.Thinking != "" {
+		e.Str("thinking", cb.Thinking)
+	}
+	if cb.Signature != "" {
+		e.Str("signature", cb.Signature)
 	}
 }
 
@@ -125,6 +146,12 @@ func (d Delta) MarshalZerologObject(e *zerolog.Event) {
 	}
 	if d.StopSequence != "" {
 		e.Str("stop_sequence", d.StopSequence)
+	}
+	if d.Thinking != "" {
+		e.Str("thinking", d.Thinking)
+	}
+	if d.Signature != "" {
+		e.Str("signature", d.Signature)
 	}
 }
 

--- a/pkg/steps/ai/claude/content-block-merger.go
+++ b/pkg/steps/ai/claude/content-block-merger.go
@@ -217,9 +217,19 @@ func (cbm *ContentBlockMerger) Add(event api.StreamingEvent) ([]events.Event, er
 			return []events.Event{events.NewPartialCompletionEvent(cbm.metadata, cbm.stepMetadata, delta, cbm.response.FullText()+cb.Text)}, nil
 		case api.InputJSONDeltaType:
 			delta = event.Delta.PartialJSON
-			cb.Input += event.Delta.PartialJSON
+			if cb.Type == api.ContentTypeWebSearchToolResult {
+				cb.Content = append(cb.Content, []byte(event.Delta.PartialJSON)...)
+			} else {
+				cb.Input += event.Delta.PartialJSON
+			}
 			// TODO(manuel, 2024-07-04) This is where we would do partial tool call streaming
 			_ = delta
+		case api.ThinkingDeltaType:
+			cb.Thinking += event.Delta.Thinking
+			return []events.Event{}, nil
+		case api.SignatureDeltaType:
+			cb.Signature += event.Delta.Signature
+			return []events.Event{}, nil
 		}
 		return []events.Event{}, nil
 
@@ -244,6 +254,26 @@ func (cbm *ContentBlockMerger) Add(event api.StreamingEvent) ([]events.Event, er
 				Name:  cb.Name,
 				Input: cb.Input,
 			})}, nil
+
+		case api.ContentTypeServerToolUse:
+			cbm.response.Content = append(cbm.response.Content, api.NewServerToolUseContent(cb.ID, cb.Name, cb.Input))
+			return []events.Event{events.NewToolCallEvent(cbm.metadata, cbm.stepMetadata, events.ToolCall{
+				ID:    cb.ID,
+				Name:  cb.Name,
+				Input: cb.Input,
+			})}, nil
+
+		case api.ContentTypeWebSearchToolResult:
+			cbm.response.Content = append(cbm.response.Content, api.NewWebSearchToolResultContent(cb.ToolUseID, cb.Content))
+			return []events.Event{events.NewToolResultEvent(cbm.metadata, cbm.stepMetadata, events.ToolResult{ID: cb.ToolUseID, Result: string(cb.Content)})}, nil
+
+		case api.ContentTypeThinking:
+			cbm.response.Content = append(cbm.response.Content, api.NewThinkingContent(cb.Signature, cb.Thinking))
+			return []events.Event{}, nil
+
+		case api.ContentTypeRedactedThinking:
+			cbm.response.Content = append(cbm.response.Content, api.NewRedactedThinkingContent(cb.Text))
+			return []events.Event{}, nil
 
 		case api.ContentTypeImage, api.ContentTypeToolResult:
 			return nil, errors.Errorf("Unsupported content block type: %s", cb.Type)


### PR DESCRIPTION
## Summary
- support new Claude API content types and deltas
- handle new blocks in merger
- add tests for server tool use, thinking, and web search blocks

## Testing
- `go test ./...`
