### PR TITLE
Feat: Add tool name to tool result events

### DIFF
--- a/pkg/events/chat-events.go
+++ b/pkg/events/chat-events.go
@@ -260,6 +260,7 @@ var _ Event = &EventToolCall{}
 
 type ToolResult struct {
 	ID     string `json:"id"`
+	Name   string `json:"name,omitempty"`
 	Result string `json:"result"`
 }
 
@@ -793,6 +794,9 @@ func (e EventToolCall) MarshalZerologObject(ev *zerolog.Event) {
 
 func (tr ToolResult) MarshalZerologObject(ev *zerolog.Event) {
 	ev.Str("id", tr.ID).Str("result", tr.Result)
+	if tr.Name != "" {
+		ev.Str("name", tr.Name)
+	}
 }
 
 func (e EventToolResult) MarshalZerologObject(ev *zerolog.Event) {

--- a/pkg/inference/tools/base_executor.go
+++ b/pkg/inference/tools/base_executor.go
@@ -113,7 +113,7 @@ func (b *BaseToolExecutor) PublishResult(ctx context.Context, call ToolCall, res
 	}
 	events.PublishEventToContext(ctx, events.NewToolCallExecutionResultEvent(
 		events.EventMetadata{},
-		events.ToolResult{ID: call.ID, Result: payload},
+		events.ToolResult{ID: call.ID, Name: call.Name, Result: payload},
 	))
 }
 


### PR DESCRIPTION
This change enhances observability by adding the tool's name to the tool
result event. Previously, only the tool call ID was present, making it
difficult to identify which tool generated a specific result directly from the
event or logs.

- The `ToolResult` event struct is updated with a `Name` field.
- The `BaseToolExecutor` now populates this `Name` field from the original
  `ToolCall`.
- Structured logs for `ToolResult` now include the tool name for easier
  debugging.