### PR TITLE
Fix markdown formatting for streamed reasoning

### DIFF
--- a/pkg/steps/ai/openai_responses/engine.go
+++ b/pkg/steps/ai/openai_responses/engine.go
@@ -464,14 +464,16 @@ func (e *Engine) RunInference(ctx context.Context, t *turns.Turn) (*turns.Turn, 
 				e.publishEvent(ctx, events.NewInfoEvent(metadata, "reasoning-summary-started", nil))
 			case "response.reasoning_summary_text.delta":
 				if v, ok := m["delta"].(string); ok && v != "" {
-					summaryBuf.WriteString(v)
-					currentReasoningSummary.WriteString(v)
+					normalized := streamhelpers.NormalizeReasoningSummaryDelta(summaryBuf.String(), v)
+					summaryBuf.WriteString(normalized)
+					currentReasoningSummary.WriteString(normalized)
 					// Emit thinking partials for live reasoning summary text
-					e.publishEvent(ctx, events.NewThinkingPartialEvent(metadata, v, summaryBuf.String()))
+					e.publishEvent(ctx, events.NewThinkingPartialEvent(metadata, normalized, summaryBuf.String()))
 				} else if s, ok := m["text"].(string); ok && s != "" {
-					summaryBuf.WriteString(s)
-					currentReasoningSummary.WriteString(s)
-					e.publishEvent(ctx, events.NewThinkingPartialEvent(metadata, s, summaryBuf.String()))
+					normalized := streamhelpers.NormalizeReasoningSummaryDelta(summaryBuf.String(), s)
+					summaryBuf.WriteString(normalized)
+					currentReasoningSummary.WriteString(normalized)
+					e.publishEvent(ctx, events.NewThinkingPartialEvent(metadata, normalized, summaryBuf.String()))
 				}
 			case "response.reasoning_summary_part.done":
 				// End of a summary piece – forward as streaming info event

--- a/pkg/steps/ai/openai_responses/engine_test.go
+++ b/pkg/steps/ai/openai_responses/engine_test.go
@@ -434,6 +434,105 @@ func TestRunInference_StreamingReasoningTextEventsArePublished(t *testing.T) {
 	}
 }
 
