### PR TITLE
warn on common URL mistakes

### DIFF
--- a/pkg/steps/ai/openai/chat_stream.go
+++ b/pkg/steps/ai/openai/chat_stream.go
@@ -8,15 +8,18 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/go-go-golems/geppetto/pkg/security"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
 	ai_types "github.com/go-go-golems/geppetto/pkg/steps/ai/types"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
 
 type chatStreamConfig struct {
+	baseURL    string
 	endpoint   string
 	apiKey     string
 	httpClient *http.Client
@@ -72,6 +75,7 @@ func resolveChatStreamConfig(
 		return chatStreamConfig{}, err
 	}
 	return chatStreamConfig{
+		baseURL:    baseURL,
 		endpoint:   endpoint,
 		apiKey:     apiKey,
 		httpClient: httpClient,
@@ -104,16 +108,67 @@ func openChatCompletionStream(
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		defer resp.Body.Close()
 		raw, _ := io.ReadAll(resp.Body)
-		if len(raw) == 0 {
-			return nil, fmt.Errorf("chat completions error: status=%d", resp.StatusCode)
+		hint := chatCompletionEndpointHint(resp.StatusCode, cfg)
+		if hint != "" {
+			log.Warn().
+				Int("status", resp.StatusCode).
+				Str("base_url", cfg.baseURL).
+				Str("endpoint", cfg.endpoint).
+				Msg("OpenAI-compatible chat completions request failed with suspicious base URL")
 		}
-		return nil, fmt.Errorf("chat completions error: status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(raw)))
+		if len(raw) == 0 {
+			return nil, fmt.Errorf("chat completions error: status=%d%s", resp.StatusCode, hint)
+		}
+		return nil, fmt.Errorf("chat completions error: status=%d body=%s%s", resp.StatusCode, strings.TrimSpace(string(raw)), hint)
 	}
 
 	return &chatCompletionStream{
 		resp:   resp,
 		reader: bufio.NewReader(resp.Body),
 	}, nil
+}
+
+func chatCompletionEndpointHint(statusCode int, cfg chatStreamConfig) string {
+	if statusCode != http.StatusNotFound {
+		return ""
+	}
+	reason, ok := suspiciousChatCompletionBaseURLReason(cfg.baseURL)
+	if !ok {
+		return ""
+	}
+	endpoint := cfg.endpoint
+	if parsed, err := url.Parse(endpoint); err == nil {
+		endpoint = parsed.Redacted()
+	}
+	return fmt.Sprintf(
+		"; possible OpenAI-compatible base URL misconfiguration: %s; Geppetto appends /chat/completions internally (computed endpoint: %s)",
+		reason,
+		endpoint,
+	)
+}
+
+func suspiciousChatCompletionBaseURLReason(baseURL string) (string, bool) {
+	trimmed := strings.TrimSpace(baseURL)
+	if trimmed == "" {
+		return "", false
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", false
+	}
+	path := strings.TrimRight(strings.ToLower(parsed.EscapedPath()), "/")
+	if path == "" || path == "/" {
+		return "", false
+	}
+	if strings.Contains(path, "/chat/completion") {
+		return fmt.Sprintf("configured base URL path %q already looks like a chat completions endpoint", parsed.EscapedPath()), true
+	}
+	for _, versionPrefix := range []string{"/v1/", "/v2/"} {
+		if strings.HasPrefix(path, versionPrefix) {
+			return fmt.Sprintf("configured base URL path %q has extra path components after %s; expected provider root like https://host%s", parsed.EscapedPath(), strings.TrimSuffix(versionPrefix, "/"), strings.TrimSuffix(versionPrefix, "/")), true
+		}
+	}
+	return "", false
 }
 
 func (s *chatCompletionStream) Close() error {

--- a/pkg/steps/ai/openai/chat_stream_test.go
+++ b/pkg/steps/ai/openai/chat_stream_test.go
@@ -2,9 +2,59 @@ package openai
 
 import (
 	"bufio"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+func TestOpenChatCompletionStream_404HintsWhenBaseURLLooksLikeChatEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	_, err := openChatCompletionStream(t.Context(), chatStreamConfig{
+		baseURL:    "https://pass.wafer.ai/v1/chat/completions",
+		endpoint:   server.URL + "/v1/chat/completions/chat/completions",
+		apiKey:     "test-key",
+		httpClient: server.Client(),
+	}, map[string]any{"model": "test"})
+	if err == nil {
+		t.Fatal("expected 404 error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"status=404",
+		"possible OpenAI-compatible base URL misconfiguration",
+		"already looks like a chat completions endpoint",
+		"Geppetto appends /chat/completions internally",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("expected error to contain %q, got %q", want, msg)
+		}
+	}
+}
+
+func TestSuspiciousChatCompletionBaseURLReason(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{name: "provider root", url: "https://pass.wafer.ai/v1", want: false},
+		{name: "provider root trailing slash", url: "https://pass.wafer.ai/v1/", want: false},
+		{name: "chat completions endpoint", url: "https://pass.wafer.ai/v1/chat/completions", want: true},
+		{name: "extra path after v1", url: "https://example.com/v1/openai", want: true},
+		{name: "rootless provider", url: "https://example.com", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, got := suspiciousChatCompletionBaseURLReason(tt.url)
+			if got != tt.want {
+				t.Fatalf("suspiciousChatCompletionBaseURLReason(%q)=%v, want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestReadSSEFrame_MultilineDataAndEvent(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader(strings.Join([]string{

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/README.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/README.md
@@ -1,0 +1,21 @@
+# Enable thinking mode controls for OpenAI-compatible chat completions
+
+This is the document workspace for ticket OAI-CHAT-THINKING.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket OAI-CHAT-THINKING --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket OAI-CHAT-THINKING --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket OAI-CHAT-THINKING --field Status --value review`

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/changelog.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/changelog.md
@@ -1,0 +1,28 @@
+# Changelog
+
+## 2026-05-03
+
+- Initial workspace created.
+- Added DeepSeek thinking-mode source documentation and redacted Wafer probe evidence.
+- Wrote OpenAI Chat Completions thinking mode analysis and implementation guide.
+- Wrote implementation diary.
+- Updated task list with completed analysis and follow-up implementation tasks.
+
+## 2026-05-03
+
+Completed initial thinking-mode analysis: captured DeepSeek docs, Wafer probe evidence, current code architecture, and implementation guide.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/design-doc/01-openai-chat-completions-thinking-mode-controls-analysis-and-implementation-guide.md — Primary analysis and implementation guide
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md — Chronological implementation diary
+
+
+## 2026-05-03
+
+Validated ticket with docmgr doctor and uploaded implementation guide bundle to reMarkable at /ai/2026/05/03/OAI-CHAT-THINKING.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md — Added validation and reMarkable delivery step
+

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/design-doc/01-openai-chat-completions-thinking-mode-controls-analysis-and-implementation-guide.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/design-doc/01-openai-chat-completions-thinking-mode-controls-analysis-and-implementation-guide.md
@@ -1,0 +1,686 @@
+---
+Title: OpenAI chat completions thinking mode controls analysis and implementation guide
+Ticket: OAI-CHAT-THINKING
+Status: active
+Topics:
+    - llm
+    - openai
+    - inference
+    - streaming
+    - profiles
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: geppetto/pkg/inference/engine/inference_config.go
+      Note: Generic per-turn reasoning effort exists but thinking toggle does not
+    - Path: geppetto/pkg/steps/ai/openai/chat_types.go
+      Note: OpenAI Chat Completions request type currently lacks thinking and reasoning_effort fields
+    - Path: geppetto/pkg/steps/ai/openai/engine_openai.go
+      Note: Streaming path already emits thinking/reasoning events from reasoning_content deltas
+    - Path: geppetto/pkg/steps/ai/openai/helpers.go
+      Note: Request builder should wire thinking settings into ChatCompletionRequest
+    - Path: geppetto/pkg/steps/ai/settings/openai/chat.yaml
+      Note: Flag schema currently limits reasoning effort to Responses-oriented low/medium/high
+    - Path: geppetto/pkg/steps/ai/settings/openai/settings.go
+      Note: OpenAI settings need thinking toggle and chat-compatible effort semantics
+    - Path: geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/01-deepseek-thinking-mode-defuddle.md
+      Note: DeepSeek thinking mode API source
+    - Path: geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/02-wafer-deepseek-thinking-probe-redacted.md
+      Note: Live Wafer request-shape evidence
+ExternalSources:
+    - https://api-docs.deepseek.com/guides/thinking_mode
+Summary: Design and implementation guide for adding DeepSeek-style thinking controls to Geppetto's OpenAI Chat Completions path.
+LastUpdated: 2026-05-03T12:05:00-04:00
+WhatFor: Use when implementing provider-native thinking controls for OpenAI-compatible chat-completions models such as Wafer DeepSeek-V4-Pro.
+WhenToUse: Use before modifying OpenAI chat request structs, OpenAI settings, profile schema docs, and tests.
+---
+
+
+
+
+
+
+
+
+
+# OpenAI chat completions thinking mode controls analysis and implementation guide
+
+## Executive summary
+
+Geppetto already parses and streams `reasoning_content` from OpenAI-compatible Chat Completions responses, so DeepSeek/Wafer thinking output can be displayed once the provider emits it. The missing piece is request-side configuration: the OpenAI Chat Completions request type currently has no `thinking` field and does not send `reasoning_effort` on the chat-completions path.
+
+DeepSeek's current OpenAI-format thinking contract is:
+
+```json
+{
+  "thinking": {"type": "enabled"},
+  "reasoning_effort": "high"
+}
+```
+
+or for maximum effort:
+
+```json
+{
+  "thinking": {"type": "enabled"},
+  "reasoning_effort": "max"
+}
+```
+
+or for fast/no-thinking mode:
+
+```json
+{
+  "thinking": {"type": "disabled"}
+}
+```
+
+A live Wafer probe confirmed that `DeepSeek-V4-Pro` accepts these fields on `https://pass.wafer.ai/v1/chat/completions`.
+
+The recommended implementation is to add provider-agnostic-but-OpenAI-chat-scoped settings under `inference_settings.openai`, extend `ChatCompletionRequest`, and wire both profile defaults and per-turn overrides into `MakeCompletionRequestFromTurn`.
+
+## Problem statement and scope
+
+Users need to control thinking mode for OpenAI-compatible Chat Completions providers, especially Wafer-hosted DeepSeek V4. Today, profiles can choose the provider and model, and the engine can stream `reasoning_content`, but there is no supported profile field or CLI flag that emits DeepSeek's Chat Completions thinking controls.
+
+In scope:
+
+1. Add profile/flag settings for OpenAI Chat Completions thinking toggle and effort.
+2. Add JSON request fields for `thinking` and `reasoning_effort` on the OpenAI chat path.
+3. Preserve existing Responses API reasoning behavior.
+4. Add tests for request JSON generation and streaming reasoning output compatibility.
+5. Document profile examples for Wafer/DeepSeek V4.
+
+Out of scope:
+
+1. Implementing the feature in this document. This is an implementation guide.
+2. Changing OpenAI Responses request semantics.
+3. Forcing all providers to support `thinking`; the feature should be opt-in and should omit fields when unset.
+
+## Source evidence
+
+### DeepSeek docs
+
+The Defuddle-extracted source is stored at:
+
+- `sources/01-deepseek-thinking-mode-defuddle.md`
+
+Key facts from the source:
+
+- OpenAI-format thinking toggle:
+
+```json
+{"thinking": {"type": "enabled/disabled"}}
+```
+
+- OpenAI-format thinking effort:
+
+```json
+{"reasoning_effort": "high/max"}
+```
+
+- Defaults/mapping:
+  - thinking defaults to `enabled`;
+  - regular requests default to `high`;
+  - some complex agent requests may be automatically set to `max`;
+  - `low` and `medium` map to `high`;
+  - `xhigh` maps to `max`.
+
+- DeepSeek says thinking mode does not support `temperature`, `top_p`, `presence_penalty`, or `frequency_penalty`. For compatibility, setting them may not error, but has no effect.
+
+### Wafer live probe
+
+The redacted probe source is stored at:
+
+- `sources/02-wafer-deepseek-thinking-probe-redacted.md`
+
+Observed behavior:
+
+1. `thinking.type=disabled` returned HTTP 200 with normal `message.content` and `reasoning_content: null`.
+2. `thinking.type=enabled`, `reasoning_effort=high` returned HTTP 200 with `reasoning_content`.
+3. `thinking.type=enabled`, `reasoning_effort=max` returned HTTP 200 with `reasoning_content`.
+
+This confirms that Wafer's OpenAI-compatible endpoint accepts the DeepSeek request contract.
+
+## Current-state architecture
+
+### OpenAI Chat Completions request type lacks thinking fields
+
+`geppetto/pkg/steps/ai/openai/chat_types.go` defines `ChatCompletionRequest`.
+
+Line evidence:
+
+- `chat_types.go:13-32` contains model, messages, max token fields, sampling fields, stream options, tool fields, and response format.
+- There is currently no `Thinking` field.
+- There is currently no `ReasoningEffort` field on the chat-completions request.
+
+Current shape excerpt:
+
+```go
+type ChatCompletionRequest struct {
+    Model               string
+    Messages            []ChatCompletionMessage
+    MaxTokens           int
+    MaxCompletionTokens int
+    Temperature         float32
+    TopP                float32
+    // ...
+    ParallelToolCalls   *bool
+}
+```
+
+### OpenAI Chat Completions request builder already centralizes request fields
+
+`geppetto/pkg/steps/ai/openai/helpers.go` builds the request in `MakeCompletionRequestFromTurn`.
+
+Line evidence:
+
+- `helpers.go:360-368` reads OpenAI presence/frequency penalties.
+- `helpers.go:370-378` sanitizes some settings for models recognized by `isReasoningModel`.
+- `helpers.go:432-446` constructs `ChatCompletionRequest`.
+- `helpers.go:448-470` applies structured output.
+
+This is the correct place to wire profile-default thinking controls into the request.
+
+### The OpenAI chat stream decoder already handles reasoning output
+
+`geppetto/pkg/steps/ai/openai/engine_openai.go` consumes normalized stream events.
+
+Line evidence:
+
+- `engine_openai.go:273-280` checks `response.DeltaReasoning` and emits reasoning/thinking events.
+
+`geppetto/pkg/steps/ai/openai/chat_stream.go` normalizes both `reasoning` and `reasoning_content` deltas. That means request-side controls should unlock existing output handling.
+
+### Existing OpenAI settings have Responses-oriented reasoning fields
+
+`geppetto/pkg/steps/ai/settings/openai/settings.go` already has:
+
+```go
+ReasoningEffort *string `yaml:"reasoning_effort,omitempty" glazed:"openai-reasoning-effort"`
+ReasoningSummary *string `yaml:"reasoning_summary,omitempty" glazed:"openai-reasoning-summary"`
+```
+
+Line evidence:
+
+- `settings.go:21-30` defines reasoning-related OpenAI settings.
+- `chat.yaml:32-39` exposes `openai-reasoning-effort` as a choice of `low|medium|high` and describes it as "for Responses API models".
+
+The problem is not that no reasoning setting exists. The problem is that the existing setting is Responses-oriented, does not allow `max`, and is only wired to `openai_responses` request construction.
+
+### OpenAI Responses already maps reasoning effort
+
+`geppetto/pkg/steps/ai/openai_responses/helpers.go` applies `s.OpenAI.ReasoningEffort` and `InferenceConfig.ReasoningEffort` to `req.Reasoning.Effort`.
+
+Line evidence:
+
+- `openai_responses/helpers.go:141-146` maps `s.OpenAI.ReasoningEffort`.
+- `openai_responses/helpers.go:186-190` maps per-turn `InferenceConfig.ReasoningEffort`.
+
+This path should continue to work and should not be broken by Chat Completions support.
+
+### InferenceConfig has generic reasoning effort but no thinking toggle
+
+`geppetto/pkg/inference/engine/inference_config.go` contains `ReasoningEffort`, but no thinking toggle.
+
+Line evidence:
+
+- `inference_config.go:19-21` defines `ReasoningEffort` as `low`, `medium`, `high` for OpenAI Responses.
+- There is no `ThinkingType`, `ThinkingEnabled`, or equivalent field.
+
+## Gap analysis
+
+### Gap 1: no request JSON fields
+
+The chat-completions path cannot emit this JSON today:
+
+```json
+"thinking": {"type": "enabled"},
+"reasoning_effort": "max"
+```
+
+Even if a profile contains fields, the request struct cannot marshal them.
+
+### Gap 2: no profile setting for thinking toggle
+
+There is no `openai-thinking-type` or YAML field such as:
+
+```yaml
+openai:
+  thinking_type: enabled
+```
+
+### Gap 3: existing reasoning effort choices omit DeepSeek `max`
+
+DeepSeek supports `high|max`. Geppetto's `openai-reasoning-effort` and `inference-reasoning-effort` choices currently focus on `low|medium|high`.
+
+For compatibility, DeepSeek maps `low|medium` to `high` and `xhigh` to `max`, but a first-class implementation should allow `max`.
+
+### Gap 4: thinking-mode sampling sanitization is not tied to provider setting
+
+DeepSeek docs say thinking mode ignores `temperature`, `top_p`, `presence_penalty`, and `frequency_penalty`. Current `helpers.go` only zeroes these for `isReasoningModel(engine)`. DeepSeek V4 model names may or may not be included in that heuristic. The implementation should explicitly sanitize when `thinking.type=enabled` for known DeepSeek/Wafer-style chat thinking requests, or at least document that providers may ignore those fields.
+
+### Gap 5: multi-turn tool-call reasoning-content replay needs attention
+
+DeepSeek docs state that if a thinking-mode assistant turn performed a tool call, `reasoning_content` must be passed back in subsequent requests. The current turn/message model stores reasoning text as blocks, and tool calls are stored separately. The implementation should verify whether existing message reconstruction can preserve `reasoning_content` in assistant messages when tool calls are involved.
+
+This can be a phase-2 task if basic single-turn and non-tool multi-turn support is needed first.
+
+## Proposed settings contract
+
+### Add OpenAI chat thinking settings
+
+Extend `geppetto/pkg/steps/ai/settings/openai/settings.go`:
+
+```go
+type Settings struct {
+    // existing fields...
+
+    // ThinkingType controls provider-native OpenAI Chat Completions thinking mode.
+    // Known values: "", "enabled", "disabled".
+    ThinkingType *string `yaml:"thinking_type,omitempty" glazed:"openai-thinking-type"`
+
+    // ReasoningEffort applies to providers that accept Chat Completions
+    // reasoning_effort. OpenAI Responses also uses this setting.
+    // Known values should include low, medium, high, max, xhigh.
+    ReasoningEffort *string `yaml:"reasoning_effort,omitempty" glazed:"openai-reasoning-effort"`
+}
+```
+
+Add to `chat.yaml`:
+
+```yaml
+- name: openai-thinking-type
+  type: choice
+  choices:
+    - ""
+    - enabled
+    - disabled
+  help: Provider-native OpenAI Chat Completions thinking toggle; omit for providers that do not support it.
+  default: ""
+
+- name: openai-reasoning-effort
+  type: choice
+  choices:
+    - ""
+    - low
+    - medium
+    - high
+    - max
+    - xhigh
+  help: Reasoning effort for providers that support it. For DeepSeek Chat Completions, high/max are native; low/medium map to high and xhigh maps to max.
+  default: ""
+```
+
+Important design choice: change the default from `medium` to empty string if possible. Defaults should not emit provider-specific fields to every OpenAI-compatible provider.
+
+If changing the default is too risky for OpenAI Responses behavior, introduce a separate chat-specific setting:
+
+```go
+ChatReasoningEffort *string `yaml:"chat_reasoning_effort,omitempty" glazed:"openai-chat-reasoning-effort"`
+```
+
+and keep existing `ReasoningEffort` for Responses. The tradeoff is more settings but fewer compatibility surprises.
+
+### Optional generic InferenceConfig extension
+
+If per-turn control is required, extend `InferenceConfig`:
+
+```go
+type InferenceConfig struct {
+    // existing fields...
+    ThinkingType *string `json:"thinking_type,omitempty" yaml:"thinking_type,omitempty" glazed:"inference-thinking-type"`
+}
+```
+
+Then resolution order becomes:
+
+1. turn `InferenceConfig.ThinkingType`,
+2. `InferenceSettings.Inference.ThinkingType`,
+3. `InferenceSettings.OpenAI.ThinkingType`,
+4. unset/omit.
+
+This is useful for UI/runtime toggles, but profile-only support can be implemented without it.
+
+## Proposed request contract
+
+Extend `geppetto/pkg/steps/ai/openai/chat_types.go`:
+
+```go
+type ChatCompletionRequest struct {
+    // existing fields...
+    ReasoningEffort string               `json:"reasoning_effort,omitempty"`
+    Thinking        *ChatThinkingControl `json:"thinking,omitempty"`
+}
+
+type ChatThinkingControl struct {
+    Type string `json:"type"`
+}
+```
+
+Use `string` for `ReasoningEffort` to omit cleanly when empty.
+
+## Request-building pseudocode
+
+In `MakeCompletionRequestFromTurn`, after base parameter extraction and before constructing `ChatCompletionRequest`:
+
+```go
+thinkingType := ""
+reasoningEffort := ""
+
+if settings.OpenAI != nil {
+    if settings.OpenAI.ThinkingType != nil {
+        thinkingType = strings.TrimSpace(*settings.OpenAI.ThinkingType)
+    }
+    if settings.OpenAI.ReasoningEffort != nil {
+        reasoningEffort = normalizeChatReasoningEffort(*settings.OpenAI.ReasoningEffort)
+    }
+}
+
+if infCfg := engine.ResolveInferenceConfig(t, settings.Inference); infCfg != nil {
+    if infCfg.ReasoningEffort != nil {
+        reasoningEffort = normalizeChatReasoningEffort(*infCfg.ReasoningEffort)
+    }
+    if infCfg.ThinkingType != nil {
+        thinkingType = strings.TrimSpace(*infCfg.ThinkingType)
+    }
+}
+
+var thinking *ChatThinkingControl
+switch thinkingType {
+case "", "auto":
+    // omit; provider default applies
+case "enabled", "disabled":
+    thinking = &ChatThinkingControl{Type: thinkingType}
+default:
+    return nil, fmt.Errorf("unsupported openai thinking_type %q", thinkingType)
+}
+
+if thinking != nil && thinking.Type == "enabled" {
+    // Optional: sanitize sampling fields, or only warn.
+    if isDeepSeekV4Like(engine) {
+        temperature = 0
+        topP = 0
+        presencePenalty = 0
+        frequencyPenalty = 0
+    }
+}
+```
+
+Then add fields to the request:
+
+```go
+req := ChatCompletionRequest{
+    // existing fields...
+    Thinking: thinking,
+    ReasoningEffort: reasoningEffort,
+}
+```
+
+Suggested normalization for DeepSeek compatibility:
+
+```go
+func normalizeChatReasoningEffort(v string) string {
+    switch strings.ToLower(strings.TrimSpace(v)) {
+    case "", "auto":
+        return ""
+    case "low", "medium":
+        return "high"
+    case "xhigh":
+        return "max"
+    case "high", "max":
+        return strings.ToLower(strings.TrimSpace(v))
+    default:
+        return strings.ToLower(strings.TrimSpace(v)) // or reject strictly
+    }
+}
+```
+
+Strict validation is safer for profiles; permissive pass-through is safer for future providers. The recommended first implementation is strict for `openai-thinking-type` and permissive-but-documented for `reasoning_effort`.
+
+## Profile examples
+
+### Wafer DeepSeek V4 base plus variants
+
+With the provider-base profile layout already used locally:
+
+```yaml
+wafer-base:
+  slug: wafer-base
+  inference_settings:
+    chat:
+      api_type: openai
+    api:
+      api_keys:
+        openai-api-key: ${WAFER_API_KEY}
+      base_urls:
+        openai-base-url: https://pass.wafer.ai/v1
+
+wafer-deepseek-v4-pro:
+  slug: wafer-deepseek-v4-pro
+  stack:
+    - profile_slug: wafer-base
+  inference_settings:
+    chat:
+      engine: DeepSeek-V4-Pro
+    openai:
+      thinking_type: enabled
+      reasoning_effort: high
+
+wafer-deepseek-v4-pro-max:
+  slug: wafer-deepseek-v4-pro-max
+  stack:
+    - profile_slug: wafer-deepseek-v4-pro
+  inference_settings:
+    openai:
+      thinking_type: enabled
+      reasoning_effort: max
+
+wafer-deepseek-v4-pro-fast:
+  slug: wafer-deepseek-v4-pro-fast
+  stack:
+    - profile_slug: wafer-deepseek-v4-pro
+  inference_settings:
+    openai:
+      thinking_type: disabled
+```
+
+### CLI examples
+
+After adding flags:
+
+```bash
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro \
+  pinocchio code professional --openai-thinking-type enabled --openai-reasoning-effort max hello
+```
+
+Fast/no-thinking:
+
+```bash
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro \
+  pinocchio code professional --openai-thinking-type disabled hello
+```
+
+## Implementation phases
+
+### Phase 1: Add settings and request fields
+
+1. Add `ThinkingType` to `openai.Settings`.
+2. Update `openai/chat.yaml` with `openai-thinking-type`.
+3. Decide whether to expand existing `openai-reasoning-effort` choices or add `openai-chat-reasoning-effort`.
+4. Add `ChatThinkingControl` and request fields to `ChatCompletionRequest`.
+5. Run focused settings tests if present:
+
+```bash
+go test ./pkg/steps/ai/settings/openai ./pkg/steps/ai/settings -count=1
+```
+
+### Phase 2: Wire request construction
+
+1. Add helper functions:
+   - `normalizeChatThinkingType(string) (string, error)`
+   - `normalizeChatReasoningEffort(string) string`
+   - optionally `isDeepSeekV4Like(model string) bool`
+2. In `MakeCompletionRequestFromTurn`, resolve settings and per-turn overrides.
+3. Set `req.Thinking` only when configured.
+4. Set `req.ReasoningEffort` only when configured.
+5. Ensure default OpenAI-compatible requests do not gain new provider-specific fields.
+
+### Phase 3: Add tests
+
+Add request JSON tests in `geppetto/pkg/steps/ai/openai`.
+
+Test cases:
+
+1. No thinking settings → request JSON omits `thinking` and `reasoning_effort`.
+2. `thinking_type: disabled` → request JSON includes:
+
+```json
+"thinking": {"type":"disabled"}
+```
+
+3. `thinking_type: enabled`, `reasoning_effort: high` → request JSON includes both fields.
+4. `reasoning_effort: max` is accepted.
+5. `reasoning_effort: low|medium|xhigh` normalization behavior is covered if implemented.
+6. Invalid thinking type returns a clear error.
+
+Example test skeleton:
+
+```go
+func TestMakeCompletionRequestFromTurnAddsDeepSeekThinkingControls(t *testing.T) {
+    settings := testOpenAISettings("DeepSeek-V4-Pro")
+    enabled := "enabled"
+    max := "max"
+    settings.OpenAI.ThinkingType = &enabled
+    settings.OpenAI.ReasoningEffort = &max
+
+    engine, err := NewOpenAIEngine(settings)
+    require.NoError(t, err)
+    req, err := engine.MakeCompletionRequestFromTurn(simpleUserTurn("hello"))
+    require.NoError(t, err)
+
+    require.Equal(t, &ChatThinkingControl{Type: "enabled"}, req.Thinking)
+    require.Equal(t, "max", req.ReasoningEffort)
+}
+```
+
+Add marshal test:
+
+```go
+raw, err := json.Marshal(req)
+require.NoError(t, err)
+require.JSONEq(t, `{"thinking":{"type":"enabled"},"reasoning_effort":"max"}`, extractRelevant(raw))
+```
+
+### Phase 4: Validate against Wafer
+
+After implementation, run safe settings validation:
+
+```bash
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro-max \
+  pinocchio code professional --print-inference-settings --non-interactive hello
+```
+
+Then live validation:
+
+```bash
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro-fast \
+  pinocchio --log-level debug --with-caller code professional --non-interactive "Say hi"
+
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro-max \
+  pinocchio --log-level debug --with-caller code professional --non-interactive "Solve a small logic puzzle"
+```
+
+Expected observations:
+
+- fast profile: mostly `content`, no/low `reasoning_content`;
+- high/max profile: stream includes `reasoning_content` deltas and Geppetto emits thinking events.
+
+### Phase 5: Documentation
+
+Update:
+
+- `geppetto/pkg/doc/topics/06-inference-engines.md`
+- `geppetto/pkg/doc/topics/01-profiles.md` if profile examples are appropriate
+- Pinocchio profile migration docs if user-facing profile examples are maintained there
+
+Include:
+
+- provider compatibility caveat;
+- DeepSeek/Wafer example;
+- warning that thinking mode may ignore sampling parameters;
+- tool-call caveat about passing back `reasoning_content`.
+
+## Risk analysis
+
+### Risk: provider-specific fields sent to providers that reject them
+
+Mitigation: omit `thinking` and `reasoning_effort` by default. Only send when explicitly configured.
+
+### Risk: changing default `openai-reasoning-effort` breaks Responses behavior
+
+Mitigation options:
+
+1. keep existing `openai-reasoning-effort` default for Responses and add separate chat-specific field; or
+2. change default to empty and update Responses code to apply its own default if needed.
+
+The safer first implementation is a new chat-specific field if backward compatibility is a priority.
+
+### Risk: ambiguous semantics of `reasoning_effort` across providers
+
+DeepSeek accepts `high|max`; OpenAI Responses accepts `low|medium|high`; other OpenAI-compatible providers may accept different values or reject the field.
+
+Mitigation: document that this is opt-in provider-native behavior. Do not auto-send for every model.
+
+### Risk: tool-call replay with reasoning content
+
+DeepSeek requires `reasoning_content` replay after tool calls. If Geppetto drops it when reconstructing assistant tool-call messages, multi-turn tool workflows may fail.
+
+Mitigation: add a dedicated tool-call regression after the basic request controls land.
+
+## Acceptance criteria
+
+1. A profile can configure:
+
+```yaml
+openai:
+  thinking_type: enabled
+  reasoning_effort: max
+```
+
+2. The OpenAI Chat Completions request JSON includes:
+
+```json
+"thinking": {"type":"enabled"},
+"reasoning_effort":"max"
+```
+
+3. When fields are unset, existing OpenAI-compatible requests are unchanged.
+4. `thinking_type: disabled` emits `"thinking":{"type":"disabled"}`.
+5. Streaming `reasoning_content` continues to emit Geppetto thinking events.
+6. Focused OpenAI tests pass:
+
+```bash
+go test ./pkg/steps/ai/openai -count=1
+```
+
+7. Settings tests pass:
+
+```bash
+go test ./pkg/steps/ai/settings ./pkg/steps/ai/settings/openai -count=1
+```
+
+8. A live Wafer smoke test confirms DeepSeek V4 accepts the generated fields.
+
+## References
+
+- `sources/01-deepseek-thinking-mode-defuddle.md` — DeepSeek thinking-mode source documentation.
+- `sources/02-wafer-deepseek-thinking-probe-redacted.md` — live Wafer acceptance probe.
+- `geppetto/pkg/steps/ai/openai/chat_types.go:13-32` — current Chat Completions request shape.
+- `geppetto/pkg/steps/ai/openai/helpers.go:432-446` — request construction site.
+- `geppetto/pkg/steps/ai/openai/engine_openai.go:273-280` — existing reasoning delta event publication.
+- `geppetto/pkg/steps/ai/settings/openai/settings.go:21-30` — existing OpenAI reasoning settings.
+- `geppetto/pkg/steps/ai/settings/openai/chat.yaml:32-39` — existing `openai-reasoning-effort` choices.
+- `geppetto/pkg/steps/ai/openai_responses/helpers.go:141-146` — Responses reasoning effort mapping.
+- `geppetto/pkg/inference/engine/inference_config.go:19-21` — generic reasoning effort override.

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/index.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/index.md
@@ -1,0 +1,60 @@
+---
+Title: Enable thinking mode controls for OpenAI-compatible chat completions
+Ticket: OAI-CHAT-THINKING
+Status: active
+Topics:
+    - llm
+    - openai
+    - inference
+    - streaming
+    - profiles
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-05-03T11:57:43.706395772-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Enable thinking mode controls for OpenAI-compatible chat completions
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- llm
+- openai
+- inference
+- streaming
+- profiles
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md
@@ -1,0 +1,415 @@
+---
+Title: Implementation diary
+Ticket: OAI-CHAT-THINKING
+Status: active
+Topics:
+    - llm
+    - openai
+    - inference
+    - streaming
+    - profiles
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: geppetto/pkg/inference/engine/inference_config.go
+      Note: Generic per-turn reasoning effort exists but thinking toggle does not
+    - Path: geppetto/pkg/steps/ai/openai/chat_types.go
+      Note: OpenAI Chat Completions request type currently lacks thinking and reasoning_effort fields
+    - Path: geppetto/pkg/steps/ai/openai/engine_openai.go
+      Note: Streaming path already emits thinking/reasoning events from reasoning_content deltas
+    - Path: geppetto/pkg/steps/ai/openai/helpers.go
+      Note: Request builder should wire thinking settings into ChatCompletionRequest
+    - Path: geppetto/pkg/steps/ai/settings/openai/chat.yaml
+      Note: Flag schema currently limits reasoning effort to Responses-oriented low/medium/high
+    - Path: geppetto/pkg/steps/ai/settings/openai/settings.go
+      Note: OpenAI settings need thinking toggle and chat-compatible effort semantics
+    - Path: geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/design-doc/01-openai-chat-completions-thinking-mode-controls-analysis-and-implementation-guide.md
+    - Path: geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/01-deepseek-thinking-mode-defuddle.md
+      Note: DeepSeek thinking mode API source
+    - Path: geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/02-wafer-deepseek-thinking-probe-redacted.md
+      Note: Live Wafer request-shape evidence
+ExternalSources:
+    - https://api-docs.deepseek.com/guides/thinking_mode
+Summary: Diary for the OAI-CHAT-THINKING analysis and implementation guide.
+LastUpdated: 2026-05-03T12:05:00-04:00
+WhatFor: Records the investigation steps for enabling thinking controls in the OpenAI Chat Completions path.
+WhenToUse: Use when continuing implementation or reviewing evidence and decisions.
+---
+
+
+
+
+
+
+
+
+
+# Diary
+
+## Goal
+
+This diary records the analysis work for adding provider-native thinking mode controls to Geppetto's OpenAI-compatible Chat Completions path.
+
+## Step 1: Create the ticket and define the scope
+
+I created a new docmgr ticket dedicated to the OpenAI Chat Completions thinking-mode work. This keeps it separate from the earlier Wafer 404 diagnosis, because this is now a feature design: request-side controls for DeepSeek-style thinking mode.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Create a new ticket to enable handling of thinking modes in the openai completions api. Create a detailed implementation guide and analysis document and store it in the ticket and upload it to remarkable. Keep a diary as you work."
+
+**Assistant interpretation:** Create a docmgr ticket, analyze the current code and provider docs, write an implementation guide and diary, validate docmgr, and upload the final bundle to reMarkable.
+
+**Inferred user intent:** The user wants a durable engineering plan for adding `thinking` and `reasoning_effort` support to the OpenAI Chat Completions path used by Wafer/DeepSeek V4.
+
+**Commit (code):** N/A — this step created documentation only.
+
+### What I did
+
+- Ran:
+
+```bash
+docmgr ticket create-ticket --ticket OAI-CHAT-THINKING --title "Enable thinking mode controls for OpenAI-compatible chat completions" --topics llm,openai,inference,streaming,profiles
+
+docmgr doc add --ticket OAI-CHAT-THINKING --doc-type design-doc --title "OpenAI chat completions thinking mode controls analysis and implementation guide"
+docmgr doc add --ticket OAI-CHAT-THINKING --doc-type reference --title "Implementation diary"
+```
+
+### Why
+
+- The requested work has enough scope to deserve its own ticket: settings schema, request JSON, tests, docs, and provider-specific compatibility caveats.
+
+### What worked
+
+- The ticket workspace was created at:
+
+```text
+geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/
+```
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- The feature should be framed as OpenAI-compatible Chat Completions support, not OpenAI Responses support, because Responses already has a separate reasoning path.
+
+### What was tricky to build
+
+- The earlier Wafer ticket already contained some DeepSeek source evidence. I needed to reuse the evidence but keep this new ticket self-contained.
+
+### What warrants a second pair of eyes
+
+- Confirm the ticket ID/name is the desired convention before implementation starts.
+
+### What should be done in the future
+
+- Implement the guide in a follow-up coding pass.
+
+### Code review instructions
+
+- Start at the design doc's Executive summary and Gap analysis.
+
+### Technical details
+
+- Ticket path:
+  - `geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/`
+
+## Step 2: Capture external source evidence and provider behavior
+
+I stored DeepSeek's thinking-mode documentation in the ticket sources folder and added a redacted Wafer probe summary. This gives the implementation plan a concrete API contract instead of relying on memory from the earlier investigation.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Preserve the authoritative source and live provider observations that justify the implementation.
+
+**Inferred user intent:** Make the design reviewable and reproducible.
+
+**Commit (code):** N/A.
+
+### What I did
+
+- Copied the Defuddle extract of DeepSeek's thinking-mode docs into this ticket:
+  - `sources/01-deepseek-thinking-mode-defuddle.md`
+- Added redacted live Wafer probe observations:
+  - `sources/02-wafer-deepseek-thinking-probe-redacted.md`
+
+### Why
+
+- DeepSeek documents the OpenAI-format contract as:
+
+```json
+{"thinking": {"type": "enabled/disabled"}}
+{"reasoning_effort": "high/max"}
+```
+
+- Wafer live probes confirmed the endpoint accepts these fields for `DeepSeek-V4-Pro`.
+
+### What worked
+
+- The source docs clearly state that thinking defaults to enabled and high effort, with `max` available.
+- The live probe showed:
+  - disabled thinking returns normal content;
+  - enabled thinking returns `reasoning_content`.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- `low` and `medium` are compatibility aliases that DeepSeek maps to `high`; `xhigh` maps to `max`.
+- Thinking mode may ignore sampling controls such as temperature/top_p.
+
+### What was tricky to build
+
+- The probe used a real configured Wafer API key. I stored only redacted request shapes and observations, never the key.
+
+### What warrants a second pair of eyes
+
+- Confirm whether Wafer has any provider-specific deviations from DeepSeek's official API beyond the observed acceptance of these fields.
+
+### What should be done in the future
+
+- Add an automated integration smoke test only if a safe credential-gated test pattern exists.
+
+### Code review instructions
+
+- Review:
+  - `sources/01-deepseek-thinking-mode-defuddle.md`
+  - `sources/02-wafer-deepseek-thinking-probe-redacted.md`
+
+### Technical details
+
+- Direct live request shapes used `stream: false` and low `max_tokens` to make the effect visible quickly.
+
+## Step 3: Inspect the current Geppetto OpenAI chat implementation
+
+I read the OpenAI Chat Completions request type, request builder, stream event handler, OpenAI settings, and Responses reasoning implementation. The key finding is that Geppetto already handles `reasoning_content` on the response side, but cannot currently send the request-side `thinking` controls.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Map the code paths that need to change and distinguish Chat Completions from Responses.
+
+**Inferred user intent:** Produce a file-level implementation guide an engineer can follow without rediscovering the architecture.
+
+**Commit (code):** N/A.
+
+### What I did
+
+- Captured line evidence from:
+  - `geppetto/pkg/steps/ai/openai/chat_types.go`
+  - `geppetto/pkg/steps/ai/openai/helpers.go`
+  - `geppetto/pkg/steps/ai/openai/engine_openai.go`
+  - `geppetto/pkg/steps/ai/settings/openai/settings.go`
+  - `geppetto/pkg/steps/ai/settings/openai/chat.yaml`
+  - `geppetto/pkg/steps/ai/openai_responses/helpers.go`
+  - `geppetto/pkg/inference/engine/inference_config.go`
+
+### Why
+
+- The feature crosses settings, request construction, and runtime event handling.
+
+### What worked
+
+- The missing request fields are obvious in `ChatCompletionRequest`.
+- The request construction point is centralized in `MakeCompletionRequestFromTurn`.
+- Existing streaming reasoning events mean output rendering should mostly already work once request controls are sent.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- Existing `openai-reasoning-effort` is documented as Responses-oriented and only allows `low|medium|high`.
+- OpenAI Responses already maps reasoning effort from both settings and per-turn inference config.
+- Chat Completions needs either a new chat-specific setting or careful expansion of the existing setting.
+
+### What was tricky to build
+
+- The same words — OpenAI, reasoning, thinking — mean different request shapes in Responses versus Chat Completions. The design doc explicitly separates these paths to avoid accidentally breaking Responses.
+
+### What warrants a second pair of eyes
+
+- Decide whether to reuse `openai-reasoning-effort` for Chat Completions or introduce `openai-chat-reasoning-effort` to avoid compatibility surprises.
+
+### What should be done in the future
+
+- Add tests that prove no provider-specific thinking fields are emitted when profiles do not request them.
+
+### Code review instructions
+
+- Start with:
+  - `chat_types.go:13-32`
+  - `helpers.go:432-446`
+  - `engine_openai.go:273-280`
+
+### Technical details
+
+- Response-side reasoning events already use `response.DeltaReasoning`, which is normalized from `reasoning` or `reasoning_content` stream deltas.
+
+## Step 4: Write the implementation guide
+
+I wrote the primary design document with the proposed settings contract, request JSON contract, pseudocode, implementation phases, tests, risks, and profile examples.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Turn the evidence and code reading into a detailed implementation plan.
+
+**Inferred user intent:** Make it straightforward to implement the feature in a later coding pass.
+
+**Commit (code):** N/A.
+
+### What I did
+
+- Wrote:
+  - `design-doc/01-openai-chat-completions-thinking-mode-controls-analysis-and-implementation-guide.md`
+
+### Why
+
+- The implementation needs clear decisions around schema naming, default behavior, and compatibility with existing OpenAI Responses settings.
+
+### What worked
+
+- The document now has:
+  - executive summary;
+  - source evidence;
+  - current-state architecture;
+  - gap analysis;
+  - proposed API/settings contract;
+  - implementation phases;
+  - acceptance criteria.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- The safest design is opt-in: omit `thinking` and `reasoning_effort` unless a profile or turn explicitly requests them.
+
+### What was tricky to build
+
+- `openai-reasoning-effort` already exists, so the design had to present two options: expand/reuse it, or add a separate chat-specific field. The guide recommends being careful about defaults.
+
+### What warrants a second pair of eyes
+
+- Review whether the project prefers fewer settings with overloaded semantics or separate settings per API family.
+
+### What should be done in the future
+
+- Implement Phase 1 and Phase 2, then validate against Wafer.
+
+### Code review instructions
+
+- Read the Proposed settings contract and Acceptance criteria sections before coding.
+
+### Technical details
+
+- Main guide:
+  - `geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/design-doc/01-openai-chat-completions-thinking-mode-controls-analysis-and-implementation-guide.md`
+
+## Step 5: Validate docmgr and upload to reMarkable
+
+I validated the ticket with docmgr and uploaded the final bundle to reMarkable. The bundle includes the implementation guide, diary, DeepSeek source extract, and redacted Wafer probe.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Complete the requested documentation delivery workflow.
+
+**Inferred user intent:** Make the implementation guide available on reMarkable for review.
+
+**Commit (code):** N/A.
+
+### What I did
+
+- Ran:
+
+```bash
+docmgr doctor --ticket OAI-CHAT-THINKING --stale-after 30
+```
+
+- Ran reMarkable checks and upload:
+
+```bash
+remarquee status
+remarquee cloud account --non-interactive
+remarquee upload bundle --dry-run ... --remote-dir /ai/2026/05/03/OAI-CHAT-THINKING
+remarquee upload bundle ... --remote-dir /ai/2026/05/03/OAI-CHAT-THINKING
+remarquee cloud ls /ai/2026/05/03/OAI-CHAT-THINKING --long --non-interactive
+```
+
+### Why
+
+- The ticket should be valid before handoff, and the user specifically requested reMarkable upload.
+
+### What worked
+
+- Doctor passed:
+
+```text
+## Doctor Report (1 findings)
+
+### OAI-CHAT-THINKING
+
+- ✅ All checks passed
+```
+
+- reMarkable upload succeeded:
+
+```text
+OK: uploaded OAI-CHAT-THINKING implementation guide.pdf -> /ai/2026/05/03/OAI-CHAT-THINKING
+```
+
+- Verification listing showed:
+
+```text
+[f]	OAI-CHAT-THINKING implementation guide
+```
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- The ticket had enough frontmatter/vocabulary coverage to pass doctor without remediation.
+
+### What was tricky to build
+
+- The bundle includes long source extracts. If the PDF is too long for review, a shorter bundle containing only the design guide and diary could be uploaded later.
+
+### What warrants a second pair of eyes
+
+- Verify PDF readability on the reMarkable, especially code blocks and long JSON examples.
+
+### What should be done in the future
+
+- Implement the feature in code and update the same ticket with implementation results.
+
+### Code review instructions
+
+- Validate with:
+
+```bash
+docmgr doctor --ticket OAI-CHAT-THINKING --stale-after 30
+remarquee cloud ls /ai/2026/05/03/OAI-CHAT-THINKING --long --non-interactive
+```
+
+### Technical details
+
+- Remote directory:
+  - `/ai/2026/05/03/OAI-CHAT-THINKING`
+- Uploaded bundle:
+  - `OAI-CHAT-THINKING implementation guide`

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/01-deepseek-thinking-mode-defuddle.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/01-deepseek-thinking-mode-defuddle.md
@@ -1,0 +1,266 @@
+---
+Title: DeepSeek Thinking Mode documentation (Defuddle extract)
+Ticket: OAI-CHAT-THINKING
+Status: active
+Topics:
+    - llm
+    - openai
+    - wafer-ai
+DocType: source
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/geppetto/pkg/steps/ai/openai/chat_types.go
+      Note: Current OpenAI ChatCompletionRequest shape lacks DeepSeek thinking/reasoning_effort fields
+ExternalSources:
+    - https://api-docs.deepseek.com/guides/thinking_mode
+Summary: Defuddle extract of DeepSeek's thinking mode docs, including OpenAI-format thinking toggle and reasoning_effort parameters.
+LastUpdated: 2026-05-03T11:55:00-04:00
+WhatFor: Source evidence for configuring DeepSeek V4 thinking mode through Wafer/OpenAI-compatible chat completions.
+WhenToUse: Use when implementing or validating DeepSeek V4 thinking toggle and effort settings.
+---
+
+
+# DeepSeek Thinking Mode documentation (Defuddle extract)
+
+Source: https://api-docs.deepseek.com/guides/thinking_mode
+
+## Thinking Mode
+
+The DeepSeek model supports the thinking mode: before outputting the final answer, the model will first output a chain-of-thought reasoning to improve the accuracy of the final response.
+
+## Thinking Mode Toggle and Effort Control
+
+**
+
+<table><tbody><tr><td></td><td>Control Parameter (OpenAI Format)</td><td>Control Parameter (Anthropic Format)</td></tr><tr><td>Thinking Mode Toggle <sup>(1)</sup></td><td colspan="2"><code>{"thinking": {"type": "enabled/disabled"}}</code></td></tr><tr><td>Thinking Effort Control <sup>(2)(3)</sup></td><td><code>{"reasoning_effort": "high/max"}</code></td><td><code>{"output_config": {"effort": "high/max"}}</code></td></tr></tbody></table>
+
+**
+
+(1) The thinking toggle defaults to `enabled`  
+(2) In thinking mode, the default effort is `high` for regular requests; for some complex agent requests (such as Claude Code, OpenCode), effort is automatically set to `max`  
+(3) In thinking mode, for compatibility, `low` and `medium` are mapped to `high`, and `xhigh` is mapped to `max`
+
+When using the OpenAI SDK, you need to pass the `thinking` parameter within `extra_body`:
+
+```python
+response = client.chat.completions.create(
+  model="deepseek-v4-pro",
+  # ...
+  reasoning_effort="high",
+  extra_body={"thinking": {"type": "enabled"}}
+)
+```
+
+## Input and Output Parameters
+
+Thinking mode does not support the `temperature`, `top_p`, `presence_penalty`, or `frequency_penalty` parameters. Please note that, for compatibility with existing software, setting these parameters will not trigger an error but will also have no effect.
+
+In thinking mode, the chain-of-thought content is returned via the `reasoning_content` parameter, at the same level as `content`. When concatenating subsequent turns, you can selectively return `reasoning_content` to the API:
+
+- Between two `user` messages, if the model **did not perform a tool call**, the intermediate `assistant` 's `reasoning_content` does not need to participate in the context concatenation. If passed to the API in subsequent turns, it will be ignored. See [Multi-turn Conversation](https://api-docs.deepseek.com/guides/thinking_mode#multi-turn-conversation) for details.
+- Between two `user` messages, if the model **performed a tool call**, the intermediate `assistant` 's `reasoning_content` must participate in the context concatenation and must be **passed back to the API** in all subsequent user interaction turns. See [Tool Calls](https://api-docs.deepseek.com/guides/thinking_mode#tool-calls) for details.
+
+## Multi-turn Conversation
+
+In each turn of the conversation, the model outputs the CoT (`reasoning_content`) and the final answer (`content`). If there is no tool call, the CoT content from previous turns will not be concatenated into the context in the next turn, as illustrated in the following diagram:
+
+![](https://api-docs.deepseek.com/img/deepseek_r1_multiround_example_en.jpeg)
+
+### Sample Code
+
+The following code, using Python as an example, demonstrates how to access the CoT and the final answer, as well as how to concatenate context in multi-turn conversations.
+
+- NoStreaming
+- Streaming
+
+```python
+from openai import OpenAI
+client = OpenAI(api_key="<DeepSeek API Key>", base_url="https://api.deepseek.com")
+
+# Turn 1
+messages = [{"role": "user", "content": "9.11 and 9.8, which is greater?"}]
+response = client.chat.completions.create(
+    model="deepseek-v4-pro",
+    messages=messages,
+    reasoning_effort="high"
+    extra_body={"thinking": {"type": "enabled"}},
+)
+
+reasoning_content = response.choices[0].message.reasoning_content
+content = response.choices[0].message.content
+
+# Turn 2
+# The reasoning_content will be ignored by the API
+messages.append(response.choices[0].message)
+messages.append({'role': 'user', 'content': "How many Rs are there in the word 'strawberry'?"})
+response = client.chat.completions.create(
+    model="deepseek-v4-pro",
+    messages=messages,
+    reasoning_effort="high"
+    extra_body={"thinking": {"type": "enabled"}},
+)
+# ...
+```
+
+## Tool Calls
+
+The DeepSeek model's thinking mode supports tool calls. Before outputting the final answer, the model can perform multiple turns of reasoning and tool calls to improve the quality of the response. The calling pattern is illustrated below:
+
+![](https://api-docs.deepseek.com/img/thinking_with_tools_en.jpg)
+
+Please note that, unlike turns in thinking mode that do not involve tool calls, for turns that do perform tool calls, the `reasoning_content` must be fully passed back to the API in all subsequent requests.
+
+If your code does not correctly pass back `reasoning_content`, the API will return a 400 error. Please refer to the sample code below for the correct approach.
+
+### Sample Code
+
+Below is a simple sample code for tool calls in thinking mode:
+
+```python
+import os
+import json
+from openai import OpenAI
+from datetime import datetime
+
+# The definition of the tools
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_date",
+            "description": "Get the current date",
+            "parameters": { "type": "object", "properties": {} },
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather of a location, the user should supply the location and date.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": { "type": "string", "description": "The city name" },
+                    "date": { "type": "string", "description": "The date in format YYYY-mm-dd" },
+                },
+                "required": ["location", "date"]
+            },
+        }
+    },
+]
+
+# The mocked version of the tool calls
+def get_date_mock():
+    return datetime.now().strftime("%Y-%m-%d")
+
+def get_weather_mock(location, date):
+    return "Cloudy 7~13°C"
+
+TOOL_CALL_MAP = {
+    "get_date": get_date_mock,
+    "get_weather": get_weather_mock
+}
+
+def run_turn(turn, messages):
+    sub_turn = 1
+    while True:
+        response = client.chat.completions.create(
+            model='deepseek-v4-pro',
+            messages=messages,
+            tools=tools,
+            reasoning_effort="high",
+            extra_body={ "thinking": { "type": "enabled" } },
+        )
+        messages.append(response.choices[0].message)
+        reasoning_content = response.choices[0].message.reasoning_content
+        content = response.choices[0].message.content
+        tool_calls = response.choices[0].message.tool_calls
+        print(f"Turn {turn}.{sub_turn}\n{reasoning_content=}\n{content=}\n{tool_calls=}")
+        # If there is no tool calls, then the model should get a final answer and we need to stop the loop
+        if tool_calls is None:
+            break
+        for tool in tool_calls:
+            tool_function = TOOL_CALL_MAP[tool.function.name]
+            tool_result = tool_function(**json.loads(tool.function.arguments))
+            print(f"tool result for {tool.function.name}: {tool_result}\n")
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tool.id,
+                "content": tool_result,
+            })
+        sub_turn += 1
+    print()
+
+client = OpenAI(
+    api_key=os.environ.get('DEEPSEEK_API_KEY'),
+    base_url=os.environ.get('DEEPSEEK_BASE_URL'),
+)
+
+# The user starts a question
+turn = 1
+messages = [{
+    "role": "user",
+    "content": "How's the weather in Hangzhou Tomorrow"
+}]
+run_turn(turn, messages)
+
+# The user starts a new question
+turn = 2
+messages.append({
+    "role": "user",
+    "content": "How's the weather in Guangzhou Tomorrow"
+})
+run_turn(turn, messages)
+```
+
+In each sub-request of Turn 1, the `reasoning_content` generated during that turn is sent to the API, allowing the model to continue its previous reasoning. `response.choices[0].message` contains all necessary fields for the `assistant` message, including `content`, `reasoning_content`, and `tool_calls`. For simplicity, you can directly append the message to the end of the messages list using the following code:
+
+```markdown
+messages.append(response.choices[0].message)
+```
+
+This line of code is equivalent to:
+
+```markdown
+messages.append({
+    'role': 'assistant',
+    'content': response.choices[0].message.content,
+    'reasoning_content': response.choices[0].message.reasoning_content,
+    'tool_calls': response.choices[0].message.tool_calls,
+})
+```
+
+Additionally, in the Turn 2 request, we still pass the `reasoning_content` generated in Turn 1 to the API.
+
+The sample output of this code is as follows:
+
+```bash
+Turn 1.1
+reasoning_content="The user is asking about the weather in Hangzhou tomorrow. I need to get tomorrow's date first, then call the weather function."
+content="Let me check tomorrow's weather in Hangzhou for you. First, let me get tomorrow's date."
+tool_calls=[ChatCompletionMessageFunctionToolCall(id='call_00_kw66qNnNto11bSfJVIdlV5Oo', function=Function(arguments='{}', name='get_date'), type='function', index=0)]
+tool result for get_date: 2026-04-19
+
+Turn 1.2
+reasoning_content="Today is 2026-04-19, so tomorrow is 2026-04-20. Now I'll call the weather function for Hangzhou."
+content=''
+tool_calls=[ChatCompletionMessageFunctionToolCall(id='call_00_H2SCW6136vWJGq9SQlBuhVt4', function=Function(arguments='{"location": "Hangzhou", "date": "2026-04-20"}', name='get_weather'), type='function', index=0)]
+tool result for get_weather: Cloudy 7~13°C
+
+Turn 1.3
+reasoning_content='The weather result is in. Let me share this with the user.'
+content="Here's the weather forecast for **Hangzhou tomorrow (April 20, 2026)**:\n\n- 🌤 **Condition:** Cloudy  \n- 🌡 **Temperature:** 7°C ~ 13°C (45°F ~ 55°F)\n\nIt'll be on the cooler side, so you might want to bring a light jacket if you're heading out! Let me know if you need anything else."
+tool_calls=None
+
+Turn 2.1
+reasoning_content='The user is asking about the weather in Guangzhou tomorrow. Today is 2026-04-19, so tomorrow is 2026-04-20. I can directly call the weather function.'
+content=''
+tool_calls=[ChatCompletionMessageFunctionToolCall(id='call_00_8URkLt5NjmNkVKhDmMcNq9Mo', function=Function(arguments='{"location": "Guangzhou", "date": "2026-04-20"}', name='get_weather'), type='function', index=0)]
+tool result for get_weather: Cloudy 7~13°C
+
+Turn 2.2
+reasoning_content='The weather result for Guangzhou is the same as Hangzhou. Let me share this with the user.'
+content="Here's the weather forecast for **Guangzhou tomorrow (April 20, 2026)**:\n\n- 🌤 **Condition:** Cloudy  \n- 🌡 **Temperature:** 7°C ~ 13°C (45°F ~ 55°F)\n\nIt'll be cool and cloudy, so a light jacket would be a good idea if you're going out. Let me know if there's anything else you'd like to know!"
+tool_calls=None
+```

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/02-wafer-deepseek-thinking-probe-redacted.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/02-wafer-deepseek-thinking-probe-redacted.md
@@ -1,0 +1,96 @@
+---
+Title: Wafer DeepSeek V4 thinking parameter probe redacted
+Ticket: OAI-CHAT-THINKING
+Status: active
+Topics:
+    - llm
+    - openai
+    - inference
+DocType: source
+Intent: short-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: "Redacted live Wafer probes showing DeepSeek-V4-Pro accepts OpenAI Chat Completions thinking.type and reasoning_effort fields."
+LastUpdated: 2026-05-03T12:05:00-04:00
+WhatFor: "Provider behavior evidence for implementing chat-completions thinking controls."
+WhenToUse: "Use when validating the request JSON contract against Wafer/DeepSeek V4."
+---
+
+# Wafer DeepSeek V4 thinking parameter probe redacted
+
+Authorization used the locally configured Wafer API key. The key is not stored here.
+
+## Disabled thinking
+
+Request shape:
+
+```json
+{
+  "model": "DeepSeek-V4-Pro",
+  "messages": [{"role": "user", "content": "Say hi"}],
+  "max_tokens": 16,
+  "stream": false,
+  "thinking": {"type": "disabled"}
+}
+```
+
+Observed result:
+
+```text
+HTTP_STATUS:200
+message.content: "Hi there! How can I help you today?"
+message.reasoning_content: null
+```
+
+## Enabled high effort thinking
+
+Request shape:
+
+```json
+{
+  "model": "DeepSeek-V4-Pro",
+  "messages": [{"role": "user", "content": "Say hi"}],
+  "max_tokens": 16,
+  "stream": false,
+  "thinking": {"type": "enabled"},
+  "reasoning_effort": "high"
+}
+```
+
+Observed result:
+
+```text
+HTTP_STATUS:200
+message.content: null
+message.reasoning_content: "We need to respond with ..."
+finish_reason: "length"
+```
+
+The low `max_tokens` intentionally cut off the answer during reasoning, proving the request entered thinking mode.
+
+## Enabled max effort thinking
+
+Request shape:
+
+```json
+{
+  "model": "DeepSeek-V4-Pro",
+  "messages": [{"role": "user", "content": "Say hi"}],
+  "max_tokens": 16,
+  "stream": false,
+  "thinking": {"type": "enabled"},
+  "reasoning_effort": "max"
+}
+```
+
+Observed result:
+
+```text
+HTTP_STATUS:200
+message.content: null
+message.reasoning_content: "We are asked: ..."
+finish_reason: "length"
+```
+
+This confirms Wafer's OpenAI-compatible endpoint accepts both `thinking.type` and `reasoning_effort` for `DeepSeek-V4-Pro`.

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/tasks.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/tasks.md
@@ -1,0 +1,19 @@
+# Tasks
+
+## Completed analysis tasks
+
+- [x] Create docmgr ticket workspace.
+- [x] Add primary design/implementation guide.
+- [x] Add chronological implementation diary.
+- [x] Store DeepSeek thinking-mode source documentation in `sources/`.
+- [x] Store redacted Wafer thinking-parameter probe in `sources/`.
+- [x] Map current OpenAI chat request/settings/streaming architecture with file references.
+
+## Follow-up implementation tasks
+
+- [ ] Add `thinking` and `reasoning_effort` fields to the OpenAI Chat Completions request type.
+- [ ] Add settings/flags/profile schema for OpenAI Chat Completions thinking toggle and effort.
+- [ ] Wire settings and optional per-turn overrides into `MakeCompletionRequestFromTurn`.
+- [ ] Add request JSON tests for enabled/disabled/high/max/omitted behavior.
+- [ ] Validate live against Wafer DeepSeek-V4-Pro.
+- [ ] Update Geppetto and Pinocchio docs with profile examples.

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/README.md
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/README.md
@@ -1,0 +1,21 @@
+# Investigate wafer.ai profile 404 in OpenAI chat completions
+
+This is the document workspace for ticket WAFER-AI-404.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket WAFER-AI-404 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket WAFER-AI-404 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket WAFER-AI-404 --field Status --value review`

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/changelog.md
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/changelog.md
@@ -1,0 +1,68 @@
+# Changelog
+
+## 2026-05-03
+
+- Initial workspace created.
+- Added redacted settings, live 404, and curl endpoint probe evidence for the Wafer AI profile failure.
+- Wrote the Wafer AI OpenAI-compatible 404 analysis and implementation guide.
+- Wrote the chronological investigation diary.
+- Updated tasks with completed investigation steps and follow-up implementation items.
+
+## 2026-05-03
+
+Completed Wafer AI 404 investigation: profile stores full chat-completions endpoint while Geppetto appends /chat/completions, causing double-path 404; wrote guide and diary.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/design-doc/01-wafer-ai-openai-compatible-404-analysis-and-implementation-guide.md — Primary analysis and implementation guide
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/reference/01-investigation-diary.md — Chronological investigation diary
+
+
+## 2026-05-03
+
+Validated ticket with docmgr doctor and uploaded the analysis bundle to reMarkable at /ai/2026/05/03/WAFER-AI-404.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/reference/01-investigation-diary.md — Added validation and reMarkable delivery step
+
+
+## 2026-05-03
+
+Implemented the follow-up: added OpenAI-compatible 404 base-URL diagnostics, tested them, backed up and refactored local Wafer profiles to use wafer-base stack, and confirmed live Wafer streaming succeeds.
+
+### Related Files
+
+- /home/manuel/.config/pinocchio/profiles.yaml — Local profile stack refactor
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/pkg/steps/ai/openai/chat_stream.go — 404 hint implementation
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/pkg/steps/ai/openai/chat_stream_test.go — 404 hint regression tests
+
+
+## 2026-05-03
+
+Uploaded updated analysis bundle to reMarkable as 'WAFER-AI-404 Wafer AI 404 analysis updated'.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/design-doc/01-wafer-ai-openai-compatible-404-analysis-and-implementation-guide.md — Updated bundle content
+
+
+## 2026-05-03
+
+Added Defuddle-extracted DeepSeek thinking mode documentation and Kagi search provenance to sources for thinking-level analysis.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/04-deepseek-thinking-mode-defuddle.md — DeepSeek thinking mode source
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/05-kagi-deepseek-v4-thinking-search.md — Search provenance
+
+
+## 2026-05-03
+
+Refactored all local Pinocchio profiles to provider base profiles, backed up profiles.yaml, validated every leaf profile, and added a redacted audit source.
+
+### Related Files
+
+- /home/manuel/.config/pinocchio/profiles.yaml — Full provider base profile refactor
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/06-profiles-provider-base-refactor-redacted.md — Redacted profile refactor summary
+

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/design-doc/01-wafer-ai-openai-compatible-404-analysis-and-implementation-guide.md
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/design-doc/01-wafer-ai-openai-compatible-404-analysis-and-implementation-guide.md
@@ -1,0 +1,612 @@
+---
+Title: Wafer AI OpenAI-compatible 404 analysis and implementation guide
+Ticket: WAFER-AI-404
+Status: active
+Topics:
+    - llm
+    - openai
+    - pinocchio
+    - wafer-ai
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ../../../../../../../../../../.config/pinocchio/profiles.yaml
+      Note: |-
+        Local Wafer profiles currently store full chat-completions endpoint in openai-base-url; contains secrets
+        Refactored local Wafer profiles to stack on wafer-base with one shared credential and corrected base URL
+    - Path: geppetto/pkg/cli/bootstrap/inference_debug.go
+      Note: --print-inference-settings source trace proves profile value reaches final settings
+    - Path: geppetto/pkg/steps/ai/openai/chat_stream.go
+      Note: |-
+        OpenAI chat engine constructs final /chat/completions endpoint from provider base URL
+        Added HTTP 404 hint/warning when configured OpenAI-compatible base URL looks like an operation endpoint
+    - Path: geppetto/pkg/steps/ai/openai/chat_stream_test.go
+      Note: Regression tests for 404 hint and suspicious base URL detection
+    - Path: geppetto/pkg/steps/ai/openai/engine_openai.go
+      Note: Runtime streaming path logs failures but not currently the computed endpoint
+    - Path: geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/04-deepseek-thinking-mode-defuddle.md
+      Note: Defuddle source for DeepSeek thinking-mode parameters
+ExternalSources: []
+Summary: Wafer profile 404 is caused by storing the full chat-completions endpoint in openai-base-url while Geppetto appends /chat/completions itself.
+LastUpdated: 2026-05-03T11:45:00-04:00
+WhatFor: Use when fixing or reviewing Wafer/OpenAI-compatible provider configuration and request diagnostics.
+WhenToUse: When Pinocchio/Geppetto OpenAI-compatible profiles show 404 even though curl against the provider endpoint succeeds.
+---
+
+
+
+
+
+
+
+
+
+# Wafer AI OpenAI-compatible 404 analysis and implementation guide
+
+## Executive summary
+
+The immediate Wafer AI 404 is a profile configuration problem, not a failing API key and not evidence that `PINOCCHIO_PROFILE` is being ignored.
+
+The current `wafer-deepseek-v4-pro` profile resolves `api.base_urls.openai-base-url` to:
+
+```text
+https://pass.wafer.ai/v1/chat/completions
+```
+
+Geppetto's OpenAI chat engine treats `openai-base-url` as the provider **base** URL and appends `/chat/completions` at runtime. With the current profile, the actual request target becomes:
+
+```text
+https://pass.wafer.ai/v1/chat/completions/chat/completions
+```
+
+A direct curl probe showed that Wafer accepts streaming chat completions at `/v1/chat/completions`, while the double-appended path returns HTTP 404. Therefore the minimal operator fix is to change all Wafer OpenAI-chat profiles in `~/.config/pinocchio/profiles.yaml` to use:
+
+```yaml
+base_urls:
+  openai-base-url: https://pass.wafer.ai/v1
+```
+
+There are two worthwhile code/documentation follow-ups:
+
+1. Add request-endpoint logging in the OpenAI chat streaming path, with credentials excluded.
+2. Add validation or a warning when an `*-base-url` value already ends in a known operation path such as `/chat/completions`.
+
+## Problem statement and scope
+
+The user reported this contrast:
+
+1. Direct curl to Wafer succeeds when POSTing to `https://pass.wafer.ai/v1/chat/completions`.
+2. `PINOCCHIO_PROFILE=wafer-deepseek-v4-pro llmunix --log-level trace --with-caller hello` fails with:
+
+```text
+OpenAI streaming request failed error="chat completions error: status=404"
+Error: inference failed: chat completions error: status=404
+```
+
+The requested analysis focused on whether the OpenAI API base URL or another profile setting is wrong, and on the fact that debug logging does not currently show the final HTTP URL used for the request.
+
+This document covers:
+
+- the profile value resolved by Pinocchio's `--print-inference-settings` path;
+- the OpenAI chat engine's URL construction behavior;
+- live endpoint evidence against Wafer;
+- an implementation guide for the immediate config fix and the more durable diagnostics improvements.
+
+This document does not change production code by itself. It is an analysis and implementation guide.
+
+## Current-state analysis
+
+### Profile resolution works and applies the Wafer profile
+
+`pinocchio code professional --print-inference-settings` with `PINOCCHIO_PROFILE=wafer-deepseek-v4-pro` showed the selected profile reaches final inference settings. The saved evidence is:
+
+- `sources/print_inference_settings_wafer_deepseek_redacted.log`
+
+Key resolved settings from that log:
+
+```yaml
+settings:
+  api:
+    api_keys:
+      openai-api-key: '***'
+    base_urls:
+      openai-base-url: https://pass.wafer.ai/v1/chat/completions
+  chat:
+    api_type: openai
+    engine: DeepSeek-V4-Pro
+    stream: true
+```
+
+The `sources` section also shows the value came from the selected profile:
+
+```yaml
+source: profile
+profile_slug: wafer-deepseek-v4-pro
+value: https://pass.wafer.ai/v1/chat/completions
+```
+
+So the problem is not that Pinocchio fails to load the profile. It loads the profile and faithfully applies the base URL stored there.
+
+### The OpenAI chat engine appends `/chat/completions`
+
+In `geppetto/pkg/steps/ai/openai/chat_stream.go`, `resolveChatStreamConfig` reads `openai-base-url` and constructs the final endpoint as follows:
+
+```go
+baseURL, ok := apiSettings.BaseUrls[string(apiType)+"-base-url"]
+endpoint := strings.TrimRight(baseURL, "/") + "/chat/completions"
+```
+
+Line-anchored evidence:
+
+- `geppetto/pkg/steps/ai/openai/chat_stream.go:60` reads the provider-specific base URL.
+- `geppetto/pkg/steps/ai/openai/chat_stream.go:64` appends `/chat/completions`.
+- `geppetto/pkg/steps/ai/openai/chat_stream.go:90` creates the HTTP request from that computed endpoint.
+
+That contract means `openai-base-url` must be the base API root, such as:
+
+```text
+https://api.openai.com/v1
+https://pass.wafer.ai/v1
+```
+
+It must not be the operation endpoint:
+
+```text
+https://pass.wafer.ai/v1/chat/completions
+```
+
+### The existing runtime log does not print the final endpoint
+
+`geppetto/pkg/steps/ai/openai/engine_openai.go` resolves the stream config, builds the request body, then calls `openChatCompletionStream`:
+
+- `engine_openai.go:56` calls `resolveChatStreamConfig`.
+- `engine_openai.go:213` logs `OpenAI using streaming mode`.
+- `engine_openai.go:214` calls `openChatCompletionStream`.
+- `engine_openai.go:216` logs only the error if the HTTP call fails.
+
+The current logs show model, messages, and the generic HTTP status, but not the endpoint. That explains the user's observation that `--print-inference-settings` shows the configured base URL, while trace logging still does not reveal the final request URL.
+
+### Live Wafer endpoint evidence
+
+The saved probe is:
+
+- `sources/01-curl-endpoint-probe-redacted.md`
+
+With the locally configured Wafer API key redacted, curl showed:
+
+| URL | Result |
+| --- | --- |
+| `https://pass.wafer.ai/v1/chat/completions` | HTTP 200 with SSE chat completion chunks |
+| `https://pass.wafer.ai/v1/chat/completions/chat/completions` | HTTP 404 |
+
+This exactly matches the failure mode produced by putting the full endpoint into `openai-base-url` and then letting Geppetto append `/chat/completions` again.
+
+## Gap analysis
+
+### Gap 1: Profile stores endpoint where Geppetto expects base URL
+
+Current Wafer profiles in `~/.config/pinocchio/profiles.yaml` use this shape:
+
+```yaml
+profiles:
+  wafer-deepseek-v4-pro:
+    inference_settings:
+      chat:
+        api_type: openai
+        engine: DeepSeek-V4-Pro
+      api:
+        base_urls:
+          openai-base-url: https://pass.wafer.ai/v1/chat/completions
+```
+
+For Geppetto's OpenAI chat engine, this should be:
+
+```yaml
+profiles:
+  wafer-deepseek-v4-pro:
+    inference_settings:
+      chat:
+        api_type: openai
+        engine: DeepSeek-V4-Pro
+      api:
+        base_urls:
+          openai-base-url: https://pass.wafer.ai/v1
+```
+
+The same correction applies to the other Wafer OpenAI-compatible chat profiles found locally:
+
+- `wafer-qwen3.5-397b`
+- `wafer-deepseek-v4-pro`
+- `wafer-glm-5.1`
+
+### Gap 2: CLI flag overrides are not a reliable quick workaround in this profile path
+
+A quick attempt to pass `--openai-base-url https://pass.wafer.ai/v1` did not override the profile value in the final resolved settings. The source trace showed the CLI value first, followed by the profile value, with the profile winning:
+
+```yaml
+source: cobra
+value: https://pass.wafer.ai/v1
+source: profile
+value: https://pass.wafer.ai/v1/chat/completions
+final value: https://pass.wafer.ai/v1/chat/completions
+```
+
+That means the reliable fix is to edit the profile file or adjust the profile resolution precedence intentionally in a separate ticket. For this incident, treat the profile file as the source of truth.
+
+### Gap 3: Debugging visibility is one layer too shallow
+
+`--print-inference-settings` answers "what base URL was configured?" It does not answer "what exact URL did the HTTP client call after engine-specific path construction?"
+
+The engine should log both values at debug level:
+
+- `base_url`: the redacted/non-secret provider root from settings;
+- `endpoint`: the computed request URL, with query strings and credentials omitted if ever present;
+- `api_type`: `openai`;
+- `stream`: `true`.
+
+## Proposed solution
+
+### Immediate operator fix
+
+Edit `~/.config/pinocchio/profiles.yaml` and change each Wafer profile's `openai-base-url` from the operation endpoint to the API root:
+
+```diff
+- openai-base-url: https://pass.wafer.ai/v1/chat/completions
++ openai-base-url: https://pass.wafer.ai/v1
+```
+
+Recommended safe workflow:
+
+```bash
+cp ~/.config/pinocchio/profiles.yaml \
+  ~/.config/pinocchio/profiles.yaml.bak-$(date +%Y%m%d-%H%M%S)
+
+python3 - <<'PY'
+from pathlib import Path
+p = Path.home() / '.config' / 'pinocchio' / 'profiles.yaml'
+text = p.read_text()
+text = text.replace(
+    'https://pass.wafer.ai/v1/chat/completions',
+    'https://pass.wafer.ai/v1',
+)
+p.write_text(text)
+PY
+```
+
+Then validate without making a model call:
+
+```bash
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro \
+  pinocchio code professional --print-inference-settings --non-interactive hello
+```
+
+Expected output excerpt:
+
+```yaml
+settings:
+  api:
+    base_urls:
+      openai-base-url: https://pass.wafer.ai/v1
+```
+
+Then validate with a real call:
+
+```bash
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro \
+  pinocchio --log-level debug --with-caller code professional --non-interactive hello
+```
+
+Expected behavior: no 404; streamed response chunks are received.
+
+### Code improvement 1: log the computed endpoint
+
+Add debug logging after `resolveChatStreamConfig` and before `openChatCompletionStream`.
+
+Suggested patch shape in `geppetto/pkg/steps/ai/openai/engine_openai.go`:
+
+```go
+streamCfg, err := resolveChatStreamConfig(e.settings.API, e.settings.Client, *e.settings.Chat.ApiType)
+if err != nil {
+    return nil, err
+}
+log.Debug().
+    Str("api_type", string(*e.settings.Chat.ApiType)).
+    Str("endpoint", streamCfg.endpoint).
+    Msg("OpenAI chat completion endpoint resolved")
+```
+
+The endpoint contains no credential in the current implementation. Still, do not log headers or request body at this point.
+
+Alternatively, log in `openChatCompletionStream` immediately before `cfg.httpClient.Do(req)`:
+
+```go
+log.Debug().
+    Str("method", http.MethodPost).
+    Str("url", req.URL.Redacted()).
+    Msg("OpenAI chat completion HTTP request")
+```
+
+Using `req.URL.Redacted()` protects against accidental future userinfo in URLs.
+
+### Code improvement 2: warn on likely endpoint/base-URL confusion
+
+Add a small helper in `chat_stream.go`:
+
+```go
+func warnIfChatCompletionEndpointConfigured(apiType ai_types.ApiType, baseURL string) {
+    normalized := strings.TrimRight(strings.ToLower(strings.TrimSpace(baseURL)), "/")
+    if strings.HasSuffix(normalized, "/chat/completions") {
+        log.Warn().
+            Str("api_type", string(apiType)).
+            Str("base_url", baseURL).
+            Str("expected_shape", "provider API root, e.g. https://host/v1").
+            Str("computed_suffix", "/chat/completions will be appended by Geppetto").
+            Msg("OpenAI base URL appears to include the chat completions operation path")
+    }
+}
+```
+
+Call it before constructing `endpoint`:
+
+```go
+warnIfChatCompletionEndpointConfigured(apiType, baseURL)
+endpoint := strings.TrimRight(baseURL, "/") + "/chat/completions"
+```
+
+This preserves compatibility: existing configs still behave as before, but users get a direct warning explaining the double-append hazard.
+
+### Code improvement 3: add unit coverage for URL construction
+
+Extend `geppetto/pkg/steps/ai/openai/engine_openai_test.go` or add a focused `chat_stream_test.go`:
+
+```go
+func TestResolveChatStreamConfigAppendsChatCompletionsToBaseURL(t *testing.T) {
+    ss := settings.NewStepSettings()
+    ss.API.APIKeys["openai-api-key"] = "test-key"
+    ss.API.BaseUrls["openai-base-url"] = "https://pass.wafer.ai/v1"
+
+    cfg, err := resolveChatStreamConfig(ss.API, ss.Client, types.ApiTypeOpenAI)
+    require.NoError(t, err)
+    require.Equal(t, "https://pass.wafer.ai/v1/chat/completions", cfg.endpoint)
+}
+```
+
+Optional second test:
+
+```go
+func TestResolveChatStreamConfigDoubleAppendDocumentsMisconfiguredEndpoint(t *testing.T) {
+    ss := settings.NewStepSettings()
+    ss.API.APIKeys["openai-api-key"] = "test-key"
+    ss.API.BaseUrls["openai-base-url"] = "https://pass.wafer.ai/v1/chat/completions"
+
+    cfg, err := resolveChatStreamConfig(ss.API, ss.Client, types.ApiTypeOpenAI)
+    require.NoError(t, err)
+    require.Equal(t, "https://pass.wafer.ai/v1/chat/completions/chat/completions", cfg.endpoint)
+}
+```
+
+If the warning helper is implemented, capture zerolog output or keep the warning covered through a pure predicate helper:
+
+```go
+func looksLikeChatCompletionsEndpoint(baseURL string) bool
+```
+
+## Implementation phases
+
+### Phase 1: Fix local Wafer profiles
+
+1. Back up `~/.config/pinocchio/profiles.yaml`.
+2. Replace Wafer `openai-base-url` values with `https://pass.wafer.ai/v1`.
+3. Run `--print-inference-settings` for all Wafer profiles:
+   - `wafer-qwen3.5-397b`
+   - `wafer-deepseek-v4-pro`
+   - `wafer-glm-5.1`
+4. Confirm each profile reports the corrected base URL.
+5. Run one real streaming smoke test.
+
+### Phase 2: Add endpoint logging
+
+1. Add debug log in `OpenAIEngine.RunInference` after `resolveChatStreamConfig`.
+2. Ensure only the URL is logged; never log `Authorization`.
+3. Run focused OpenAI tests:
+
+```bash
+cd geppetto
+go test ./pkg/steps/ai/openai -count=1
+```
+
+4. Run a safe `--print-inference-settings` smoke path to confirm no debug output changes affect the no-network path.
+
+### Phase 3: Add misconfiguration warning
+
+1. Add `looksLikeChatCompletionsEndpoint(baseURL string) bool`.
+2. Warn when true.
+3. Add unit tests for:
+   - `https://pass.wafer.ai/v1` → false;
+   - `https://pass.wafer.ai/v1/` → false;
+   - `https://pass.wafer.ai/v1/chat/completions` → true;
+   - `https://pass.wafer.ai/v1/chat/completions/` → true.
+4. Run focused package tests.
+
+### Phase 4: Document the base URL contract
+
+Update the OpenAI-compatible provider docs to explicitly distinguish base URL from operation endpoint.
+
+Candidate docs:
+
+- `geppetto/pkg/doc/topics/06-inference-engines.md`
+- `pinocchio/pkg/doc/tutorials/08-migrating-legacy-pinocchio-config-to-unified-profile-documents.md`
+
+Suggested wording:
+
+> For `ai-api-type: openai`, configure `api.base_urls.openai-base-url` as the provider API root. The engine appends `/chat/completions` internally. For an OpenAI-compatible service whose chat endpoint is `https://example.com/v1/chat/completions`, set `openai-base-url: https://example.com/v1`.
+
+## Testing and validation strategy
+
+### Config-only validation
+
+Run:
+
+```bash
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro \
+  pinocchio code professional --print-inference-settings --non-interactive hello
+```
+
+Check:
+
+```yaml
+settings.api.base_urls.openai-base-url: https://pass.wafer.ai/v1
+settings.chat.api_type: openai
+settings.chat.engine: DeepSeek-V4-Pro
+```
+
+### Direct provider validation
+
+Run a redacted curl probe:
+
+```bash
+curl -sS -w '\nHTTP_STATUS:%{http_code}\n' -X POST \
+  https://pass.wafer.ai/v1/chat/completions \
+  -H 'Authorization: Bearer ***' \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"DeepSeek-V4-Pro","messages":[{"role":"user","content":"Hello!"}],"max_tokens":8,"stream":true}'
+```
+
+Expected: HTTP 200 with SSE frames.
+
+### Negative validation
+
+Run the same probe against the double-appended endpoint:
+
+```bash
+https://pass.wafer.ai/v1/chat/completions/chat/completions
+```
+
+Expected: HTTP 404. This verifies that the original symptom is explained by URL construction.
+
+### Code validation after logging/warning changes
+
+```bash
+cd geppetto
+go test ./pkg/steps/ai/openai -count=1
+go test ./pkg/cli/bootstrap -count=1
+```
+
+If docs are changed:
+
+```bash
+cd pinocchio
+go test ./pkg/cmds ./cmd/pinocchio/cmds -count=1
+```
+
+## Risks, alternatives, and open questions
+
+### Risk: changing profile values affects any tool that expects full endpoint values
+
+The local `profiles.yaml` is consumed by Pinocchio/Geppetto profile resolution. If another unrelated tool reads the same file and expects full operation endpoints, changing the value could affect that tool. The current evidence and field name (`openai-base-url`) indicate the Geppetto contract is base URL, not full endpoint.
+
+### Risk: some OpenAI-compatible providers use nonstandard paths
+
+If a provider does not use `/chat/completions`, the current OpenAI chat engine cannot be configured to use a fully custom operation path; it always appends `/chat/completions`. That is not the Wafer case, because Wafer's successful endpoint is exactly `/v1/chat/completions`.
+
+### Alternative: make `openai-base-url` accept either root or full endpoint
+
+The engine could detect a base URL ending in `/chat/completions` and avoid appending. This is user-friendly but changes a long-standing contract and can hide configuration mistakes. A warning is safer initially.
+
+If implemented, use a separate setting such as `openai-chat-completions-url` rather than overloading `openai-base-url`.
+
+### Alternative: use `ai-api-type: openai-responses`
+
+Not appropriate for this incident. The working Wafer endpoint is OpenAI Chat Completions-compatible. The Responses engine has a different path and event contract.
+
+### Open question: should profile values override CLI flags?
+
+In the observed `--openai-base-url` test, the profile value won over the CLI flag in the final settings. That may be intended profile-first behavior, but it makes one-off command-line overrides less useful for debugging provider endpoints. Consider a separate ticket if operator overrides are expected to win.
+
+## Implementation update: warning and profile stack applied
+
+This follow-up has now been implemented in the working tree and local operator config.
+
+### Runtime 404 hint
+
+`geppetto/pkg/steps/ai/openai/chat_stream.go` now preserves the configured `baseURL` in `chatStreamConfig`. When a chat-completions HTTP request returns 404, it checks whether the configured base URL looks suspicious:
+
+- contains `/chat/completion`, which usually means the operation endpoint was configured as the base URL; or
+- contains extra path components after `/v1/` or `/v2/`, which often means the provider root was not used.
+
+When the heuristic matches, the returned error includes a hint like:
+
+```text
+possible OpenAI-compatible base URL misconfiguration: configured base URL path "/v1/chat/completions" already looks like a chat completions endpoint; Geppetto appends /chat/completions internally
+```
+
+The same condition also emits a warning log with `status`, `base_url`, and computed `endpoint`, but no headers or API keys.
+
+Focused validation passed:
+
+```bash
+cd geppetto && go test ./pkg/steps/ai/openai -count=1
+```
+
+### Local Wafer profile stack
+
+`/home/manuel/.config/pinocchio/profiles.yaml` was backed up to:
+
+```text
+/home/manuel/.config/pinocchio/profiles.yaml.bak-20260503-114952-wafer-stack
+```
+
+The Wafer profiles were rewritten to use one shared base profile:
+
+```yaml
+wafer-base:
+  inference_settings:
+    chat:
+      api_type: openai
+    api:
+      api_keys:
+        openai-api-key: '***'
+      base_urls:
+        openai-base-url: https://pass.wafer.ai/v1
+
+wafer-deepseek-v4-pro:
+  stack:
+    - profile_slug: wafer-base
+  inference_settings:
+    chat:
+      engine: DeepSeek-V4-Pro
+```
+
+Validation showed `PINOCCHIO_PROFILE=wafer-deepseek-v4-pro` now resolves:
+
+```yaml
+api.base_urls.openai-base-url: https://pass.wafer.ai/v1
+chat.api_type: openai
+chat.engine: DeepSeek-V4-Pro
+```
+
+The live Wafer smoke test also succeeded and streamed:
+
+```text
+Hello. How can I help you today?
+OpenAI stream completed chunks_received=9
+OpenAI RunInference completed (streaming)
+```
+
+Evidence files:
+
+- `sources/02-print-inference-settings-wafer-stacked-redacted.log`
+- `sources/03-live-wafer-deepseek-after-profile-stack.log`
+
+## References
+
+- `geppetto/pkg/steps/ai/openai/chat_stream.go:60-64` — reads base URL and appends `/chat/completions`.
+- `geppetto/pkg/steps/ai/openai/chat_stream.go:90` — creates the HTTP request with the computed endpoint.
+- `geppetto/pkg/steps/ai/openai/engine_openai.go:56` — resolves streaming config.
+- `geppetto/pkg/steps/ai/openai/engine_openai.go:213-216` — logs streaming mode and generic request failure.
+- `geppetto/pkg/cli/bootstrap/inference_debug.go:145-165` — builds the settings/source trace used by `--print-inference-settings`.
+- `~/.config/pinocchio/profiles.yaml` — local Wafer profile source; API keys are sensitive and must not be copied into reports.
+- `sources/print_inference_settings_wafer_deepseek_redacted.log` — final resolved settings and source trace.
+- `sources/live_wafer_deepseek_404.log` — live 404 reproduction with current profile.
+- `sources/01-curl-endpoint-probe-redacted.md` — direct positive/negative Wafer endpoint probe.

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/index.md
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/index.md
@@ -1,0 +1,58 @@
+---
+Title: Investigate wafer.ai profile 404 in OpenAI chat completions
+Ticket: WAFER-AI-404
+Status: active
+Topics:
+    - llm
+    - openai
+    - pinocchio
+    - wafer-ai
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-05-03T11:39:07.231797273-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Investigate wafer.ai profile 404 in OpenAI chat completions
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- llm
+- openai
+- pinocchio
+- wafer-ai
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/reference/01-investigation-diary.md
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/reference/01-investigation-diary.md
@@ -1,0 +1,880 @@
+---
+Title: Investigation diary
+Ticket: WAFER-AI-404
+Status: active
+Topics:
+    - llm
+    - openai
+    - pinocchio
+    - wafer-ai
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ../../../../../../../../../../.config/pinocchio/profiles.yaml
+      Note: |-
+        Local Wafer profiles currently store full chat-completions endpoint in openai-base-url; contains secrets
+        Refactored local Wafer profiles to stack on wafer-base with one shared credential and corrected base URL
+        Refactored all local profiles to stack on provider base profiles without repeated keys/base URLs/API types
+    - Path: geppetto/pkg/cli/bootstrap/inference_debug.go
+      Note: --print-inference-settings source trace proves profile value reaches final settings
+    - Path: geppetto/pkg/steps/ai/openai/chat_stream.go
+      Note: |-
+        OpenAI chat engine constructs final /chat/completions endpoint from provider base URL
+        Added HTTP 404 hint/warning when configured OpenAI-compatible base URL looks like an operation endpoint
+    - Path: geppetto/pkg/steps/ai/openai/chat_stream_test.go
+      Note: Regression tests for 404 hint and suspicious base URL detection
+    - Path: geppetto/pkg/steps/ai/openai/engine_openai.go
+      Note: Runtime streaming path logs failures but not currently the computed endpoint
+    - Path: geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/design-doc/01-wafer-ai-openai-compatible-404-analysis-and-implementation-guide.md
+    - Path: geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/04-deepseek-thinking-mode-defuddle.md
+      Note: Defuddle source for DeepSeek thinking-mode parameters
+    - Path: geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/06-profiles-provider-base-refactor-redacted.md
+      Note: Redacted audit summary of full profile base refactor
+ExternalSources: []
+Summary: Chronological investigation of Wafer AI 404; root cause is a full endpoint stored where Geppetto expects a base URL.
+LastUpdated: 2026-05-03T11:45:00-04:00
+WhatFor: Records commands, evidence, and reasoning for the Wafer AI profile 404 analysis.
+WhenToUse: Use when continuing the fix, reviewing the diagnosis, or validating future OpenAI-compatible profile behavior.
+---
+
+
+
+
+
+
+
+
+
+
+
+# Diary
+
+## Goal
+
+This diary records the investigation into why the Wafer AI profile fails with HTTP 404 through Pinocchio/Geppetto while direct curl against Wafer's OpenAI-compatible chat-completions endpoint succeeds.
+
+## Step 1: Create the docmgr ticket and capture the starting hypothesis
+
+I created a dedicated ticket workspace so the investigation, evidence, implementation guidance, and delivery artifacts have a stable home. The user's initial hypothesis was that the OpenAI base URL might be wrong or that trace logging hides the final request URL.
+
+### Prompt Context
+
+**User prompt (verbatim):** The user asked to create a new docmgr ticket to analyze why the Wafer AI profile from `~/.config/pinocchio/profiles.yaml` returns `chat completions error: status=404` even though a direct curl to `https://pass.wafer.ai/v1/chat/completions` succeeds. The prompt included a live Bearer token; it is intentionally redacted from this diary and the ticket documents.
+
+**Assistant interpretation:** Create a docmgr ticket, keep a diary, investigate profile resolution and OpenAI-compatible base URL behavior, write an implementation guide, and upload the result to reMarkable.
+
+**Inferred user intent:** The user wants a durable, evidence-backed diagnosis and a practical fix path for Wafer AI profile failures, plus better future diagnostics.
+
+**Commit (code):** N/A — no code changes were made in this analysis pass.
+
+### What I did
+
+- Loaded the `ticket-research-docmgr-remarkable` and `diary` skills.
+- Ran:
+  - `docmgr status --summary-only`
+  - `docmgr ticket create-ticket --ticket WAFER-AI-404 --title "Investigate wafer.ai profile 404 in OpenAI chat completions" --topics llm,openai,pinocchio,wafer-ai`
+  - `docmgr doc add --ticket WAFER-AI-404 --doc-type design-doc --title "Wafer AI OpenAI-compatible 404 analysis and implementation guide"`
+  - `docmgr doc add --ticket WAFER-AI-404 --doc-type reference --title "Investigation diary"`
+
+### Why
+
+- The ticket gives the analysis a searchable, reviewable location.
+- A diary is useful because this problem spans profile configuration, runtime settings resolution, HTTP endpoint construction, and live provider behavior.
+
+### What worked
+
+- The ticket and two initial documents were created under:
+  - `geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/`
+
+### What didn't work
+
+- My first `find geppetto/ttmp/WAFER-AI-404` command failed because docmgr stores tickets in dated paths, not directly under `ttmp/<ticket-id>`:
+
+```text
+find: ‘geppetto/ttmp/WAFER-AI-404’: No such file or directory
+```
+
+### What I learned
+
+- The active docmgr root for this workspace is `geppetto/ttmp`.
+- The correct ticket path is date-based.
+
+### What was tricky to build
+
+- The user prompt included a real-looking API token. The investigation needed to use configured credentials for live validation without copying secrets into the ticket docs. I handled this by redacting the token from reports and saved evidence.
+
+### What warrants a second pair of eyes
+
+- Confirm whether the exposed token has already been rotated. The token appeared in the user prompt before this analysis started.
+
+### What should be done in the future
+
+- Avoid pasting live API keys into prompts; use environment variables or local config references instead.
+
+### Code review instructions
+
+- Start with the ticket index and the design doc.
+- Verify no saved ticket artifact contains a full Wafer API token.
+
+### Technical details
+
+- Ticket path:
+  - `geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/`
+
+## Step 2: Inspect the local Wafer profiles without exposing secrets
+
+I inspected the local `~/.config/pinocchio/profiles.yaml` file with a small Python redaction script. This confirmed that the Wafer profile is present and that it sets the expected model and API type, but it also revealed the suspicious base URL value.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Determine whether the configured Wafer profile contains a base URL, endpoint URL, API type, or model mismatch.
+
+**Inferred user intent:** Find the concrete configuration value that explains why direct curl succeeds but Pinocchio fails.
+
+**Commit (code):** N/A.
+
+### What I did
+
+- Ran a Python script that loaded `~/.config/pinocchio/profiles.yaml`, selected profiles containing `wafer` or `deepseek`, and redacted key-like fields before printing.
+- Observed these Wafer profiles:
+  - `wafer-qwen3.5-397b`
+  - `wafer-deepseek-v4-pro`
+  - `wafer-glm-5.1`
+
+### Why
+
+- The failure could have come from a wrong model name, wrong API type, missing key, or wrong URL. Inspecting the profile source was the fastest way to narrow the search.
+
+### What worked
+
+- The profile inspection showed that the profiles use:
+
+```yaml
+chat:
+  api_type: openai
+api:
+  base_urls:
+    openai-base-url: https://pass.wafer.ai/v1/chat/completions
+```
+
+### What didn't work
+
+- N/A for this step.
+
+### What I learned
+
+- The local Wafer profile stores the **full chat-completions operation endpoint** in `openai-base-url`.
+- That is suspicious because the setting name and the OpenAI default both imply the value should be a base API root like `https://api.openai.com/v1`.
+
+### What was tricky to build
+
+- The profile file contains API keys. The inspection command had to avoid printing or saving secrets.
+
+### What warrants a second pair of eyes
+
+- Verify whether any non-Pinocchio tooling consumes the same `profiles.yaml` file and expects `openai-base-url` to be a full operation endpoint. The Geppetto contract appears to be base URL.
+
+### What should be done in the future
+
+- Add a profile linter warning for base URLs ending in `/chat/completions`.
+
+### Code review instructions
+
+- Review the design doc's "Gap 1" section for the recommended local profile change.
+
+### Technical details
+
+- Sensitive source file:
+  - `/home/manuel/.config/pinocchio/profiles.yaml`
+- Do not copy API key values from that file into docs or logs.
+
+## Step 3: Read the OpenAI chat engine URL construction path
+
+I then inspected the Geppetto OpenAI chat implementation. This turned the profile suspicion into a concrete cause: Geppetto appends `/chat/completions` to `openai-base-url` for the chat-completions engine.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Find the code that turns `openai-base-url` into the HTTP request URL and determine whether it logs that URL.
+
+**Inferred user intent:** Explain the 404 from code behavior, not just from configuration guesswork.
+
+**Commit (code):** N/A.
+
+### What I did
+
+- Searched the repository for base URL and chat completions handling.
+- Read:
+  - `geppetto/pkg/steps/ai/openai/chat_stream.go`
+  - `geppetto/pkg/steps/ai/openai/engine_openai.go`
+  - `geppetto/pkg/cli/bootstrap/inference_debug.go`
+- Captured line-numbered excerpts with `nl -ba`.
+
+### Why
+
+- The user specifically noticed that debug logs do not show the URL used for the request. I needed to inspect both endpoint construction and logging.
+
+### What worked
+
+- `chat_stream.go` showed the key behavior:
+
+```go
+baseURL, ok := apiSettings.BaseUrls[string(apiType)+"-base-url"]
+endpoint := strings.TrimRight(baseURL, "/") + "/chat/completions"
+```
+
+- `engine_openai.go` showed that the engine logs request setup and failure, but not the computed endpoint.
+
+### What didn't work
+
+- The initial broad `rg` included too many historical `ttmp` files. I reran with `--glob '!**/ttmp/**'` to focus on live code.
+
+### What I learned
+
+- The root URL contract is unambiguous in code: `openai-base-url` is an API root, not a full operation endpoint.
+- The current runtime logs are insufficient for diagnosing URL double-append problems because they do not print `streamCfg.endpoint`.
+
+### What was tricky to build
+
+- There are both `openai` and `openai_responses` paths. The user's profile uses `api_type: openai`, and the failing log says `OpenAI streaming request failed`, so the relevant path is `geppetto/pkg/steps/ai/openai`, not `openai_responses`.
+
+### What warrants a second pair of eyes
+
+- If adding endpoint logging, ensure it never logs headers or credentials. The endpoint itself is not currently sensitive, but future URL shapes could include query parameters or userinfo.
+
+### What should be done in the future
+
+- Add a debug log such as `OpenAI chat completion endpoint resolved` with `req.URL.Redacted()` or `streamCfg.endpoint`.
+
+### Code review instructions
+
+- Start at:
+  - `geppetto/pkg/steps/ai/openai/chat_stream.go:51-78`
+  - `geppetto/pkg/steps/ai/openai/engine_openai.go:56` and `:213-216`
+
+### Technical details
+
+- If `openai-base-url` is `https://pass.wafer.ai/v1/chat/completions`, the code computes:
+
+```text
+https://pass.wafer.ai/v1/chat/completions/chat/completions
+```
+
+## Step 4: Reproduce the runtime behavior and save redacted evidence
+
+I ran safe and live Pinocchio checks to separate profile resolution from live HTTP behavior. The safe `--print-inference-settings` path proved the Wafer profile is applied. The live request reproduced the 404 without exposing the API key in saved output.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Validate the user's report with local tools and preserve enough output for review.
+
+**Inferred user intent:** Have a reliable reproduction and a clear explanation of which layer fails.
+
+**Commit (code):** N/A.
+
+### What I did
+
+- Tried to run the user's `llmunix` command but the binary was not in this shell's `PATH`:
+
+```text
+/bin/bash: line 36: llmunix: command not found
+```
+
+- Used the installed `pinocchio` binary instead:
+
+```bash
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro \
+  pinocchio code professional --print-inference-settings --non-interactive hello
+```
+
+- Saved the redacted settings output to:
+  - `sources/print_inference_settings_wafer_deepseek_redacted.log`
+
+- Reproduced the live 404:
+
+```bash
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro \
+  pinocchio --log-level debug --with-caller code professional --non-interactive hello
+```
+
+- Saved the 404 log to:
+  - `sources/live_wafer_deepseek_404.log`
+
+### Why
+
+- `--print-inference-settings` proves profile selection and settings merging without making a provider request.
+- The live request proves the failure still occurs after settings resolution succeeds.
+
+### What worked
+
+- The redacted settings output showed:
+
+```yaml
+openai-base-url: https://pass.wafer.ai/v1/chat/completions
+api_type: openai
+engine: DeepSeek-V4-Pro
+```
+
+- The live run reproduced:
+
+```text
+OpenAI streaming request failed error="chat completions error: status=404"
+Error: inference failed: chat completions error: status=404
+```
+
+### What didn't work
+
+- `llmunix` was unavailable in the tool shell, so I used `pinocchio code professional` as the equivalent Pinocchio command surface.
+- Passing `--openai-base-url https://pass.wafer.ai/v1` did not override the profile in the final resolved settings. The source trace showed the profile value winning after the CLI value.
+
+### What I learned
+
+- The profile system is not the failing layer; it is applying exactly the value stored in the profile.
+- One-off CLI overrides may not be reliable for this profile-first path, so the local file should be fixed directly.
+
+### What was tricky to build
+
+- The attempted CLI override was misleading: it appeared in the source log but was later overwritten by the profile value. The final `settings:` block, not just the source trace, must be checked.
+
+### What warrants a second pair of eyes
+
+- Decide whether profile values should override CLI flags. If not, that deserves a separate precedence bug/ticket.
+
+### What should be done in the future
+
+- Add tests or docs for profile-versus-CLI precedence on provider base URL fields.
+
+### Code review instructions
+
+- Review saved logs in `sources/` and compare the final `settings:` value with the live failure.
+
+### Technical details
+
+- Important saved artifacts:
+  - `sources/print_inference_settings_wafer_deepseek_redacted.log`
+  - `sources/live_wafer_deepseek_404.log`
+
+## Step 5: Probe Wafer endpoints directly
+
+I used curl with the locally configured Wafer key, without saving the key, to compare the intended endpoint with the endpoint Geppetto would compute from the current profile. This confirmed the exact double-append failure mode.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Validate the suspected endpoint mismatch independently of Pinocchio/Geppetto.
+
+**Inferred user intent:** Know whether Wafer itself accepts streaming chat completions and whether the 404 is caused by the path.
+
+**Commit (code):** N/A.
+
+### What I did
+
+- Loaded the Wafer API key from local config into a temporary file.
+- Ran curl against:
+  - `https://pass.wafer.ai/v1/chat/completions`
+  - `https://pass.wafer.ai/v1/chat/completions/chat/completions`
+- Deleted the temporary key file.
+- Saved only redacted command shapes and outcomes to:
+  - `sources/01-curl-endpoint-probe-redacted.md`
+
+### Why
+
+- This isolates provider behavior from Pinocchio runtime behavior.
+- If the double-appended URL returns the same 404 as Pinocchio, the root cause is strongly confirmed.
+
+### What worked
+
+- Correct endpoint result:
+
+```text
+HTTP 200 with SSE chat.completion.chunk frames
+```
+
+- Double-appended endpoint result:
+
+```text
+HTTP_STATUS:404
+```
+
+### What didn't work
+
+- N/A for this step.
+
+### What I learned
+
+- Wafer supports streaming chat completions at the expected OpenAI-compatible operation endpoint.
+- The double-appended endpoint returns HTTP 404, matching the Pinocchio failure.
+
+### What was tricky to build
+
+- The live provider probe needed to use a real key but preserve no secret in the ticket workspace. I saved a redacted markdown summary rather than raw curl command history with credentials.
+
+### What warrants a second pair of eyes
+
+- Confirm all Wafer profile models use the same base root `https://pass.wafer.ai/v1` and not model-specific paths.
+
+### What should be done in the future
+
+- Add a reusable provider endpoint probe script that reads keys from config but always redacts output.
+
+### Code review instructions
+
+- Review `sources/01-curl-endpoint-probe-redacted.md` for the positive and negative endpoint evidence.
+
+### Technical details
+
+- Correct base URL for Geppetto profile configuration:
+
+```text
+https://pass.wafer.ai/v1
+```
+
+- Correct operation endpoint after Geppetto appends path:
+
+```text
+https://pass.wafer.ai/v1/chat/completions
+```
+
+## Step 6: Write the implementation guide and ticket artifacts
+
+I wrote the main analysis document with an immediate profile fix, code-level diagnostics improvements, implementation phases, and validation commands. I also preserved the evidence files under the ticket's `sources/` directory.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Convert the investigation into a usable guide for fixing the local profile and improving future debugging.
+
+**Inferred user intent:** Have a document that can be reviewed, followed, and uploaded to reMarkable.
+
+**Commit (code):** N/A.
+
+### What I did
+
+- Wrote:
+  - `design-doc/01-wafer-ai-openai-compatible-404-analysis-and-implementation-guide.md`
+- Updated this diary.
+- Included references to:
+  - `chat_stream.go`
+  - `engine_openai.go`
+  - `inference_debug.go`
+  - local `profiles.yaml`
+  - saved runtime/source evidence.
+
+### Why
+
+- The guide needs to be actionable for both immediate operator repair and future code improvements.
+
+### What worked
+
+- The guide now states the root cause clearly:
+  - Current profile stores `https://pass.wafer.ai/v1/chat/completions` as `openai-base-url`.
+  - Geppetto appends `/chat/completions`.
+  - The resulting double-appended URL returns 404.
+
+### What didn't work
+
+- No code fix was applied in this pass, so the local profile is still unchanged unless the operator follows the guide.
+
+### What I learned
+
+- The most valuable code improvement is not changing URL behavior immediately; it is logging the computed endpoint and warning on likely endpoint/base-URL confusion.
+
+### What was tricky to build
+
+- The guide had to distinguish three related but separate things:
+  1. configured base URL shown by `--print-inference-settings`;
+  2. computed endpoint used by the engine;
+  3. provider operation endpoint validated by curl.
+
+### What warrants a second pair of eyes
+
+- Review whether the proposed warning should be log-only or should become a validation error in a future major release.
+
+### What should be done in the future
+
+- Implement the optional code changes and add tests.
+- Decide whether CLI base URL flags should override profile values for debugging.
+
+### Code review instructions
+
+- Start with the Executive summary in the design doc.
+- Then inspect the line-anchored evidence in:
+  - `geppetto/pkg/steps/ai/openai/chat_stream.go`
+  - `geppetto/pkg/steps/ai/openai/engine_openai.go`
+- Validate with:
+
+```bash
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro \
+  pinocchio code professional --print-inference-settings --non-interactive hello
+```
+
+### Technical details
+
+- Main deliverable:
+  - `geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/design-doc/01-wafer-ai-openai-compatible-404-analysis-and-implementation-guide.md`
+
+## Step 7: Validate docmgr and upload the bundle to reMarkable
+
+I validated the ticket with `docmgr doctor`, fixed the issues it reported, then uploaded a bundled PDF to reMarkable. The bundle includes the analysis guide, diary, and redacted curl endpoint probe.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Complete the ticket workflow by validating the documentation and delivering the final report to reMarkable.
+
+**Inferred user intent:** Make the analysis available for review away from the terminal.
+
+**Commit (code):** N/A.
+
+### What I did
+
+- Ran:
+
+```bash
+docmgr doctor --ticket WAFER-AI-404 --stale-after 30
+```
+
+- Fixed doctor findings by:
+  - adding vocabulary entries for `llm`, `openai`, and `wafer-ai`;
+  - renaming `sources/curl_endpoint_probe_redacted.md` to `sources/01-curl-endpoint-probe-redacted.md`;
+  - adding frontmatter to the redacted curl source note;
+  - updating references to the renamed source file.
+- Re-ran doctor successfully.
+- Ran:
+
+```bash
+remarquee status
+remarquee cloud account --non-interactive
+remarquee upload bundle --dry-run ... --remote-dir /ai/2026/05/03/WAFER-AI-404
+remarquee upload bundle ... --remote-dir /ai/2026/05/03/WAFER-AI-404
+remarquee cloud ls /ai/2026/05/03/WAFER-AI-404 --long --non-interactive
+```
+
+### Why
+
+- The ticket should pass docmgr validation before being used as a durable reference.
+- The user explicitly requested reMarkable delivery once the analysis was done.
+
+### What worked
+
+- Final `docmgr doctor` result:
+
+```text
+## Doctor Report (1 findings)
+
+### WAFER-AI-404
+
+- ✅ All checks passed
+```
+
+- reMarkable upload succeeded:
+
+```text
+OK: uploaded WAFER-AI-404 Wafer AI 404 analysis.pdf -> /ai/2026/05/03/WAFER-AI-404
+```
+
+- Verification listing showed:
+
+```text
+[f]	WAFER-AI-404 Wafer AI 404 analysis
+```
+
+### What didn't work
+
+- First doctor run reported:
+  - unknown topics: `llm`, `openai`, `wafer-ai`;
+  - missing frontmatter on the curl endpoint probe note;
+  - missing numeric prefix on the curl endpoint probe note.
+
+### What I learned
+
+- Docmgr validates Markdown files under `sources/` too, so source notes need proper frontmatter and naming if they are Markdown.
+
+### What was tricky to build
+
+- The source note started as a lightweight evidence artifact, but docmgr still required it to follow ticket-document conventions. Renaming and adding frontmatter solved this without changing the evidence content.
+
+### What warrants a second pair of eyes
+
+- Verify the uploaded PDF renders the long code blocks and YAML excerpts legibly on the reMarkable.
+
+### What should be done in the future
+
+- Prefer creating ticket source notes through docmgr or with frontmatter from the start.
+
+### Code review instructions
+
+- Validate the ticket with:
+
+```bash
+docmgr doctor --ticket WAFER-AI-404 --stale-after 30
+```
+
+- Verify reMarkable delivery with:
+
+```bash
+remarquee cloud ls /ai/2026/05/03/WAFER-AI-404 --long --non-interactive
+```
+
+### Technical details
+
+- Remote reMarkable directory:
+  - `/ai/2026/05/03/WAFER-AI-404`
+- Uploaded bundle:
+  - `WAFER-AI-404 Wafer AI 404 analysis`
+
+## Step 8: Add 404 endpoint hint and refactor Wafer profiles into a base stack
+
+After the initial report was delivered, the user asked for two concrete follow-ups: make this class of 404 easier to diagnose, and remove repeated Wafer credential values from the local profiles file. I implemented a runtime hint for suspicious OpenAI-compatible base URLs and rewrote the local Wafer profiles to inherit key/base-url settings from a shared `wafer-base` profile.
+
+### Prompt Context
+
+**User prompt (verbatim):** "ok, let's add a warning if the url contains chat/completion or something after v1/ and we get a 404, that would have helped me figure it out more easily. 
+
+Also, refactor my profiles.yaml to avoid repeated credential values"
+
+**Assistant interpretation:** Add code that warns when a 404 likely comes from putting an operation path into `openai-base-url`, then rewrite `~/.config/pinocchio/profiles.yaml` so Wafer profiles stack on a shared base profile.
+
+**Inferred user intent:** Make future provider endpoint mistakes self-diagnosing and reduce local secret duplication.
+
+**Commit (code):** N/A — changes are present in the working tree but not committed.
+
+### What I did
+
+- Modified `geppetto/pkg/steps/ai/openai/chat_stream.go`:
+  - `chatStreamConfig` now keeps the original `baseURL` in addition to the computed endpoint.
+  - non-2xx handling now appends a hint on HTTP 404 when the configured base URL looks suspicious.
+  - the suspicious cases include `/chat/completion...` and extra path components after `/v1/` or `/v2/`.
+  - the code logs a warning before returning the enriched error.
+- Modified `geppetto/pkg/steps/ai/openai/chat_stream_test.go`:
+  - added a 404 test proving the error mentions possible OpenAI-compatible base URL misconfiguration;
+  - added unit tests for suspicious and non-suspicious base URL shapes.
+- Ran:
+
+```bash
+gofmt -w geppetto/pkg/steps/ai/openai/chat_stream.go geppetto/pkg/steps/ai/openai/chat_stream_test.go
+cd geppetto && go test ./pkg/steps/ai/openai -count=1
+```
+
+- Backed up the local profile file to:
+  - `/home/manuel/.config/pinocchio/profiles.yaml.bak-20260503-114952-wafer-stack`
+- Rewrote the Wafer section of `/home/manuel/.config/pinocchio/profiles.yaml` to:
+  - add `wafer-base` containing the shared API key, `api_type: openai`, and corrected `openai-base-url: https://pass.wafer.ai/v1`;
+  - make `wafer-qwen3.5-397b`, `wafer-deepseek-v4-pro`, and `wafer-glm-5.1` stack on `wafer-base` and only set `chat.engine`.
+- Saved validation evidence:
+  - `sources/02-print-inference-settings-wafer-stacked-redacted.log`
+  - `sources/03-live-wafer-deepseek-after-profile-stack.log`
+
+### Why
+
+- The original failure was hard to diagnose because the runtime error only said `status=404`; it did not explain that a configured full operation endpoint would be double-appended.
+- Profile stacking is the intended way to share provider credentials and base URL while overriding only model-specific fields.
+
+### What worked
+
+- Focused OpenAI package tests passed:
+
+```text
+ok  	github.com/go-go-golems/geppetto/pkg/steps/ai/openai	0.005s
+```
+
+- The stacked Wafer profile resolved correctly:
+
+```yaml
+settings:
+  api:
+    api_keys:
+      openai-api-key: '***'
+    base_urls:
+      openai-base-url: https://pass.wafer.ai/v1
+  chat:
+    api_type: openai
+    engine: DeepSeek-V4-Pro
+```
+
+- The live Wafer run succeeded after the profile rewrite:
+
+```text
+Hello. How can I help you today?
+OpenAI stream completed chunks_received=9
+OpenAI RunInference completed (streaming)
+```
+
+### What didn't work
+
+- N/A for this step. The profile rewrite and live validation both succeeded.
+
+### What I learned
+
+- The stack merge did exactly what was needed: `wafer-base` supplied API settings and `api_type`, while the leaf profile supplied only `chat.engine`.
+- A focused unit test can reproduce the warning/hint behavior without making network calls by using `httptest.NewServer(http.NotFoundHandler())`.
+
+### What was tricky to build
+
+- The hint needs to avoid false positives for normal provider roots like `https://pass.wafer.ai/v1`, while still catching the user-facing mistake `https://pass.wafer.ai/v1/chat/completions`.
+- I kept the heuristic advisory rather than rejecting configs, so nonstandard provider paths can still work unless they actually fail with 404.
+
+### What warrants a second pair of eyes
+
+- Review the heuristic for extra path components after `/v1/` and `/v2/`; it is intentionally broad and only activates on HTTP 404.
+- Review whether logging `base_url` and computed `endpoint` is acceptable. The code does not log headers or API keys.
+
+### What should be done in the future
+
+- Consider documenting the new 404 hint in the OpenAI-compatible provider guide.
+- Consider adding the same base-url/operation-endpoint hint for non-streaming paths if new OpenAI paths are added later.
+
+### Code review instructions
+
+- Start with:
+  - `geppetto/pkg/steps/ai/openai/chat_stream.go`
+  - `geppetto/pkg/steps/ai/openai/chat_stream_test.go`
+- Validate with:
+
+```bash
+cd geppetto && go test ./pkg/steps/ai/openai -count=1
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro pinocchio code professional --print-inference-settings --non-interactive hello
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro pinocchio --log-level debug --with-caller code professional --non-interactive hello
+```
+
+### Technical details
+
+- Local profile backup:
+  - `/home/manuel/.config/pinocchio/profiles.yaml.bak-20260503-114952-wafer-stack`
+- Local profile file changed:
+  - `/home/manuel/.config/pinocchio/profiles.yaml`
+- New shared Wafer stack shape:
+
+```yaml
+wafer-base:
+  inference_settings:
+    chat:
+      api_type: openai
+    api:
+      api_keys:
+        openai-api-key: '***'
+      base_urls:
+        openai-base-url: https://pass.wafer.ai/v1
+
+wafer-deepseek-v4-pro:
+  stack:
+    - profile_slug: wafer-base
+  inference_settings:
+    chat:
+      engine: DeepSeek-V4-Pro
+```
+
+## Step 9: Refactor all local profiles to provider base profiles
+
+The user then asked to apply the same no-duplication pattern to all profiles, not just Wafer. I rewrote the local profile registry so provider-specific settings live in base profiles and model profiles only carry model-level settings.
+
+### Prompt Context
+
+**User prompt (verbatim):** "refactor all profiles to have a base and not repeat api keys or other provider specific settings."
+
+**Assistant interpretation:** Create provider base profiles for every repeated provider configuration in `~/.config/pinocchio/profiles.yaml`, move keys/base URLs/API types/client provider settings into those bases, and make leaf profiles stack on the appropriate base.
+
+**Inferred user intent:** Reduce secret duplication and make profile maintenance safer as providers/models are added.
+
+**Commit (code):** N/A — this changed local operator config, not repository code.
+
+### What I did
+
+- Created a timestamped backup:
+
+```text
+/home/manuel/.config/pinocchio/profiles.yaml.bak-20260503-115557-provider-bases
+```
+
+- Rewrote `/home/manuel/.config/pinocchio/profiles.yaml` with provider base profiles:
+  - `wafer-base`
+  - `together-base`
+  - `cerebras-base`
+  - `openai-responses-base`
+  - `claude-base`
+  - `gemini-base`
+  - `ollama-openai-base`
+  - `groq-base`
+  - `litellm-base`
+  - `mistral-base`
+  - `anyscale-base`
+  - `openrouter-base`
+  - `z-ai-base`
+- Moved provider-specific settings into those bases:
+  - `chat.api_type`
+  - `api.api_keys.*`
+  - `api.base_urls.*`
+  - `client` settings where provider-specific (`z-ai-base` timeout)
+- Updated all leaf profiles to stack on a base and keep only model-level settings like `chat.engine` and model-level `inference` tuning.
+- Added a redacted source summary:
+  - `sources/06-profiles-provider-base-refactor-redacted.md`
+
+### Why
+
+- API keys and provider roots should not be repeated across every model profile.
+- A provider base makes it less likely that one model profile drifts to an old key, old endpoint, or wrong API type.
+
+### What worked
+
+- All non-base stacked profiles resolved successfully with:
+
+```bash
+PINOCCHIO_PROFILE=<profile> pinocchio code professional --print-inference-settings --non-interactive hello
+```
+
+- A post-refactor check found no leaf-profile repetitions of API keys, base URLs, API type, or provider-specific client settings:
+
+```text
+violations []
+```
+
+### What didn't work
+
+- N/A for this step.
+
+### What I learned
+
+- The stack system is flexible enough to centralize all provider-specific settings while preserving model-specific tuning on leaves.
+- `litellm` had no explicit engine before the refactor; after stacking it still resolves through the command/default baseline for the engine while inheriting the LiteLLM base URL/API type.
+
+### What was tricky to build
+
+- The refactor needed to preserve model-level `inference` settings such as `reasoning_effort` and `reasoning_summary` on GPT-5 profiles while moving provider-level API credentials to `openai-responses-base`.
+- `z-ai-glm-5v-turbo` had a provider-specific client timeout, so that moved into `z-ai-base` along with the key and base URL.
+
+### What warrants a second pair of eyes
+
+- Review whether each base name and provider grouping is the desired long-term naming convention.
+- Check whether `litellm` should get an explicit engine leaf value instead of relying on the command/default baseline.
+
+### What should be done in the future
+
+- Consider adding a small profile linter that flags leaf profiles containing `api_keys`, `base_urls`, `chat.api_type`, or provider-specific `client` settings.
+
+### Code review instructions
+
+- Review the redacted summary:
+  - `sources/06-profiles-provider-base-refactor-redacted.md`
+- Validate a profile with:
+
+```bash
+PINOCCHIO_PROFILE=gemini-2.5-pro pinocchio code professional --print-inference-settings --non-interactive hello
+PINOCCHIO_PROFILE=gpt-5-mini pinocchio code professional --print-inference-settings --non-interactive hello
+PINOCCHIO_PROFILE=groq-oss-20b pinocchio code professional --print-inference-settings --non-interactive hello
+```
+
+### Technical details
+
+- Backup:
+  - `/home/manuel/.config/pinocchio/profiles.yaml.bak-20260503-115557-provider-bases`
+- Refactored file:
+  - `/home/manuel/.config/pinocchio/profiles.yaml`

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/01-curl-endpoint-probe-redacted.md
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/01-curl-endpoint-probe-redacted.md
@@ -1,0 +1,62 @@
+---
+Title: Curl endpoint probe redacted
+Ticket: WAFER-AI-404
+Status: active
+Topics:
+    - llm
+    - openai
+    - pinocchio
+    - wafer-ai
+DocType: source
+Intent: short-term
+Owners: []
+RelatedFiles:
+    - /home/manuel/.config/pinocchio/profiles.yaml
+ExternalSources: []
+Summary: "Redacted curl evidence showing Wafer accepts /v1/chat/completions but returns 404 for the double-appended path."
+LastUpdated: 2026-05-03T11:46:00-04:00
+WhatFor: "Provider endpoint evidence for WAFER-AI-404."
+WhenToUse: "Use when validating the Wafer base URL versus operation endpoint distinction."
+---
+
+# Curl endpoint probe (redacted)
+
+The Authorization header used the locally configured Wafer API key but is not stored here.
+
+## Correct endpoint
+
+Command shape:
+
+```bash
+curl -sS -w '\nHTTP_STATUS:%{http_code}\n' -X POST \
+  https://pass.wafer.ai/v1/chat/completions \
+  -H 'Authorization: Bearer ***' \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"DeepSeek-V4-Pro","messages":[{"role":"user","content":"Hello!"}],"max_tokens":8,"stream":true}'
+```
+
+Observed result: HTTP 200 and SSE frames beginning with:
+
+```text
+data: {"id":"...","object":"chat.completion.chunk","created":1777822856,"model":"DeepSeek-V4-Pro","choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}],"usage":null}
+
+data: {"id":"...","object":"chat.completion.chunk","created":1777822856,"model":"DeepSeek-V4-Pro","choices":[{"index":0,"delta":{"role":null,"content":"Hi","reasoning_content":null,"tool_calls":null},"logprobs":null,"finish_reason":null,"matched_stop":null}],"usage":null}
+```
+
+## Double-appended endpoint
+
+Command shape:
+
+```bash
+curl -sS -w '\nHTTP_STATUS:%{http_code}\n' -X POST \
+  https://pass.wafer.ai/v1/chat/completions/chat/completions \
+  -H 'Authorization: Bearer ***' \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"DeepSeek-V4-Pro","messages":[{"role":"user","content":"Hello!"}],"max_tokens":8,"stream":true}'
+```
+
+Observed result:
+
+```text
+HTTP_STATUS:404
+```

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/02-print-inference-settings-wafer-stacked-redacted.log
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/02-print-inference-settings-wafer-stacked-redacted.log
@@ -1,0 +1,767 @@
+http_client:
+    effective_timeout: 0s
+    mode: custom-client
+    proxy_from_environment: true
+    proxy_mode: environment
+    reasons:
+        - effective timeout is 0s instead of the default 1m0s
+settings:
+    api:
+        api_keys:
+            claude-api-key: ""
+            gemini-api-key: ""
+            openai-api-key: '***'
+        base_urls:
+            claude-base-url: https://api.anthropic.com
+            gemini-base-url: https://generativelanguage.googleapis.com/
+            openai-base-url: https://pass.wafer.ai/v1
+    chat:
+        api_type: openai
+        cache_max_entries: 1000
+        cache_max_size: 1073741824
+        cache_type: none
+        engine: DeepSeek-V4-Pro
+        stream: true
+        structured_output_mode: "off"
+        structured_output_strict: true
+        temperature: 0.7
+        top_p: 1
+    claude:
+        top_k: 1
+        user_id: ""
+    client:
+        organization: ""
+        proxy_from_environment: true
+    embeddings:
+        cachedirectory: ""
+        cachemaxentries: 1000
+        cachemaxsize: 1073741824
+        cachetype: none
+        dimensions: 1536
+        engine: text-embedding-3-small
+        type: openai
+    gemini: {}
+    inference: {}
+    ollama:
+        mirostat: 0
+        mirostat-eta: 0.1
+        mirostat-tau: 5
+        num-ctx: 2048
+        num-gpu: 50
+        num-gqa: 1
+        num-predict: 128
+        num-thread: 1
+        repeat-last-n: 64
+        repeat-penalty: 1.1
+        seed: 0
+        temperature: 0.8
+        tfs-z: 1
+        top-k: 40
+        top-p: 0.9
+    openai:
+        frequency_penalty: 0
+        include_reasoning_encrypted: false
+        "n": 1
+        parallel_tool_calls: false
+        presence_penalty: 0
+        reasoning_effort: medium
+        reasoning_summary: auto
+        stream-include-usage: true
+sources:
+    api:
+        api_keys:
+            claude-api-key:
+                log:
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                value: ""
+            gemini-api-key:
+                log:
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                value: ""
+            openai-api-key:
+                log:
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                    - metadata:
+                        profile_slug: wafer-deepseek-v4-pro
+                        profile_source: ""
+                        registry_slug: default
+                        stack_lineage:
+                            - profile_slug: wafer-base
+                              registry_slug: default
+                              source: ""
+                              version: 0
+                            - profile_slug: wafer-deepseek-v4-pro
+                              registry_slug: default
+                              source: ""
+                              version: 0
+                      source: profile
+                      value: '***'
+                value: '***'
+        base_urls:
+            claude-base-url:
+                log:
+                    - metadata: {}
+                      source: defaults
+                      value: https://api.anthropic.com
+                    - metadata: {}
+                      source: defaults
+                      value: https://api.anthropic.com
+                    - metadata: {}
+                      source: defaults
+                      value: https://api.anthropic.com
+                value: https://api.anthropic.com
+            gemini-base-url:
+                log:
+                    - metadata: {}
+                      source: defaults
+                      value: https://generativelanguage.googleapis.com/
+                    - metadata: {}
+                      source: defaults
+                      value: https://generativelanguage.googleapis.com/
+                    - metadata: {}
+                      source: defaults
+                      value: https://generativelanguage.googleapis.com/
+                value: https://generativelanguage.googleapis.com/
+            openai-base-url:
+                log:
+                    - metadata: {}
+                      source: defaults
+                      value: https://api.openai.com/v1
+                    - metadata: {}
+                      source: defaults
+                      value: https://api.openai.com/v1
+                    - metadata: {}
+                      source: defaults
+                      value: https://api.openai.com/v1
+                    - metadata:
+                        profile_slug: wafer-deepseek-v4-pro
+                        profile_source: ""
+                        registry_slug: default
+                        stack_lineage:
+                            - profile_slug: wafer-base
+                              registry_slug: default
+                              source: ""
+                              version: 0
+                            - profile_slug: wafer-deepseek-v4-pro
+                              registry_slug: default
+                              source: ""
+                              version: 0
+                      source: profile
+                      value: https://pass.wafer.ai/v1
+                value: https://pass.wafer.ai/v1
+    chat:
+        api_type:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: openai
+                - metadata: {}
+                  source: defaults
+                  value: openai
+                - metadata: {}
+                  source: defaults
+                  value: openai
+                - metadata: {}
+                  source: defaults
+                  value: openai
+                - metadata:
+                    profile_slug: wafer-deepseek-v4-pro
+                    profile_source: ""
+                    registry_slug: default
+                    stack_lineage:
+                        - profile_slug: wafer-base
+                          registry_slug: default
+                          source: ""
+                          version: 0
+                        - profile_slug: wafer-deepseek-v4-pro
+                          registry_slug: default
+                          source: ""
+                          version: 0
+                  source: profile
+                  value: openai
+            value: openai
+        cache_max_entries:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1000
+                - metadata: {}
+                  source: defaults
+                  value: 1000
+                - metadata: {}
+                  source: defaults
+                  value: 1000
+                - metadata: {}
+                  source: defaults
+                  value: 1000
+            value: 1000
+        cache_max_size:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1073741824
+                - metadata: {}
+                  source: defaults
+                  value: 1073741824
+                - metadata: {}
+                  source: defaults
+                  value: 1073741824
+                - metadata: {}
+                  source: defaults
+                  value: 1073741824
+            value: 1073741824
+        cache_type:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: none
+                - metadata: {}
+                  source: defaults
+                  value: none
+                - metadata: {}
+                  source: defaults
+                  value: none
+                - metadata: {}
+                  source: defaults
+                  value: none
+            value: none
+        engine:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: gpt-4
+                - metadata: {}
+                  source: defaults
+                  value: gpt-4
+                - metadata: {}
+                  source: defaults
+                  value: gpt-4
+                - metadata: {}
+                  source: defaults
+                  value: gpt-4
+                - metadata:
+                    profile_slug: wafer-deepseek-v4-pro
+                    profile_source: ""
+                    registry_slug: default
+                    stack_lineage:
+                        - profile_slug: wafer-base
+                          registry_slug: default
+                          source: ""
+                          version: 0
+                        - profile_slug: wafer-deepseek-v4-pro
+                          registry_slug: default
+                          source: ""
+                          version: 0
+                  source: profile
+                  value: DeepSeek-V4-Pro
+            value: DeepSeek-V4-Pro
+        stream:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: true
+            value: true
+        structured_output_mode:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: "off"
+                - metadata: {}
+                  source: defaults
+                  value: "off"
+                - metadata: {}
+                  source: defaults
+                  value: "off"
+                - metadata: {}
+                  source: defaults
+                  value: "off"
+            value: "off"
+        structured_output_strict:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+            value: true
+        temperature:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0.7
+                - metadata: {}
+                  source: defaults
+                  value: 0.7
+                - metadata: {}
+                  source: defaults
+                  value: 0.7
+                - metadata: {}
+                  source: defaults
+                  value: 0.7
+            value: 0.7
+        top_p:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+            value: 1
+    claude:
+        top_k:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+            value: 1
+        user_id:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+            value: ""
+    client:
+        organization:
+            log:
+                - metadata: {}
+                  source: defaults
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+            value: ""
+        proxy_from_environment:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+            value: true
+    embeddings:
+        cachedirectory:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+            value: ""
+        cachemaxentries:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1000
+                - metadata: {}
+                  source: defaults
+                  value: 1000
+                - metadata: {}
+                  source: defaults
+                  value: 1000
+                - metadata: {}
+                  source: defaults
+                  value: 1000
+            value: 1000
+        cachemaxsize:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1073741824
+                - metadata: {}
+                  source: defaults
+                  value: 1073741824
+                - metadata: {}
+                  source: defaults
+                  value: 1073741824
+                - metadata: {}
+                  source: defaults
+                  value: 1073741824
+            value: 1073741824
+        cachetype:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: none
+                - metadata: {}
+                  source: defaults
+                  value: none
+                - metadata: {}
+                  source: defaults
+                  value: none
+                - metadata: {}
+                  source: defaults
+                  value: none
+            value: none
+        dimensions:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1536
+                - metadata: {}
+                  source: defaults
+                  value: 1536
+                - metadata: {}
+                  source: defaults
+                  value: 1536
+                - metadata: {}
+                  source: defaults
+                  value: 1536
+            value: 1536
+        engine:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: text-embedding-3-small
+                - metadata: {}
+                  source: defaults
+                  value: text-embedding-3-small
+                - metadata: {}
+                  source: defaults
+                  value: text-embedding-3-small
+                - metadata: {}
+                  source: defaults
+                  value: text-embedding-3-small
+            value: text-embedding-3-small
+        type:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: openai
+                - metadata: {}
+                  source: defaults
+                  value: openai
+                - metadata: {}
+                  source: defaults
+                  value: openai
+                - metadata: {}
+                  source: defaults
+                  value: openai
+            value: openai
+    ollama:
+        mirostat:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0
+            value: 0
+        mirostat-eta:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0.1
+            value: 0.1
+        mirostat-tau:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 5
+            value: 5
+        num-ctx:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 2048
+            value: 2048
+        num-gpu:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 50
+            value: 50
+        num-gqa:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1
+            value: 1
+        num-predict:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 128
+            value: 128
+        num-thread:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1
+            value: 1
+        repeat-last-n:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 64
+            value: 64
+        repeat-penalty:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1.1
+            value: 1.1
+        seed:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0
+            value: 0
+        temperature:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0.8
+            value: 0.8
+        tfs-z:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1
+            value: 1
+        top-k:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 40
+            value: 40
+        top-p:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0.9
+            value: 0.9
+    openai:
+        frequency_penalty:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0
+                - metadata: {}
+                  source: defaults
+                  value: 0
+                - metadata: {}
+                  source: defaults
+                  value: 0
+                - metadata: {}
+                  source: defaults
+                  value: 0
+            value: 0
+        include_reasoning_encrypted:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: false
+                - metadata: {}
+                  source: defaults
+                  value: false
+                - metadata: {}
+                  source: defaults
+                  value: false
+                - metadata: {}
+                  source: defaults
+                  value: false
+            value: false
+        "n":
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+            value: 1
+        parallel_tool_calls:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: false
+                - metadata: {}
+                  source: defaults
+                  value: false
+                - metadata: {}
+                  source: defaults
+                  value: false
+                - metadata: {}
+                  source: defaults
+                  value: false
+            value: false
+        presence_penalty:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0
+                - metadata: {}
+                  source: defaults
+                  value: 0
+                - metadata: {}
+                  source: defaults
+                  value: 0
+                - metadata: {}
+                  source: defaults
+                  value: 0
+            value: 0
+        reasoning_effort:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: medium
+                - metadata: {}
+                  source: defaults
+                  value: medium
+                - metadata: {}
+                  source: defaults
+                  value: medium
+                - metadata: {}
+                  source: defaults
+                  value: medium
+            value: medium
+        reasoning_summary:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: auto
+                - metadata: {}
+                  source: defaults
+                  value: auto
+                - metadata: {}
+                  source: defaults
+                  value: auto
+                - metadata: {}
+                  source: defaults
+                  value: auto
+            value: auto
+        stream-include-usage:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+            value: true

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/03-live-wafer-deepseek-after-profile-stack.log
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/03-live-wafer-deepseek-after-profile-stack.log
@@ -1,0 +1,26 @@
+2026-05-03T11:49:59.072470281-04:00 DBG ../../../code/wesen/corporate-headquarters/glazed/pkg/cmds/logging/init.go:118 > Logger initialized file= format=text logToStdout=false logstash=false
+2026-05-03T11:49:59.079397128-04:00 DBG ../../../code/wesen/corporate-headquarters/glazed/pkg/help/help.go:146 > Failed to load section from file error="failed to parse frontmatter: yaml: mapping values are not allowed in this context" file=tutorials/04-intern-app-owned-middleware-events-timeline-widgets.md
+2026-05-03T11:49:59.678111042-04:00 DBG ../../../code/wesen/corporate-headquarters/pinocchio/cmd/pinocchio/main.go:102 > Executing pinocchio
+2026-05-03T11:49:59.678206118-04:00 DBG ../../../code/wesen/corporate-headquarters/glazed/pkg/cmds/logging/init.go:118 > Logger initialized file= format=text logToStdout=false logstash=false
+2026-05-03T11:49:59.702475374-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:48 > OpenAI RunInference started num_blocks=2 stream=true
+2026-05-03T11:49:59.702545552-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/helpers.go:391 > Making request to openai from turn blocks frequency_penalty=0 max_completion_tokens=0 max_tokens=0 model=DeepSeek-V4-Pro n=1 presence_penalty=0 stop=[] stream=true temperature=0.7 top_p=1
+2026-05-03T11:49:59.702578155-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/helpers.go:424 > OpenAI request message content_preview="You are an experienced technology professional and technical leader in software.\nYou give concise answers.\nYou are proficient in various programming languages a…" idx=0 role=system tool_call_count=0 tool_call_id= tool_call_ids=[]
+2026-05-03T11:49:59.702602737-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/helpers.go:424 > OpenAI request message content_preview=hello idx=1 role=user tool_call_count=0 tool_call_id= tool_call_ids=[]
+2026-05-03T11:49:59.702626937-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:189 > LLMInferenceData initialized event_id=b4ab2f31-59ae-4515-b6af-efe9ff2ad790 max_tokens=null model=DeepSeek-V4-Pro temperature=0.7 top_p=1
+2026-05-03T11:49:59.702647886-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:208 > OpenAI publishing start event event_id=b4ab2f31-59ae-4515-b6af-efe9ff2ad790
+2026-05-03T11:49:59.70277003-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:213 > OpenAI using streaming mode
+2026-05-03T11:50:00.270194371-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:238 > OpenAI starting streaming loop
+Hello. How can I help you today?2026-05-03T11:50:00.520837832-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:255 > OpenAI stream completed chunks_received=9
+2026-05-03T11:50:00.520890123-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:344 > OpenAI metadata finalized input_tokens=209 output_tokens=10 stop_reason=stop
+2026-05-03T11:50:00.52092107-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:347 > OpenAI streaming complete, preparing messages final_text_length=32 tool_call_count=0
+2026-05-03T11:50:00.520988597-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:405 > OpenAI publishing final event (streaming) event_id=b4ab2f31-59ae-4515-b6af-efe9ff2ad790 max_tokens=null model=DeepSeek-V4-Pro stop_reason=stop temperature=0.7 top_p=1 usage={"input_tokens":209,"output_tokens":10}
+
+2026-05-03T11:50:00.521091616-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:409 > OpenAI RunInference completed (streaming)
+2026-05-03T11:50:00.521222216-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:93 > Closing publisher
+2026-05-03T11:50:00.521266234-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:99 > Publisher closed
+2026-05-03T11:50:00.521285935-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:103 > Closing router
+2026-05-03T11:50:00.521342462-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:93 > Closing publisher
+2026-05-03T11:50:00.521326418-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:109 > Router closed
+2026-05-03T11:50:00.521378735-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:99 > Publisher closed
+2026-05-03T11:50:00.521394704-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:103 > Closing router
+2026-05-03T11:50:00.521405574-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:109 > Router closed

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/04-deepseek-thinking-mode-defuddle.md
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/04-deepseek-thinking-mode-defuddle.md
@@ -1,0 +1,266 @@
+---
+Title: DeepSeek Thinking Mode documentation (Defuddle extract)
+Ticket: WAFER-AI-404
+Status: active
+Topics:
+    - llm
+    - openai
+    - wafer-ai
+DocType: source
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: geppetto/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/geppetto/pkg/steps/ai/openai/chat_types.go
+      Note: Current OpenAI ChatCompletionRequest shape lacks DeepSeek thinking/reasoning_effort fields
+ExternalSources:
+    - https://api-docs.deepseek.com/guides/thinking_mode
+Summary: Defuddle extract of DeepSeek's thinking mode docs, including OpenAI-format thinking toggle and reasoning_effort parameters.
+LastUpdated: 2026-05-03T11:55:00-04:00
+WhatFor: Source evidence for configuring DeepSeek V4 thinking mode through Wafer/OpenAI-compatible chat completions.
+WhenToUse: Use when implementing or validating DeepSeek V4 thinking toggle and effort settings.
+---
+
+
+# DeepSeek Thinking Mode documentation (Defuddle extract)
+
+Source: https://api-docs.deepseek.com/guides/thinking_mode
+
+## Thinking Mode
+
+The DeepSeek model supports the thinking mode: before outputting the final answer, the model will first output a chain-of-thought reasoning to improve the accuracy of the final response.
+
+## Thinking Mode Toggle and Effort Control
+
+**
+
+<table><tbody><tr><td></td><td>Control Parameter (OpenAI Format)</td><td>Control Parameter (Anthropic Format)</td></tr><tr><td>Thinking Mode Toggle <sup>(1)</sup></td><td colspan="2"><code>{"thinking": {"type": "enabled/disabled"}}</code></td></tr><tr><td>Thinking Effort Control <sup>(2)(3)</sup></td><td><code>{"reasoning_effort": "high/max"}</code></td><td><code>{"output_config": {"effort": "high/max"}}</code></td></tr></tbody></table>
+
+**
+
+(1) The thinking toggle defaults to `enabled`  
+(2) In thinking mode, the default effort is `high` for regular requests; for some complex agent requests (such as Claude Code, OpenCode), effort is automatically set to `max`  
+(3) In thinking mode, for compatibility, `low` and `medium` are mapped to `high`, and `xhigh` is mapped to `max`
+
+When using the OpenAI SDK, you need to pass the `thinking` parameter within `extra_body`:
+
+```python
+response = client.chat.completions.create(
+  model="deepseek-v4-pro",
+  # ...
+  reasoning_effort="high",
+  extra_body={"thinking": {"type": "enabled"}}
+)
+```
+
+## Input and Output Parameters
+
+Thinking mode does not support the `temperature`, `top_p`, `presence_penalty`, or `frequency_penalty` parameters. Please note that, for compatibility with existing software, setting these parameters will not trigger an error but will also have no effect.
+
+In thinking mode, the chain-of-thought content is returned via the `reasoning_content` parameter, at the same level as `content`. When concatenating subsequent turns, you can selectively return `reasoning_content` to the API:
+
+- Between two `user` messages, if the model **did not perform a tool call**, the intermediate `assistant` 's `reasoning_content` does not need to participate in the context concatenation. If passed to the API in subsequent turns, it will be ignored. See [Multi-turn Conversation](https://api-docs.deepseek.com/guides/thinking_mode#multi-turn-conversation) for details.
+- Between two `user` messages, if the model **performed a tool call**, the intermediate `assistant` 's `reasoning_content` must participate in the context concatenation and must be **passed back to the API** in all subsequent user interaction turns. See [Tool Calls](https://api-docs.deepseek.com/guides/thinking_mode#tool-calls) for details.
+
+## Multi-turn Conversation
+
+In each turn of the conversation, the model outputs the CoT (`reasoning_content`) and the final answer (`content`). If there is no tool call, the CoT content from previous turns will not be concatenated into the context in the next turn, as illustrated in the following diagram:
+
+![](https://api-docs.deepseek.com/img/deepseek_r1_multiround_example_en.jpeg)
+
+### Sample Code
+
+The following code, using Python as an example, demonstrates how to access the CoT and the final answer, as well as how to concatenate context in multi-turn conversations.
+
+- NoStreaming
+- Streaming
+
+```python
+from openai import OpenAI
+client = OpenAI(api_key="<DeepSeek API Key>", base_url="https://api.deepseek.com")
+
+# Turn 1
+messages = [{"role": "user", "content": "9.11 and 9.8, which is greater?"}]
+response = client.chat.completions.create(
+    model="deepseek-v4-pro",
+    messages=messages,
+    reasoning_effort="high"
+    extra_body={"thinking": {"type": "enabled"}},
+)
+
+reasoning_content = response.choices[0].message.reasoning_content
+content = response.choices[0].message.content
+
+# Turn 2
+# The reasoning_content will be ignored by the API
+messages.append(response.choices[0].message)
+messages.append({'role': 'user', 'content': "How many Rs are there in the word 'strawberry'?"})
+response = client.chat.completions.create(
+    model="deepseek-v4-pro",
+    messages=messages,
+    reasoning_effort="high"
+    extra_body={"thinking": {"type": "enabled"}},
+)
+# ...
+```
+
+## Tool Calls
+
+The DeepSeek model's thinking mode supports tool calls. Before outputting the final answer, the model can perform multiple turns of reasoning and tool calls to improve the quality of the response. The calling pattern is illustrated below:
+
+![](https://api-docs.deepseek.com/img/thinking_with_tools_en.jpg)
+
+Please note that, unlike turns in thinking mode that do not involve tool calls, for turns that do perform tool calls, the `reasoning_content` must be fully passed back to the API in all subsequent requests.
+
+If your code does not correctly pass back `reasoning_content`, the API will return a 400 error. Please refer to the sample code below for the correct approach.
+
+### Sample Code
+
+Below is a simple sample code for tool calls in thinking mode:
+
+```python
+import os
+import json
+from openai import OpenAI
+from datetime import datetime
+
+# The definition of the tools
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_date",
+            "description": "Get the current date",
+            "parameters": { "type": "object", "properties": {} },
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather of a location, the user should supply the location and date.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "location": { "type": "string", "description": "The city name" },
+                    "date": { "type": "string", "description": "The date in format YYYY-mm-dd" },
+                },
+                "required": ["location", "date"]
+            },
+        }
+    },
+]
+
+# The mocked version of the tool calls
+def get_date_mock():
+    return datetime.now().strftime("%Y-%m-%d")
+
+def get_weather_mock(location, date):
+    return "Cloudy 7~13°C"
+
+TOOL_CALL_MAP = {
+    "get_date": get_date_mock,
+    "get_weather": get_weather_mock
+}
+
+def run_turn(turn, messages):
+    sub_turn = 1
+    while True:
+        response = client.chat.completions.create(
+            model='deepseek-v4-pro',
+            messages=messages,
+            tools=tools,
+            reasoning_effort="high",
+            extra_body={ "thinking": { "type": "enabled" } },
+        )
+        messages.append(response.choices[0].message)
+        reasoning_content = response.choices[0].message.reasoning_content
+        content = response.choices[0].message.content
+        tool_calls = response.choices[0].message.tool_calls
+        print(f"Turn {turn}.{sub_turn}\n{reasoning_content=}\n{content=}\n{tool_calls=}")
+        # If there is no tool calls, then the model should get a final answer and we need to stop the loop
+        if tool_calls is None:
+            break
+        for tool in tool_calls:
+            tool_function = TOOL_CALL_MAP[tool.function.name]
+            tool_result = tool_function(**json.loads(tool.function.arguments))
+            print(f"tool result for {tool.function.name}: {tool_result}\n")
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tool.id,
+                "content": tool_result,
+            })
+        sub_turn += 1
+    print()
+
+client = OpenAI(
+    api_key=os.environ.get('DEEPSEEK_API_KEY'),
+    base_url=os.environ.get('DEEPSEEK_BASE_URL'),
+)
+
+# The user starts a question
+turn = 1
+messages = [{
+    "role": "user",
+    "content": "How's the weather in Hangzhou Tomorrow"
+}]
+run_turn(turn, messages)
+
+# The user starts a new question
+turn = 2
+messages.append({
+    "role": "user",
+    "content": "How's the weather in Guangzhou Tomorrow"
+})
+run_turn(turn, messages)
+```
+
+In each sub-request of Turn 1, the `reasoning_content` generated during that turn is sent to the API, allowing the model to continue its previous reasoning. `response.choices[0].message` contains all necessary fields for the `assistant` message, including `content`, `reasoning_content`, and `tool_calls`. For simplicity, you can directly append the message to the end of the messages list using the following code:
+
+```markdown
+messages.append(response.choices[0].message)
+```
+
+This line of code is equivalent to:
+
+```markdown
+messages.append({
+    'role': 'assistant',
+    'content': response.choices[0].message.content,
+    'reasoning_content': response.choices[0].message.reasoning_content,
+    'tool_calls': response.choices[0].message.tool_calls,
+})
+```
+
+Additionally, in the Turn 2 request, we still pass the `reasoning_content` generated in Turn 1 to the API.
+
+The sample output of this code is as follows:
+
+```bash
+Turn 1.1
+reasoning_content="The user is asking about the weather in Hangzhou tomorrow. I need to get tomorrow's date first, then call the weather function."
+content="Let me check tomorrow's weather in Hangzhou for you. First, let me get tomorrow's date."
+tool_calls=[ChatCompletionMessageFunctionToolCall(id='call_00_kw66qNnNto11bSfJVIdlV5Oo', function=Function(arguments='{}', name='get_date'), type='function', index=0)]
+tool result for get_date: 2026-04-19
+
+Turn 1.2
+reasoning_content="Today is 2026-04-19, so tomorrow is 2026-04-20. Now I'll call the weather function for Hangzhou."
+content=''
+tool_calls=[ChatCompletionMessageFunctionToolCall(id='call_00_H2SCW6136vWJGq9SQlBuhVt4', function=Function(arguments='{"location": "Hangzhou", "date": "2026-04-20"}', name='get_weather'), type='function', index=0)]
+tool result for get_weather: Cloudy 7~13°C
+
+Turn 1.3
+reasoning_content='The weather result is in. Let me share this with the user.'
+content="Here's the weather forecast for **Hangzhou tomorrow (April 20, 2026)**:\n\n- 🌤 **Condition:** Cloudy  \n- 🌡 **Temperature:** 7°C ~ 13°C (45°F ~ 55°F)\n\nIt'll be on the cooler side, so you might want to bring a light jacket if you're heading out! Let me know if you need anything else."
+tool_calls=None
+
+Turn 2.1
+reasoning_content='The user is asking about the weather in Guangzhou tomorrow. Today is 2026-04-19, so tomorrow is 2026-04-20. I can directly call the weather function.'
+content=''
+tool_calls=[ChatCompletionMessageFunctionToolCall(id='call_00_8URkLt5NjmNkVKhDmMcNq9Mo', function=Function(arguments='{"location": "Guangzhou", "date": "2026-04-20"}', name='get_weather'), type='function', index=0)]
+tool result for get_weather: Cloudy 7~13°C
+
+Turn 2.2
+reasoning_content='The weather result for Guangzhou is the same as Hangzhou. Let me share this with the user.'
+content="Here's the weather forecast for **Guangzhou tomorrow (April 20, 2026)**:\n\n- 🌤 **Condition:** Cloudy  \n- 🌡 **Temperature:** 7°C ~ 13°C (45°F ~ 55°F)\n\nIt'll be cool and cloudy, so a light jacket would be a good idea if you're going out. Let me know if there's anything else you'd like to know!"
+tool_calls=None
+```

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/05-kagi-deepseek-v4-thinking-search.md
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/05-kagi-deepseek-v4-thinking-search.md
@@ -1,0 +1,92 @@
+---
+Title: Kagi search results for DeepSeek V4 thinking configuration
+Ticket: WAFER-AI-404
+Status: active
+Topics:
+    - llm
+    - openai
+    - wafer-ai
+DocType: source
+Intent: short-term
+Owners: []
+RelatedFiles: []
+ExternalSources:
+    - https://kagi.com/search?q=DeepSeek+V4+API+thinking+mode+reasoning_effort+parameter
+Summary: "Search results used to locate DeepSeek V4 thinking mode documentation."
+LastUpdated: 2026-05-03T11:55:00-04:00
+WhatFor: "Search provenance for DeepSeek V4 thinking mode analysis."
+WhenToUse: "Use when retracing how the DeepSeek thinking-mode source was found."
+---
+
+# Kagi search results for DeepSeek V4 thinking configuration
+
+Command:
+
+```bash
+surf kagi search --query "DeepSeek V4 API thinking mode reasoning_effort parameter"
+```
+
+# Kagi Search
+
+- Query: `DeepSeek V4 API thinking mode reasoning_effort parameter`
+- URL: https://kagi.com/search?q=DeepSeek+V4+API+thinking+mode+reasoning_effort+parameter
+- Title: DeepSeek V4 API thinking mode reasoning_effort parameter - Kagi Search
+- Result count: 10
+
+## Results
+
+### 1. [Thinking Mode - DeepSeek API Docs](https://api-docs.deepseek.com/guides/thinking_mode)
+
+- Display URL: `api-docs.deepseek.com › guides › thinking_mode`
+
+In thinking mode, the chain-of-thought content is returned via the reasoning_content parameter, at the same level as content . When concatenating subsequent ...
+
+### 2. [thinking_mode_api_example_no...](https://api-docs.deepseek.com/api_samples/thinking_mode_api_example_non_streaming)
+
+
+response = client.chat.completions.create( model="deepseek-v4-pro", messages=messages, reasoning_effort="high" extra_body={"thinking": {"type": "enabled"}}, )
+
+### 3. [Reasoning Model (deepseek-reasoner)](https://api-docs.deepseek.com/guides/reasoning_model)
+
+
+deepseek-reasoner is a reasoning model developed by DeepSeek. Before delivering the final answer, the model first generates a Chain of Thought (CoT) to enhance ...
+
+### 4. [DeepSeek V4 API Tutorial: Building a Thinking Mode Arena](https://www.datacamp.com/tutorial/deepseek-v4-api-tutorial)
+
+- Display URL: `datacamp.com › tutorial › deepseek-v4-api-tutorial`
+
+Apr 30, 2026 The thinking_type is passed via extra_body={"thinking": {"type": ...}} , and reasoning_effort is a top-level request parameter. Non-think sets ...
+
+### 5. [Guide to Disable Reasoning on DeepSeek V4 (And More) - Reddit](https://www.reddit.com/r/SillyTavernAI/comments/1svtklp/guide_to_disable_reasoning_on_deepseek_v4_and_more/)
+
+- Display URL: `reddit.com › r › SillyTavernAI › comments › 1svtklp`
+
+Apr 26, 2026 Want a 400 token output? You're going to suck up ~400 more tokens with reasoning (depending on settings), meaning you're doubling your response ...
+
+### 6. [R1 Reasoning Effort for the Open-Webui : r/LocalLLaMA - Reddit](https://www.reddit.com/r/LocalLLaMA/comments/1idflkk/r1_reasoning_effort_for_the_openwebui/)
+
+
+Jan 30, 2025 The Reasoning Effort parameter controls how long the model spends thinking before finalizing a response. ... Then sending this back to the API to ...
+
+### 7. [How do i force an api models (i am using deepseek v3.1 now) to not ...](https://www.reddit.com/r/SillyTavernAI/comments/1nrwl64/how_do_i_force_an_api_models_i_am_using_deepseek/)
+
+
+Sep 27, 2025 How do i force an api models (i am using deepseek v3.1 now) to not use thinking? Help.
+
+### 8. [DeepSeek-V4 - SGLang Documentation](https://docs.sglang.io/cookbook/autoregressive/DeepSeek/DeepSeek-V4)
+
+- Display URL: `docs.sglang.io › cookbook › autoregressive › DeepSeek › DeepSeek-V4`
+
+Enable the deepseek-v4 reasoning parser (check the box in the command panel above) to separate thinking from the final answer into reasoning_content vs content.
+
+### 9. [API parameter: 'reasoning_effort' (for DeepSeek-R1) #8544 - GitHub](https://github.com/ollama/ollama/issues/8544)
+
+- Display URL: `github.com › ollama › ollama › issues › 8544`
+
+Jan 22, 2025 reasoning_effort is not a supported parameter either in the deepseek API or the ollama API, although ollama does allow disabling reasoning with ...
+
+### 10. [[Solution] How to enable DeepSeek V4 thinking mode in OpenCode using ...](https://github.com/anomalyco/opencode/issues/24122)
+
+- Display URL: `github.com › anomalyco › opencode › issues › 24122`
+
+Problem When using DeepSeek V4 with thinking mode enabled in OpenCode, you may encounter this error: The reasoning_content in the thinking mode must be passed back to the API This happens because: ...

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/06-profiles-provider-base-refactor-redacted.md
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/06-profiles-provider-base-refactor-redacted.md
@@ -1,0 +1,123 @@
+---
+Title: Profiles provider base refactor redacted summary
+Ticket: WAFER-AI-404
+Status: active
+Topics:
+    - llm
+    - pinocchio
+    - profiles
+DocType: source
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - /home/manuel/.config/pinocchio/profiles.yaml
+ExternalSources: []
+Summary: "Redacted summary of the local profiles.yaml refactor that moved repeated provider credentials/base URLs/API types into base profiles."
+LastUpdated: 2026-05-03T12:00:00-04:00
+WhatFor: "Audit trail for the local profile stack refactor without storing API keys."
+WhenToUse: "Use when reviewing or reversing the provider base profile layout."
+---
+
+# Profiles provider base refactor redacted summary
+
+Sensitive source file:
+
+```text
+/home/manuel/.config/pinocchio/profiles.yaml
+```
+
+Backup created before the refactor:
+
+```text
+/home/manuel/.config/pinocchio/profiles.yaml.bak-20260503-115557-provider-bases
+```
+
+## Base profiles created or normalized
+
+- `wafer-base`
+- `together-base`
+- `cerebras-base`
+- `openai-responses-base`
+- `claude-base`
+- `gemini-base`
+- `ollama-openai-base`
+- `groq-base`
+- `litellm-base`
+- `mistral-base`
+- `anyscale-base`
+- `openrouter-base`
+- `z-ai-base`
+
+Each base profile owns provider-specific settings such as:
+
+- `chat.api_type`
+- `api.api_keys.*` where needed
+- `api.base_urls.*` where needed
+- provider-level `client` settings where needed (`z-ai-base` owns its timeout)
+
+## Leaf profile pattern
+
+Leaf profiles now stack on a provider base and keep only model-specific settings.
+
+Example shape:
+
+```yaml
+openai-responses-base:
+  inference_settings:
+    chat:
+      api_type: openai-responses
+    api:
+      api_keys:
+        openai-api-key: '***'
+
+gpt-5-mini:
+  stack:
+    - profile_slug: openai-responses-base
+  inference_settings:
+    chat:
+      engine: gpt-5-mini
+```
+
+Provider/model examples:
+
+```yaml
+groq-base:
+  inference_settings:
+    chat:
+      api_type: openai
+    api:
+      api_keys:
+        openai-api-key: '***'
+      base_urls:
+        openai-base-url: https://api.groq.com/openai/v1
+
+kimi:
+  stack:
+    - profile_slug: groq-base
+  inference_settings:
+    chat:
+      engine: moonshotai/kimi-k2-instruct
+```
+
+## Validation performed
+
+All non-base stacked profiles were checked with:
+
+```bash
+PINOCCHIO_PROFILE=<profile> pinocchio code professional --print-inference-settings --non-interactive hello
+```
+
+Every checked profile resolved successfully.
+
+A script also verified there are no leaf-profile repetitions of:
+
+- `inference_settings.api.api_keys`
+- `inference_settings.api.base_urls`
+- `inference_settings.chat.api_type`
+- `inference_settings.client`
+
+Result:
+
+```text
+violations []
+```

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/live_wafer_deepseek_404.log
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/live_wafer_deepseek_404.log
@@ -1,0 +1,23 @@
+2026-05-03T11:40:16.771845717-04:00 DBG ../../../code/wesen/corporate-headquarters/glazed/pkg/cmds/logging/init.go:118 > Logger initialized file= format=text logToStdout=false logstash=false
+2026-05-03T11:40:16.801163456-04:00 DBG ../../../code/wesen/corporate-headquarters/glazed/pkg/help/help.go:146 > Failed to load section from file error="failed to parse frontmatter: yaml: mapping values are not allowed in this context" file=tutorials/04-intern-app-owned-middleware-events-timeline-widgets.md
+2026-05-03T11:40:17.488372645-04:00 DBG ../../../code/wesen/corporate-headquarters/pinocchio/cmd/pinocchio/main.go:102 > Executing pinocchio
+2026-05-03T11:40:17.488547697-04:00 DBG ../../../code/wesen/corporate-headquarters/glazed/pkg/cmds/logging/init.go:118 > Logger initialized file= format=text logToStdout=false logstash=false
+2026-05-03T11:40:17.496837407-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:48 > OpenAI RunInference started num_blocks=2 stream=true
+2026-05-03T11:40:17.49690944-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/helpers.go:391 > Making request to openai from turn blocks frequency_penalty=0 max_completion_tokens=0 max_tokens=0 model=DeepSeek-V4-Pro n=1 presence_penalty=0 stop=[] stream=true temperature=0.7 top_p=1
+2026-05-03T11:40:17.496949426-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/helpers.go:424 > OpenAI request message content_preview="You are an experienced technology professional and technical leader in software.\nYou give concise answers.\nYou are proficient in various programming languages a…" idx=0 role=system tool_call_count=0 tool_call_id= tool_call_ids=[]
+2026-05-03T11:40:17.496975298-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/helpers.go:424 > OpenAI request message content_preview=hello idx=1 role=user tool_call_count=0 tool_call_id= tool_call_ids=[]
+2026-05-03T11:40:17.497001558-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:189 > LLMInferenceData initialized event_id=7ec1d767-6eb8-435c-a70d-e0069aaf27e1 max_tokens=null model=DeepSeek-V4-Pro temperature=0.7 top_p=1
+2026-05-03T11:40:17.497025904-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:208 > OpenAI publishing start event event_id=7ec1d767-6eb8-435c-a70d-e0069aaf27e1
+2026-05-03T11:40:17.497179688-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:213 > OpenAI using streaming mode
+2026-05-03T11:40:17.901534927-04:00 ERR ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:216 > OpenAI streaming request failed error="chat completions error: status=404"
+
+[error] chat completions error: status=404
+2026-05-03T11:40:17.901728858-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:93 > Closing publisher
+2026-05-03T11:40:17.901763266-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:99 > Publisher closed
+2026-05-03T11:40:17.901774636-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:103 > Closing router
+2026-05-03T11:40:17.901797477-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:109 > Router closed
+2026-05-03T11:40:17.901806829-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:93 > Closing publisher
+2026-05-03T11:40:17.901865048-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:99 > Publisher closed
+2026-05-03T11:40:17.901878261-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:103 > Closing router
+2026-05-03T11:40:17.901889185-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:109 > Router closed
+Error: inference failed: chat completions error: status=404

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/live_wafer_deepseek_base_v1.log
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/live_wafer_deepseek_base_v1.log
@@ -1,0 +1,23 @@
+2026-05-03T11:40:23.373926196-04:00 DBG ../../../code/wesen/corporate-headquarters/glazed/pkg/cmds/logging/init.go:118 > Logger initialized file= format=text logToStdout=false logstash=false
+2026-05-03T11:40:23.383133587-04:00 DBG ../../../code/wesen/corporate-headquarters/glazed/pkg/help/help.go:146 > Failed to load section from file error="failed to parse frontmatter: yaml: mapping values are not allowed in this context" file=tutorials/04-intern-app-owned-middleware-events-timeline-widgets.md
+2026-05-03T11:40:23.803177165-04:00 DBG ../../../code/wesen/corporate-headquarters/pinocchio/cmd/pinocchio/main.go:102 > Executing pinocchio
+2026-05-03T11:40:23.803290691-04:00 DBG ../../../code/wesen/corporate-headquarters/glazed/pkg/cmds/logging/init.go:118 > Logger initialized file= format=text logToStdout=false logstash=false
+2026-05-03T11:40:23.817303771-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:48 > OpenAI RunInference started num_blocks=2 stream=true
+2026-05-03T11:40:23.8174377-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/helpers.go:391 > Making request to openai from turn blocks frequency_penalty=0 max_completion_tokens=0 max_tokens=0 model=DeepSeek-V4-Pro n=1 presence_penalty=0 stop=[] stream=true temperature=0.7 top_p=1
+2026-05-03T11:40:23.817495206-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/helpers.go:424 > OpenAI request message content_preview="You are an experienced technology professional and technical leader in software.\nYou give concise answers.\nYou are proficient in various programming languages a…" idx=0 role=system tool_call_count=0 tool_call_id= tool_call_ids=[]
+2026-05-03T11:40:23.817531475-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/helpers.go:424 > OpenAI request message content_preview=hello idx=1 role=user tool_call_count=0 tool_call_id= tool_call_ids=[]
+2026-05-03T11:40:23.817567181-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:189 > LLMInferenceData initialized event_id=ead56300-7de3-4263-b104-7e9d4743df71 max_tokens=null model=DeepSeek-V4-Pro temperature=0.7 top_p=1
+2026-05-03T11:40:23.817601341-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:208 > OpenAI publishing start event event_id=ead56300-7de3-4263-b104-7e9d4743df71
+2026-05-03T11:40:23.817800787-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:213 > OpenAI using streaming mode
+2026-05-03T11:40:24.258160466-04:00 ERR ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:216 > OpenAI streaming request failed error="chat completions error: status=404"
+
+[error] chat completions error: status=404
+2026-05-03T11:40:24.258669258-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:93 > Closing publisher
+2026-05-03T11:40:24.258743261-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:99 > Publisher closed
+2026-05-03T11:40:24.258779416-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:103 > Closing router
+2026-05-03T11:40:24.258818826-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:109 > Router closed
+2026-05-03T11:40:24.258829411-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:93 > Closing publisher
+2026-05-03T11:40:24.258982167-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:99 > Publisher closed
+2026-05-03T11:40:24.259024917-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:103 > Closing router
+2026-05-03T11:40:24.259061673-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:109 > Router closed
+Error: inference failed: chat completions error: status=404

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/live_wafer_deepseek_corrected_profile.log
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/live_wafer_deepseek_corrected_profile.log
@@ -1,0 +1,23 @@
+2026-05-03T11:40:38.92211178-04:00 DBG ../../../code/wesen/corporate-headquarters/glazed/pkg/cmds/logging/init.go:118 > Logger initialized file= format=text logToStdout=false logstash=false
+2026-05-03T11:40:38.928240798-04:00 DBG ../../../code/wesen/corporate-headquarters/glazed/pkg/help/help.go:146 > Failed to load section from file error="failed to parse frontmatter: yaml: mapping values are not allowed in this context" file=tutorials/04-intern-app-owned-middleware-events-timeline-widgets.md
+2026-05-03T11:40:39.329490626-04:00 DBG ../../../code/wesen/corporate-headquarters/pinocchio/cmd/pinocchio/main.go:102 > Executing pinocchio
+2026-05-03T11:40:39.329598035-04:00 DBG ../../../code/wesen/corporate-headquarters/glazed/pkg/cmds/logging/init.go:118 > Logger initialized file= format=text logToStdout=false logstash=false
+2026-05-03T11:40:39.337131408-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:48 > OpenAI RunInference started num_blocks=2 stream=true
+2026-05-03T11:40:39.337202065-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/helpers.go:391 > Making request to openai from turn blocks frequency_penalty=0 max_completion_tokens=0 max_tokens=0 model=DeepSeek-V4-Pro n=1 presence_penalty=0 stop=[] stream=true temperature=0.7 top_p=1
+2026-05-03T11:40:39.337238249-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/helpers.go:424 > OpenAI request message content_preview="You are an experienced technology professional and technical leader in software.\nYou give concise answers.\nYou are proficient in various programming languages a…" idx=0 role=system tool_call_count=0 tool_call_id= tool_call_ids=[]
+2026-05-03T11:40:39.337265511-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/helpers.go:424 > OpenAI request message content_preview=hello idx=1 role=user tool_call_count=0 tool_call_id= tool_call_ids=[]
+2026-05-03T11:40:39.337293821-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:189 > LLMInferenceData initialized event_id=1c3bbbe1-c8a1-48f4-b928-451d348a1084 max_tokens=null model=DeepSeek-V4-Pro temperature=0.7 top_p=1
+2026-05-03T11:40:39.337316127-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:208 > OpenAI publishing start event event_id=1c3bbbe1-c8a1-48f4-b928-451d348a1084
+2026-05-03T11:40:39.337453057-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:213 > OpenAI using streaming mode
+2026-05-03T11:40:39.730298627-04:00 ERR ../../../code/wesen/corporate-headquarters/geppetto/pkg/steps/ai/openai/engine_openai.go:216 > OpenAI streaming request failed error="chat completions error: status=404"
+
+[error] chat completions error: status=404
+2026-05-03T11:40:39.730498635-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:93 > Closing publisher
+2026-05-03T11:40:39.73053332-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:99 > Publisher closed
+2026-05-03T11:40:39.73054617-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:103 > Closing router
+2026-05-03T11:40:39.730571831-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:109 > Router closed
+2026-05-03T11:40:39.730575465-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:93 > Closing publisher
+2026-05-03T11:40:39.730616814-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:99 > Publisher closed
+2026-05-03T11:40:39.730628066-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:103 > Closing router
+2026-05-03T11:40:39.730638776-04:00 DBG ../../../code/wesen/corporate-headquarters/geppetto/pkg/events/event-router.go:109 > Router closed
+Error: inference failed: chat completions error: status=404

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/print_inference_settings_wafer_deepseek_redacted.log
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/sources/print_inference_settings_wafer_deepseek_redacted.log
@@ -1,0 +1,751 @@
+http_client:
+    effective_timeout: 0s
+    mode: custom-client
+    proxy_from_environment: true
+    proxy_mode: environment
+    reasons:
+        - effective timeout is 0s instead of the default 1m0s
+settings:
+    api:
+        api_keys:
+            claude-api-key: ""
+            gemini-api-key: ""
+            openai-api-key: '***'
+        base_urls:
+            claude-base-url: https://api.anthropic.com
+            gemini-base-url: https://generativelanguage.googleapis.com/
+            openai-base-url: https://pass.wafer.ai/v1/chat/completions
+    chat:
+        api_type: openai
+        cache_max_entries: 1000
+        cache_max_size: 1073741824
+        cache_type: none
+        engine: DeepSeek-V4-Pro
+        stream: true
+        structured_output_mode: "off"
+        structured_output_strict: true
+        temperature: 0.7
+        top_p: 1
+    claude:
+        top_k: 1
+        user_id: ""
+    client:
+        organization: ""
+        proxy_from_environment: true
+    embeddings:
+        cachedirectory: ""
+        cachemaxentries: 1000
+        cachemaxsize: 1073741824
+        cachetype: none
+        dimensions: 1536
+        engine: text-embedding-3-small
+        type: openai
+    gemini: {}
+    inference: {}
+    ollama:
+        mirostat: 0
+        mirostat-eta: 0.1
+        mirostat-tau: 5
+        num-ctx: 2048
+        num-gpu: 50
+        num-gqa: 1
+        num-predict: 128
+        num-thread: 1
+        repeat-last-n: 64
+        repeat-penalty: 1.1
+        seed: 0
+        temperature: 0.8
+        tfs-z: 1
+        top-k: 40
+        top-p: 0.9
+    openai:
+        frequency_penalty: 0
+        include_reasoning_encrypted: false
+        "n": 1
+        parallel_tool_calls: false
+        presence_penalty: 0
+        reasoning_effort: medium
+        reasoning_summary: auto
+        stream-include-usage: true
+sources:
+    api:
+        api_keys:
+            claude-api-key:
+                log:
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                value: ""
+            gemini-api-key:
+                log:
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                value: ""
+            openai-api-key:
+                log:
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                    - metadata: {}
+                      source: defaults
+                      value: ""
+                    - metadata:
+                        profile_slug: wafer-deepseek-v4-pro
+                        profile_source: ""
+                        registry_slug: default
+                        stack_lineage:
+                            - profile_slug: wafer-deepseek-v4-pro
+                              registry_slug: default
+                              source: ""
+                              version: 0
+                      source: profile
+                      value: '***'
+                value: '***'
+        base_urls:
+            claude-base-url:
+                log:
+                    - metadata: {}
+                      source: defaults
+                      value: https://api.anthropic.com
+                    - metadata: {}
+                      source: defaults
+                      value: https://api.anthropic.com
+                    - metadata: {}
+                      source: defaults
+                      value: https://api.anthropic.com
+                value: https://api.anthropic.com
+            gemini-base-url:
+                log:
+                    - metadata: {}
+                      source: defaults
+                      value: https://generativelanguage.googleapis.com/
+                    - metadata: {}
+                      source: defaults
+                      value: https://generativelanguage.googleapis.com/
+                    - metadata: {}
+                      source: defaults
+                      value: https://generativelanguage.googleapis.com/
+                value: https://generativelanguage.googleapis.com/
+            openai-base-url:
+                log:
+                    - metadata: {}
+                      source: defaults
+                      value: https://api.openai.com/v1
+                    - metadata: {}
+                      source: defaults
+                      value: https://api.openai.com/v1
+                    - metadata: {}
+                      source: defaults
+                      value: https://api.openai.com/v1
+                    - metadata:
+                        profile_slug: wafer-deepseek-v4-pro
+                        profile_source: ""
+                        registry_slug: default
+                        stack_lineage:
+                            - profile_slug: wafer-deepseek-v4-pro
+                              registry_slug: default
+                              source: ""
+                              version: 0
+                      source: profile
+                      value: https://pass.wafer.ai/v1/chat/completions
+                value: https://pass.wafer.ai/v1/chat/completions
+    chat:
+        api_type:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: openai
+                - metadata: {}
+                  source: defaults
+                  value: openai
+                - metadata: {}
+                  source: defaults
+                  value: openai
+                - metadata: {}
+                  source: defaults
+                  value: openai
+                - metadata:
+                    profile_slug: wafer-deepseek-v4-pro
+                    profile_source: ""
+                    registry_slug: default
+                    stack_lineage:
+                        - profile_slug: wafer-deepseek-v4-pro
+                          registry_slug: default
+                          source: ""
+                          version: 0
+                  source: profile
+                  value: openai
+            value: openai
+        cache_max_entries:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1000
+                - metadata: {}
+                  source: defaults
+                  value: 1000
+                - metadata: {}
+                  source: defaults
+                  value: 1000
+                - metadata: {}
+                  source: defaults
+                  value: 1000
+            value: 1000
+        cache_max_size:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1073741824
+                - metadata: {}
+                  source: defaults
+                  value: 1073741824
+                - metadata: {}
+                  source: defaults
+                  value: 1073741824
+                - metadata: {}
+                  source: defaults
+                  value: 1073741824
+            value: 1073741824
+        cache_type:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: none
+                - metadata: {}
+                  source: defaults
+                  value: none
+                - metadata: {}
+                  source: defaults
+                  value: none
+                - metadata: {}
+                  source: defaults
+                  value: none
+            value: none
+        engine:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: gpt-4
+                - metadata: {}
+                  source: defaults
+                  value: gpt-4
+                - metadata: {}
+                  source: defaults
+                  value: gpt-4
+                - metadata: {}
+                  source: defaults
+                  value: gpt-4
+                - metadata:
+                    profile_slug: wafer-deepseek-v4-pro
+                    profile_source: ""
+                    registry_slug: default
+                    stack_lineage:
+                        - profile_slug: wafer-deepseek-v4-pro
+                          registry_slug: default
+                          source: ""
+                          version: 0
+                  source: profile
+                  value: DeepSeek-V4-Pro
+            value: DeepSeek-V4-Pro
+        stream:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: true
+            value: true
+        structured_output_mode:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: "off"
+                - metadata: {}
+                  source: defaults
+                  value: "off"
+                - metadata: {}
+                  source: defaults
+                  value: "off"
+                - metadata: {}
+                  source: defaults
+                  value: "off"
+            value: "off"
+        structured_output_strict:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+            value: true
+        temperature:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0.7
+                - metadata: {}
+                  source: defaults
+                  value: 0.7
+                - metadata: {}
+                  source: defaults
+                  value: 0.7
+                - metadata: {}
+                  source: defaults
+                  value: 0.7
+            value: 0.7
+        top_p:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+            value: 1
+    claude:
+        top_k:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+            value: 1
+        user_id:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+            value: ""
+    client:
+        organization:
+            log:
+                - metadata: {}
+                  source: defaults
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+            value: ""
+        proxy_from_environment:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+            value: true
+    embeddings:
+        cachedirectory:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+                - metadata: {}
+                  source: defaults
+                  value: ""
+            value: ""
+        cachemaxentries:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1000
+                - metadata: {}
+                  source: defaults
+                  value: 1000
+                - metadata: {}
+                  source: defaults
+                  value: 1000
+                - metadata: {}
+                  source: defaults
+                  value: 1000
+            value: 1000
+        cachemaxsize:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1073741824
+                - metadata: {}
+                  source: defaults
+                  value: 1073741824
+                - metadata: {}
+                  source: defaults
+                  value: 1073741824
+                - metadata: {}
+                  source: defaults
+                  value: 1073741824
+            value: 1073741824
+        cachetype:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: none
+                - metadata: {}
+                  source: defaults
+                  value: none
+                - metadata: {}
+                  source: defaults
+                  value: none
+                - metadata: {}
+                  source: defaults
+                  value: none
+            value: none
+        dimensions:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1536
+                - metadata: {}
+                  source: defaults
+                  value: 1536
+                - metadata: {}
+                  source: defaults
+                  value: 1536
+                - metadata: {}
+                  source: defaults
+                  value: 1536
+            value: 1536
+        engine:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: text-embedding-3-small
+                - metadata: {}
+                  source: defaults
+                  value: text-embedding-3-small
+                - metadata: {}
+                  source: defaults
+                  value: text-embedding-3-small
+                - metadata: {}
+                  source: defaults
+                  value: text-embedding-3-small
+            value: text-embedding-3-small
+        type:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: openai
+                - metadata: {}
+                  source: defaults
+                  value: openai
+                - metadata: {}
+                  source: defaults
+                  value: openai
+                - metadata: {}
+                  source: defaults
+                  value: openai
+            value: openai
+    ollama:
+        mirostat:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0
+            value: 0
+        mirostat-eta:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0.1
+            value: 0.1
+        mirostat-tau:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 5
+            value: 5
+        num-ctx:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 2048
+            value: 2048
+        num-gpu:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 50
+            value: 50
+        num-gqa:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1
+            value: 1
+        num-predict:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 128
+            value: 128
+        num-thread:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1
+            value: 1
+        repeat-last-n:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 64
+            value: 64
+        repeat-penalty:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1.1
+            value: 1.1
+        seed:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0
+            value: 0
+        temperature:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0.8
+            value: 0.8
+        tfs-z:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1
+            value: 1
+        top-k:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 40
+            value: 40
+        top-p:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0.9
+            value: 0.9
+    openai:
+        frequency_penalty:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0
+                - metadata: {}
+                  source: defaults
+                  value: 0
+                - metadata: {}
+                  source: defaults
+                  value: 0
+                - metadata: {}
+                  source: defaults
+                  value: 0
+            value: 0
+        include_reasoning_encrypted:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: false
+                - metadata: {}
+                  source: defaults
+                  value: false
+                - metadata: {}
+                  source: defaults
+                  value: false
+                - metadata: {}
+                  source: defaults
+                  value: false
+            value: false
+        "n":
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+                - metadata: {}
+                  source: defaults
+                  value: 1
+            value: 1
+        parallel_tool_calls:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: false
+                - metadata: {}
+                  source: defaults
+                  value: false
+                - metadata: {}
+                  source: defaults
+                  value: false
+                - metadata: {}
+                  source: defaults
+                  value: false
+            value: false
+        presence_penalty:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: 0
+                - metadata: {}
+                  source: defaults
+                  value: 0
+                - metadata: {}
+                  source: defaults
+                  value: 0
+                - metadata: {}
+                  source: defaults
+                  value: 0
+            value: 0
+        reasoning_effort:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: medium
+                - metadata: {}
+                  source: defaults
+                  value: medium
+                - metadata: {}
+                  source: defaults
+                  value: medium
+                - metadata: {}
+                  source: defaults
+                  value: medium
+            value: medium
+        reasoning_summary:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: auto
+                - metadata: {}
+                  source: defaults
+                  value: auto
+                - metadata: {}
+                  source: defaults
+                  value: auto
+                - metadata: {}
+                  source: defaults
+                  value: auto
+            value: auto
+        stream-include-usage:
+            log:
+                - metadata:
+                    kind: command-baseline
+                  source: command
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+                - metadata: {}
+                  source: defaults
+                  value: true
+            value: true

--- a/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/tasks.md
+++ b/ttmp/2026/05/03/WAFER-AI-404--investigate-wafer-ai-profile-404-in-openai-chat-completions/tasks.md
@@ -1,0 +1,19 @@
+# Tasks
+
+## Completed
+
+- [x] Create docmgr ticket workspace for Wafer AI 404 investigation.
+- [x] Inspect local Wafer profiles with API keys redacted.
+- [x] Trace Geppetto OpenAI chat endpoint construction in source code.
+- [x] Capture `--print-inference-settings` evidence for `wafer-deepseek-v4-pro`.
+- [x] Reproduce live Pinocchio 404 with current profile.
+- [x] Probe Wafer endpoint behavior directly with redacted curl evidence.
+- [x] Write analysis and implementation guide.
+- [x] Write chronological investigation diary.
+
+## Follow-up implementation tasks
+
+- [ ] Back up and edit `~/.config/pinocchio/profiles.yaml` so Wafer `openai-base-url` values use `https://pass.wafer.ai/v1`.
+- [ ] Add debug logging for the computed OpenAI chat completions endpoint.
+- [ ] Add warning/tests for `openai-base-url` values ending in `/chat/completions`.
+- [ ] Decide whether CLI base URL flags should override profile values.

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -91,6 +91,12 @@ topics:
       description: Pinocchio web-chat backend, SEM, and frontend runtime integration
     - slug: agentmode
       description: Agent mode middleware, runtime policy, and UI/event integration
+    - slug: llm
+      description: Large language model behavior, configuration, and operations
+    - slug: openai
+      description: OpenAI API and OpenAI-compatible provider integrations
+    - slug: wafer-ai
+      description: Wafer AI provider configuration and diagnostics
 docTypes:
     - slug: index
       description: Ticket index


### PR DESCRIPTION
## Summary

Adds detection and warning for common OpenAI-compatible base URL
misconfigurations that result in 404 errors. When users accidentally
include `/chat/completions` or extra path segments in their provider
base URL, Geppetto now surfaces a clear hint in the error message
and logs a warning.

## Motivation

A common support issue: users configure their provider base URL as
`https://provider.example/v1/chat/completions` instead of
`https://provider.example/v1`. Geppetto internally appends
`/chat/completions`, resulting in a double-path 404 that is hard
to diagnose without inspecting the raw request.