### PR TITLE
Refactor: Consolidate profile selection and runtime resolution

### DIFF
--- a/pkg/cli/bootstrap/bootstrap_test.go
+++ b/pkg/cli/bootstrap/bootstrap_test.go
@@ -103,27 +103,34 @@ func TestResolveCLIConfigFilesResolved_UsesConfiguredPlanForDefaultDiscovery(t *
 	}
 }
 
-func TestResolveCLIProfileSelection_UsesConfiguredEnvPrefix(t *testing.T) {
+func TestResolveCLIProfileRuntime_UsesConfiguredEnvPrefix(t *testing.T) {
 	cfg := testAppBootstrapConfig()
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "xdg"))
 	t.Setenv("HOME", tmpDir)
-	t.Setenv("GP53APP_PROFILE", "env-profile")
-	t.Setenv("GP53APP_PROFILE_REGISTRIES", filepath.Join(tmpDir, "env-registry.yaml"))
-
-	resolved, err := ResolveCLIProfileSelection(cfg, values.New())
-	if err != nil {
-		t.Fatalf("ResolveCLIProfileSelection failed: %v", err)
+	registryPath := filepath.Join(tmpDir, "env-registry.yaml")
+	if err := os.WriteFile(registryPath, []byte("slug: workspace\nprofiles: {}\n"), 0o644); err != nil {
+		t.Fatalf("write env registry: %v", err)
 	}
-	if got := resolved.Profile; got != "env-profile" {
+	t.Setenv("GP53APP_PROFILE", "env-profile")
+	t.Setenv("GP53APP_PROFILE_REGISTRIES", registryPath)
+
+	runtime, err := ResolveCLIProfileRuntime(context.Background(), cfg, values.New())
+	if err != nil {
+		t.Fatalf("ResolveCLIProfileRuntime failed: %v", err)
+	}
+	if runtime.Close != nil {
+		defer runtime.Close()
+	}
+	if got := runtime.ProfileSettings.Profile; got != "env-profile" {
 		t.Fatalf("expected env profile, got %q", got)
 	}
-	if len(resolved.ProfileRegistries) != 1 || resolved.ProfileRegistries[0] != filepath.Join(tmpDir, "env-registry.yaml") {
-		t.Fatalf("expected env registries, got %#v", resolved.ProfileRegistries)
+	if len(runtime.ProfileSettings.ProfileRegistries) != 1 || runtime.ProfileSettings.ProfileRegistries[0] != registryPath {
+		t.Fatalf("expected env registries, got %#v", runtime.ProfileSettings.ProfileRegistries)
 	}
 }
 
-func TestResolveCLIProfileSelection_UsesImplicitProfilesFallbackFromXDGAppPath(t *testing.T) {
+func TestResolveCLIProfileRuntime_UsesImplicitProfilesFallbackFromXDGAppPath(t *testing.T) {
 	cfg := testAppBootstrapConfig()
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "xdg"))
@@ -148,12 +155,15 @@ func TestResolveCLIProfileSelection_UsesImplicitProfilesFallbackFromXDGAppPath(t
 	}
 	parsed.Set(cli.CommandSettingsSlug, commandValues)
 
-	resolved, err := ResolveCLIProfileSelection(cfg, parsed)
+	runtime, err := ResolveCLIProfileRuntime(context.Background(), cfg, parsed)
 	if err != nil {
-		t.Fatalf("ResolveCLIProfileSelection failed: %v", err)
+		t.Fatalf("ResolveCLIProfileRuntime failed: %v", err)
 	}
-	if len(resolved.ProfileRegistries) != 1 || resolved.ProfileRegistries[0] != registryPath {
-		t.Fatalf("expected implicit registry fallback %q, got %#v", registryPath, resolved.ProfileRegistries)
+	if runtime.Close != nil {
+		defer runtime.Close()
+	}
+	if len(runtime.ProfileSettings.ProfileRegistries) != 1 || runtime.ProfileSettings.ProfileRegistries[0] != registryPath {
+		t.Fatalf("expected implicit registry fallback %q, got %#v", registryPath, runtime.ProfileSettings.ProfileRegistries)
 	}
 }
 
@@ -199,8 +209,8 @@ profiles:
 	if runtime.Close != nil {
 		defer runtime.Close()
 	}
-	if runtime.ProfileSelection == nil || runtime.ProfileSelection.Profile != "analyst" {
-		t.Fatalf("expected profile selection analyst, got %#v", runtime.ProfileSelection)
+	if got := runtime.ProfileSettings.Profile; got != "analyst" {
+		t.Fatalf("expected runtime profile analyst, got %q", got)
 	}
 	if runtime.ProfileRegistryChain == nil || runtime.ProfileRegistryChain.Registry == nil {
 		t.Fatal("expected resolved profile registry chain")
@@ -214,18 +224,22 @@ profiles:
 	}
 }
 
-func TestResolveCLIProfileSelection_UsesConfigPlanBuilderLayering(t *testing.T) {
+func TestResolveCLIProfileRuntime_UsesConfigPlanBuilderLayering(t *testing.T) {
 	cfg := testAppBootstrapConfig()
 	tmpDir := t.TempDir()
 	repoFile := filepath.Join(tmpDir, "repo.yaml")
 	cwdFile := filepath.Join(tmpDir, "cwd.yaml")
 	explicitFile := filepath.Join(tmpDir, "explicit.yaml")
+	registryPath := filepath.Join(tmpDir, "profiles.yaml")
+	if err := os.WriteFile(registryPath, []byte("slug: workspace\nprofiles: {}\n"), 0o644); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
 	for path, profile := range map[string]string{
 		repoFile:     "repo-profile",
 		cwdFile:      "cwd-profile",
 		explicitFile: "explicit-profile",
 	} {
-		content := "profile-settings:\n  profile: " + profile + "\n"
+		content := "profile-settings:\n  profile: " + profile + "\n  profile-registries:\n    - " + registryPath + "\n"
 		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 			t.Fatalf("write config %s: %v", path, err)
 		}
@@ -254,15 +268,18 @@ func TestResolveCLIProfileSelection_UsesConfigPlanBuilderLayering(t *testing.T) 
 		t.Fatalf("NewCLISelectionValues failed: %v", err)
 	}
 
-	resolved, err := ResolveCLIProfileSelection(cfg, parsed)
+	runtime, err := ResolveCLIProfileRuntime(context.Background(), cfg, parsed)
 	if err != nil {
-		t.Fatalf("ResolveCLIProfileSelection failed: %v", err)
+		t.Fatalf("ResolveCLIProfileRuntime failed: %v", err)
 	}
-	if got := resolved.Profile; got != "explicit-profile" {
+	if runtime.Close != nil {
+		defer runtime.Close()
+	}
+	if got := runtime.ProfileSettings.Profile; got != "explicit-profile" {
 		t.Fatalf("expected explicit profile to win layered config precedence, got %q", got)
 	}
-	if len(resolved.ConfigFiles) != 3 || resolved.ConfigFiles[0] != repoFile || resolved.ConfigFiles[1] != cwdFile || resolved.ConfigFiles[2] != explicitFile {
-		t.Fatalf("unexpected config file order: %#v", resolved.ConfigFiles)
+	if len(runtime.ConfigFiles) != 3 || runtime.ConfigFiles[0] != repoFile || runtime.ConfigFiles[1] != cwdFile || runtime.ConfigFiles[2] != explicitFile {
+		t.Fatalf("unexpected config file order: %#v", runtime.ConfigFiles)
 	}
 }
 
@@ -307,7 +324,10 @@ func TestBuildInferenceTraceParsedValues_PreservesConfigLayerMetadata(t *testing
 		t.Fatalf("ResolveCLIEngineSettings failed: %v", err)
 	}
 	var buf bytes.Buffer
-	if err := WriteInferenceSettingsDebugYAML(&buf, resolved, InferenceDebugOutputOptions{ParsedForTrace: parsedForTrace}); err != nil {
+	if err := WriteInferenceSettingsDebugYAML(&buf, &ResolvedInferenceTrace{
+		FinalInferenceSettings: resolved.FinalInferenceSettings,
+		ResolvedEngineProfile:  resolved.ResolvedEngineProfile,
+	}, InferenceDebugOutputOptions{ParsedForTrace: parsedForTrace}); err != nil {
 		t.Fatalf("WriteInferenceSettingsDebugYAML failed: %v", err)
 	}
 	out := buf.String()

--- a/pkg/cli/bootstrap/engine_settings.go
+++ b/pkg/cli/bootstrap/engine_settings.go
@@ -17,7 +17,6 @@ import (
 type ResolvedCLIEngineSettings struct {
 	BaseInferenceSettings  *aisettings.InferenceSettings
 	FinalInferenceSettings *aisettings.InferenceSettings
-	ProfileSelection       *ResolvedCLIProfileSelection
 	ProfileRuntime         *ResolvedCLIProfileRuntime
 	ResolvedEngineProfile  *gepprofiles.ResolvedEngineProfile
 	ConfigFiles            []string
@@ -85,11 +84,10 @@ func ResolveCLIEngineSettingsFromBase(
 	if err != nil {
 		return nil, err
 	}
-	selection := profileRuntime.ProfileSelection
 
-	// Start with base config files, but if the profile selection resolved
+	// Start with base config files, but if the profile runtime resolved
 	// its own config files, those replace the base list entirely. This is
-	// because profile selection runs the same config plan as base, so its
+	// because profile runtime runs the same config plan as base, so its
 	// config files are a superset (or equal) to the base files.
 	configFiles := append([]string(nil), baseConfigFiles...)
 	if len(profileRuntime.ConfigFiles) > 0 {
@@ -101,7 +99,6 @@ func ResolveCLIEngineSettingsFromBase(
 		return &ResolvedCLIEngineSettings{
 			BaseInferenceSettings:  base,
 			FinalInferenceSettings: base,
-			ProfileSelection:       selection,
 			ProfileRuntime:         profileRuntime,
 			ConfigFiles:            configFiles,
 			Close:                  profileRuntime.Close,
@@ -126,7 +123,6 @@ func ResolveCLIEngineSettingsFromBase(
 	return &ResolvedCLIEngineSettings{
 		BaseInferenceSettings:  base,
 		FinalInferenceSettings: finalSettings,
-		ProfileSelection:       selection,
 		ProfileRuntime:         profileRuntime,
 		ResolvedEngineProfile:  resolved,
 		ConfigFiles:            configFiles,

--- a/pkg/cli/bootstrap/inference_debug.go
+++ b/pkg/cli/bootstrap/inference_debug.go
@@ -32,6 +32,11 @@ type InferenceDebugOutputOptions struct {
 	ParsedForTrace *values.Values
 }
 
+type ResolvedInferenceTrace struct {
+	FinalInferenceSettings *aisettings.InferenceSettings
+	ResolvedEngineProfile  *gepprofiles.ResolvedEngineProfile
+}
+
 type InferenceSettingSource struct {
 	Value any                `yaml:"value"`
 	Log   []fields.ParseStep `yaml:"log,omitempty"`
@@ -110,7 +115,7 @@ func BuildInferenceTraceParsedValues(cfg AppBootstrapConfig, parsed *values.Valu
 func BuildInferenceSettingsSourceTrace(
 	commandBase *aisettings.InferenceSettings,
 	parsed *values.Values,
-	resolved *ResolvedCLIEngineSettings,
+	resolved *ResolvedInferenceTrace,
 ) (map[string]any, error) {
 	if resolved == nil || resolved.FinalInferenceSettings == nil {
 		return nil, fmt.Errorf("resolved final inference settings are required")
@@ -165,7 +170,7 @@ func BuildInferenceSettingsSourceTrace(
 
 func WriteInferenceSettingsDebugYAML(
 	w io.Writer,
-	resolved *ResolvedCLIEngineSettings,
+	resolved *ResolvedInferenceTrace,
 	opts InferenceDebugOutputOptions,
 ) error {
 	if resolved == nil || resolved.FinalInferenceSettings == nil {
@@ -191,7 +196,7 @@ func HandleInferenceDebugOutput(
 	cfg AppBootstrapConfig,
 	parsed *values.Values,
 	settings InferenceDebugSettings,
-	resolved *ResolvedCLIEngineSettings,
+	resolved *ResolvedInferenceTrace,
 	opts InferenceDebugOutputOptions,
 ) (bool, error) {
 	if !settings.PrintInferenceSettings {

--- a/pkg/cli/bootstrap/profile_runtime.go
+++ b/pkg/cli/bootstrap/profile_runtime.go
@@ -4,13 +4,17 @@ import (
 	"context"
 
 	gepprofiles "github.com/go-go-golems/geppetto/pkg/engineprofiles"
+	"github.com/go-go-golems/glazed/pkg/cmds/fields"
+	"github.com/go-go-golems/glazed/pkg/cmds/schema"
+	"github.com/go-go-golems/glazed/pkg/cmds/sources"
 	"github.com/go-go-golems/glazed/pkg/cmds/values"
+	"github.com/pkg/errors"
 )
 
 type ResolvedCLIProfileRuntime struct {
-	ProfileSelection     *ResolvedCLIProfileSelection
-	ProfileRegistryChain *ResolvedProfileRegistryChain
+	ProfileSettings      ProfileSettings
 	ConfigFiles          []string
+	ProfileRegistryChain *ResolvedProfileRegistryChain
 	Close                func()
 }
 
@@ -19,20 +23,59 @@ func ResolveCLIProfileRuntime(
 	cfg AppBootstrapConfig,
 	parsed *values.Values,
 ) (*ResolvedCLIProfileRuntime, error) {
-	selection, err := ResolveCLIProfileSelection(cfg, parsed)
-	if err != nil {
+	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
 
-	registryChain, err := ResolveProfileRegistryChain(ctx, selection.ProfileSettings)
+	profileSection, err := cfg.NewProfileSection()
+	if err != nil {
+		return nil, errors.Wrap(err, "create profile settings section")
+	}
+
+	schema_ := schema.NewSchema(schema.WithSections(profileSection))
+	resolvedValues := values.New()
+	configMiddleware, configFiles, err := resolveConfigMiddleware(cfg, parsed)
+	if err != nil {
+		return nil, err
+	}
+	if err := sources.Execute(
+		schema_,
+		resolvedValues,
+		sources.FromEnv(cfg.normalizedEnvPrefix(), fields.WithSource("env")),
+		configMiddleware,
+		sources.FromDefaults(fields.WithSource(fields.SourceDefaults)),
+	); err != nil {
+		return nil, errors.Wrap(err, "resolve profile settings from config/env/defaults")
+	}
+	if parsed != nil {
+		if err := resolvedValues.Merge(parsed); err != nil {
+			return nil, errors.Wrap(err, "merge explicit profile settings")
+		}
+	}
+
+	return ResolveCLIProfileRuntimeFromSettings(ctx, cfg, ResolveProfileSettings(resolvedValues), configFiles.Paths)
+}
+
+func ResolveCLIProfileRuntimeFromSettings(
+	ctx context.Context,
+	cfg AppBootstrapConfig,
+	settings ProfileSettings,
+	configFiles []string,
+) (*ResolvedCLIProfileRuntime, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	settings = PrepareProfileSettingsForRuntime(cfg, settings)
+	registryChain, err := ResolveProfileRegistryChain(ctx, settings)
 	if err != nil {
 		return nil, err
 	}
 
 	ret := &ResolvedCLIProfileRuntime{
-		ProfileSelection:     selection,
+		ProfileSettings:      settings,
+		ConfigFiles:          append([]string(nil), configFiles...),
 		ProfileRegistryChain: registryChain,
-		ConfigFiles:          append([]string(nil), selection.ConfigFiles...),
 	}
 	if registryChain != nil {
 		ret.Close = registryChain.Close

--- a/pkg/cli/bootstrap/profile_selection.go
+++ b/pkg/cli/bootstrap/profile_selection.go
@@ -7,20 +7,13 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cli"
 	"github.com/go-go-golems/glazed/pkg/cmds/fields"
 	"github.com/go-go-golems/glazed/pkg/cmds/schema"
-	"github.com/go-go-golems/glazed/pkg/cmds/sources"
 	"github.com/go-go-golems/glazed/pkg/cmds/values"
 	glazedconfig "github.com/go-go-golems/glazed/pkg/config"
-	"github.com/pkg/errors"
 )
 
 type ProfileSettings struct {
 	Profile           string   `glazed:"profile"`
 	ProfileRegistries []string `glazed:"profile-registries"`
-}
-
-type ResolvedCLIProfileSelection struct {
-	ProfileSettings
-	ConfigFiles []string
 }
 
 type ResolvedCLIConfigFiles struct {
@@ -52,53 +45,13 @@ func ResolveProfileSettings(parsed *values.Values) ProfileSettings {
 	return ret
 }
 
-func ResolveCLIProfileSelection(cfg AppBootstrapConfig, parsed *values.Values) (*ResolvedCLIProfileSelection, error) {
-	if err := cfg.Validate(); err != nil {
-		return nil, err
+func PrepareProfileSettingsForRuntime(cfg AppBootstrapConfig, settings ProfileSettings) ProfileSettings {
+	settings.Profile = strings.TrimSpace(settings.Profile)
+	settings.ProfileRegistries = normalizeProfileRegistries(settings.ProfileRegistries)
+	if len(settings.ProfileRegistries) == 0 {
+		settings.ProfileRegistries = normalizeProfileRegistries(defaultProfileRegistrySources(cfg))
 	}
-
-	profileSection, err := cfg.NewProfileSection()
-	if err != nil {
-		return nil, errors.Wrap(err, "create profile settings section")
-	}
-
-	schema_ := schema.NewSchema(schema.WithSections(profileSection))
-	resolvedValues := values.New()
-	configMiddleware, configFiles, err := resolveConfigMiddleware(cfg, parsed)
-	if err != nil {
-		return nil, err
-	}
-	if err := sources.Execute(
-		schema_,
-		resolvedValues,
-		sources.FromEnv(cfg.normalizedEnvPrefix(), fields.WithSource("env")),
-		configMiddleware,
-		sources.FromDefaults(fields.WithSource(fields.SourceDefaults)),
-	); err != nil {
-		return nil, errors.Wrap(err, "resolve profile settings from config/env/defaults")
-	}
-	if parsed != nil {
-		if err := resolvedValues.Merge(parsed); err != nil {
-			return nil, errors.Wrap(err, "merge explicit profile settings")
-		}
-	}
-
-	profileSettings := ResolveProfileSettings(resolvedValues)
-	if len(profileSettings.ProfileRegistries) == 0 {
-		profileSettings.ProfileRegistries = normalizeProfileRegistries(defaultProfileRegistrySources(cfg))
-	}
-	return &ResolvedCLIProfileSelection{
-		ProfileSettings: profileSettings,
-		ConfigFiles:     append([]string(nil), configFiles.Paths...),
-	}, nil
-}
-
-func ResolveEngineProfileSettings(cfg AppBootstrapConfig, parsed *values.Values) (ProfileSettings, []string, error) {
-	resolved, err := ResolveCLIProfileSelection(cfg, parsed)
-	if err != nil {
-		return ProfileSettings{}, nil, err
-	}
-	return resolved.ProfileSettings, resolved.ConfigFiles, nil
+	return settings
 }
 
 func NewCLISelectionValues(cfg AppBootstrapConfig, input CLISelectionInput) (*values.Values, error) {

--- a/pkg/doc/tutorials/09-migrating-cli-commands-to-glazed-bootstrap-profile-resolution.md
+++ b/pkg/doc/tutorials/09-migrating-cli-commands-to-glazed-bootstrap-profile-resolution.md
@@ -349,7 +349,10 @@ if debugSettings.PrintInferenceSettings {
 		appBootstrapConfig(),
 		parsed,
 		*debugSettings,
-		resolved,
+		&geppettobootstrap.ResolvedInferenceTrace{
+			FinalInferenceSettings: resolved.FinalInferenceSettings,
+			ResolvedEngineProfile:  resolved.ResolvedEngineProfile,
+		},
 		geppettobootstrap.InferenceDebugOutputOptions{},
 	)
 	return err

--- a/pkg/doc/tutorials/09-migrating-cli-commands-to-glazed-bootstrap-profile-resolution.md
+++ b/pkg/doc/tutorials/09-migrating-cli-commands-to-glazed-bootstrap-profile-resolution.md
@@ -311,7 +311,7 @@ if resolved.Close != nil {
 
 The result gives you:
 
-- `resolved.ProfileSelection`
+- `resolved.ProfileRuntime`
 - `resolved.BaseInferenceSettings`
 - `resolved.FinalInferenceSettings`
 - `resolved.ResolvedEngineProfile`


### PR DESCRIPTION
This change refactors the CLI bootstrap process by consolidating profile
setting selection and runtime resolution into a single, unified step. This
simplifies the API and reduces conceptual overhead.

Key changes:

- Removes the `ResolvedCLIProfileSelection` struct and the
  `ResolveCLIProfileSelection` function.
- The `ResolveCLIProfileRuntime` function now handles the complete
  process of discovering and layering profile settings from config files,
  environment variables, and defaults.
- The `ResolvedCLIEngineSettings` struct is simplified by removing the now
  redundant `ProfileSelection` field.
- Decouples inference debugging by introducing a new `ResolvedInferenceTrace`
  struct. Debug output functions now accept this more focused struct instead
  of the full `ResolvedCLIEngineSettings`.
- Updates all tests and documentation to align with the new, simpler API.