+func TestRunInference_StreamingReasoningSummaryPreservesSentenceBoundaries(t *testing.T) {
+	origClient := http.DefaultClient
+	http.DefaultClient = &http.Client{
+		Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			body := strings.Join([]string{
+				"event: response.output_item.added",
+				`data: {"item":{"type":"reasoning","id":"rs_summary"}}`,
+				"",
+				"event: response.reasoning_summary_text.delta",
+				`data: {"delta":"The provider groups work into a category."}`,
+				"",
+				"event: response.reasoning_summary_text.delta",
+				`data: {"delta":"Creating an analysis plan"}`,
+				"",
+				"event: response.output_item.done",
+				`data: {"item":{"type":"reasoning","id":"rs_summary"}}`,
+				"",
+				"event: response.output_item.added",
+				`data: {"item":{"type":"message","id":"msg_1"}}`,
+				"",
+				"event: response.output_text.delta",
+				`data: {"delta":"done"}`,
+				"",
+				"event: response.output_item.done",
+				`data: {"item":{"type":"message","id":"msg_1"}}`,
+				"",
+				"event: response.completed",
+				`data: {"response":{"usage":{"input_tokens":1,"output_tokens":1}}}`,
+				"",
+			}, "\n")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Request:    r,
+			}, nil
+		}),
+	}
+	defer func() { http.DefaultClient = origClient }()
+
+	eng, err := NewEngine(&settings.InferenceSettings{
+		API: &settings.APISettings{
+			APIKeys:  map[string]string{"openai-api-key": "test"},
+			BaseUrls: map[string]string{"openai-base-url": "https://example.test/v1"},
+		},
+		Chat: &settings.ChatSettings{
+			Engine: ptr("gpt-5-mini"),
+			Stream: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	sink := &capturingEventSink{}
+	ctx := events.WithEventSinks(context.Background(), sink)
+	turn := &turns.Turn{Blocks: []turns.Block{
+		turns.NewUserTextBlock("Hello"),
+	}}
+
+	_, err = eng.RunInference(ctx, turn)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	want := "The provider groups work into a category. Creating an analysis plan"
+	var lastThinkingCompletion string
+	var finalSummary string
+	var finalSummaryFromMetadata string
+	for _, event := range sink.snapshot() {
+		switch e := event.(type) {
+		case *events.EventThinkingPartial:
+			lastThinkingCompletion = e.Completion
+		case *events.EventInfo:
+			if e.Message == "reasoning-summary" {
+				if s, ok := e.Data["text"].(string); ok {
+					finalSummary = s
+				}
+			}
+		case *events.EventFinal:
+			if e.Metadata().Extra != nil {
+				if s, ok := e.Metadata().Extra["reasoning_summary_text"].(string); ok {
+					finalSummaryFromMetadata = s
+				}
+			}
+		}
+	}
+
+	if lastThinkingCompletion != want {
+		t.Fatalf("expected normalized thinking partial completion %q, got %q", want, lastThinkingCompletion)
+	}
+	if finalSummary != want {
+		t.Fatalf("expected normalized reasoning-summary info text %q, got %q", want, finalSummary)
+	}
+	if finalSummaryFromMetadata != want {
+		t.Fatalf("expected normalized final metadata reasoning_summary_text %q, got %q", want, finalSummaryFromMetadata)
+	}
+}
+
 func TestRunInference_StreamingReasoningAliasEventsAreNormalized(t *testing.T) {
 	origClient := http.DefaultClient
 	http.DefaultClient = &http.Client{

--- a/pkg/steps/ai/streamhelpers/reasoning_markdown.go
+++ b/pkg/steps/ai/streamhelpers/reasoning_markdown.go
@@ -101,7 +101,7 @@ func shouldInsertSentenceBoundarySpace(current, delta string) bool {
 	if !ok {
 		return false
 	}
-	return unicode.IsUpper(first) || unicode.IsDigit(first)
+	return unicode.IsUpper(first)
 }
 
 func isSentenceBoundaryRune(r rune) bool {

--- a/pkg/steps/ai/streamhelpers/reasoning_markdown.go
+++ b/pkg/steps/ai/streamhelpers/reasoning_markdown.go
@@ -1,6 +1,10 @@
 package streamhelpers
 
-import "strings"
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
 
 // EnsureReasoningItemBoundary inserts a paragraph break between provider
 // reasoning items when the accumulated stream does not already end at a
@@ -37,6 +41,31 @@ func NormalizeReasoningDelta(current, delta string) string {
 	return "\n\n" + delta
 }
 
+// NormalizeReasoningSummaryDelta preserves readable boundaries in public
+// reasoning summaries. It reuses markdown-block detection and also inserts a
+// plain space when one streamed chunk ends at sentence punctuation and the next
+// chunk starts with an uppercase continuation without any leading whitespace.
+func NormalizeReasoningSummaryDelta(current, delta string) string {
+	if current == "" || delta == "" {
+		return delta
+	}
+	if normalized := NormalizeReasoningDelta(current, delta); normalized != delta {
+		return normalized
+	}
+	trimmedCurrent := strings.TrimRight(current, " \t")
+	if trimmedCurrent == "" || strings.HasSuffix(trimmedCurrent, "\n") {
+		return delta
+	}
+	trimmedDelta := strings.TrimLeft(delta, " \t")
+	if trimmedDelta == "" || trimmedDelta != delta {
+		return delta
+	}
+	if !shouldInsertSentenceBoundarySpace(trimmedCurrent, trimmedDelta) {
+		return delta
+	}
+	return " " + delta
+}
+
 func startsLikelyMarkdownBlock(s string) bool {
 	switch {
 	case strings.HasPrefix(s, "#"),
@@ -61,4 +90,41 @@ func startsLikelyMarkdownBlock(s string) bool {
 	}
 	after := rest[idx+2:]
 	return strings.HasPrefix(after, "\n") || strings.HasPrefix(after, "\r\n")
+}
+
+func shouldInsertSentenceBoundarySpace(current, delta string) bool {
+	last, ok := lastRune(current)
+	if !ok || !isSentenceBoundaryRune(last) {
+		return false
+	}
+	first, ok := firstRune(delta)
+	if !ok {
+		return false
+	}
+	return unicode.IsUpper(first) || unicode.IsDigit(first)
+}
+
+func isSentenceBoundaryRune(r rune) bool {
+	switch r {
+	case '.', '!', '?', ':':
+		return true
+	default:
+		return false
+	}
+}
+
+func firstRune(s string) (rune, bool) {
+	r, _ := utf8.DecodeRuneInString(s)
+	if r == utf8.RuneError && s == "" {
+		return 0, false
+	}
+	return r, true
+}
+
+func lastRune(s string) (rune, bool) {
+	r, _ := utf8.DecodeLastRuneInString(s)
+	if r == utf8.RuneError && s == "" {
+		return 0, false
+	}
+	return r, true
 }

--- a/pkg/steps/ai/streamhelpers/reasoning_markdown_test.go
+++ b/pkg/steps/ai/streamhelpers/reasoning_markdown_test.go
@@ -51,3 +51,33 @@ func TestNormalizeReasoningDelta(t *testing.T) {
 		}
 	})
 }
+
+func TestNormalizeReasoningSummaryDelta(t *testing.T) {
+	t.Run("sentence boundary gets space", func(t *testing.T) {
+		got := NormalizeReasoningSummaryDelta("A prior category.", "Creating an analysis plan")
+		if got != " Creating an analysis plan" {
+			t.Fatalf("expected sentence boundary space, got %q", got)
+		}
+	})
+
+	t.Run("existing leading whitespace is preserved", func(t *testing.T) {
+		got := NormalizeReasoningSummaryDelta("A prior category.", " Creating an analysis plan")
+		if got != " Creating an analysis plan" {
+			t.Fatalf("expected unchanged delta when leading space already present, got %q", got)
+		}
+	})
+
+	t.Run("markdown heading still gets paragraph break", func(t *testing.T) {
+		got := NormalizeReasoningSummaryDelta("Some thought.", "**Crafting a response**\n\nMore text.")
+		if got != "\n\n**Crafting a response**\n\nMore text." {
+			t.Fatalf("expected paragraph break before bold heading, got %q", got)
+		}
+	})
+
+	t.Run("lowercase continuation stays unchanged", func(t *testing.T) {
+		got := NormalizeReasoningSummaryDelta("Some thought.", "more detail")
+		if got != "more detail" {
+			t.Fatalf("expected unchanged lowercase continuation, got %q", got)
+		}
+	})
+}

--- a/pkg/steps/ai/streamhelpers/reasoning_markdown_test.go
+++ b/pkg/steps/ai/streamhelpers/reasoning_markdown_test.go
@@ -80,4 +80,18 @@ func TestNormalizeReasoningSummaryDelta(t *testing.T) {
 			t.Fatalf("expected unchanged lowercase continuation, got %q", got)
 		}
 	})
+
+	t.Run("digit continuation stays unchanged", func(t *testing.T) {
+		got := NormalizeReasoningSummaryDelta("v3.", "14")
+		if got != "14" {
+			t.Fatalf("expected unchanged digit continuation, got %q", got)
+		}
+	})
+
+	t.Run("section digit continuation stays unchanged", func(t *testing.T) {
+		got := NormalizeReasoningSummaryDelta("Section 2.", "1")
+		if got != "1" {
+			t.Fatalf("expected unchanged digit continuation, got %q", got)
+		}
+	})
 }


### PR DESCRIPTION
This change addresses a formatting issue in streamed AI reasoning summaries, where
text chunks (deltas) were not being joined correctly, leading to malformed
markdown.

- A new helper function, `NormalizeReasoningSummaryDelta`, is introduced to
  intelligently "glue" text chunks together.
- This function inspects the end of the existing buffer and the start of the new
  delta to ensure a newline is inserted where necessary, preserving the
  markdown structure.