### PR TITLE
add reasoning flag supports for openai completions api

### DIFF
--- a/pkg/inference/engine/inference_config.go
+++ b/pkg/inference/engine/inference_config.go
@@ -16,7 +16,7 @@ type InferenceConfig struct {
 	// Maps to Claude thinking.budget_tokens, OpenAI Responses reasoning.max_tokens.
 	ThinkingBudget *int `json:"thinking_budget,omitempty" yaml:"thinking_budget,omitempty" glazed:"inference-thinking-budget"`
 
-	// ReasoningEffort controls reasoning depth: "low", "medium", "high".
+	// ReasoningEffort controls reasoning depth.
 	// Maps to OpenAI Responses reasoning.effort and provider-native Chat Completions reasoning_effort when supported.
 	ReasoningEffort *string `json:"reasoning_effort,omitempty" yaml:"reasoning_effort,omitempty" glazed:"inference-reasoning-effort"`
 

--- a/pkg/inference/engine/inference_config.go
+++ b/pkg/inference/engine/inference_config.go
@@ -17,8 +17,11 @@ type InferenceConfig struct {
 	ThinkingBudget *int `json:"thinking_budget,omitempty" yaml:"thinking_budget,omitempty" glazed:"inference-thinking-budget"`
 
 	// ReasoningEffort controls reasoning depth: "low", "medium", "high".
-	// Maps to OpenAI Responses reasoning.effort.
+	// Maps to OpenAI Responses reasoning.effort and provider-native Chat Completions reasoning_effort when supported.
 	ReasoningEffort *string `json:"reasoning_effort,omitempty" yaml:"reasoning_effort,omitempty" glazed:"inference-reasoning-effort"`
+
+	// ThinkingType controls provider-native thinking mode toggles such as DeepSeek Chat Completions thinking.type.
+	ThinkingType *string `json:"thinking_type,omitempty" yaml:"thinking_type,omitempty" glazed:"inference-thinking-type"`
 
 	// ReasoningSummary controls reasoning summary generation.
 	// Maps to OpenAI Responses reasoning.summary ("auto", "concise", "detailed").
@@ -87,6 +90,10 @@ func MergeInferenceConfig(turnCfg, engineDefault *InferenceConfig) *InferenceCon
 	if turnCfg.ReasoningEffort != nil {
 		v := *turnCfg.ReasoningEffort
 		merged.ReasoningEffort = &v
+	}
+	if turnCfg.ThinkingType != nil {
+		v := *turnCfg.ThinkingType
+		merged.ThinkingType = &v
 	}
 	if turnCfg.ReasoningSummary != nil {
 		v := *turnCfg.ReasoningSummary

--- a/pkg/inference/engine/inference_config_test.go
+++ b/pkg/inference/engine/inference_config_test.go
@@ -38,6 +38,7 @@ func TestMergeInferenceConfig_TurnFieldsOverrideDefaults(t *testing.T) {
 		TopP:              float64Ptr(0.9),
 		MaxResponseTokens: intPtr(1024),
 		ThinkingBudget:    intPtr(4096),
+		ThinkingType:      strPtr("enabled"),
 		Stop:              []string{"<END>"},
 		Seed:              intPtr(42),
 	}
@@ -64,6 +65,9 @@ func TestMergeInferenceConfig_TurnFieldsOverrideDefaults(t *testing.T) {
 	if *got.ThinkingBudget != 4096 {
 		t.Errorf("ThinkingBudget: want 4096 (default), got %v", *got.ThinkingBudget)
 	}
+	if *got.ThinkingType != "enabled" {
+		t.Errorf("ThinkingType: want enabled (default), got %v", *got.ThinkingType)
+	}
 	if *got.Seed != 42 {
 		t.Errorf("Seed: want 42 (default), got %v", *got.Seed)
 	}
@@ -78,6 +82,7 @@ func TestMergeInferenceConfig_AllTurnFieldsSet(t *testing.T) {
 	turn := &InferenceConfig{
 		ThinkingBudget:    intPtr(8192),
 		ReasoningEffort:   strPtr("high"),
+		ThinkingType:      strPtr("disabled"),
 		ReasoningSummary:  strPtr("concise"),
 		Temperature:       float64Ptr(1.0),
 		TopP:              float64Ptr(0.5),
@@ -92,6 +97,9 @@ func TestMergeInferenceConfig_AllTurnFieldsSet(t *testing.T) {
 	}
 	if *got.ReasoningEffort != "high" {
 		t.Errorf("ReasoningEffort: want high, got %v", *got.ReasoningEffort)
+	}
+	if *got.ThinkingType != "disabled" {
+		t.Errorf("ThinkingType: want disabled, got %v", *got.ThinkingType)
 	}
 	if *got.ReasoningSummary != "concise" {
 		t.Errorf("ReasoningSummary: want concise, got %v", *got.ReasoningSummary)

--- a/pkg/steps/ai/openai/chat_types.go
+++ b/pkg/steps/ai/openai/chat_types.go
@@ -29,6 +29,14 @@ type ChatCompletionRequest struct {
 	Tools               []ChatCompletionTool          `json:"tools,omitempty"`
 	ToolChoice          any                           `json:"tool_choice,omitempty"`
 	ParallelToolCalls   *bool                         `json:"parallel_tool_calls,omitempty"`
+	ReasoningEffort     string                        `json:"reasoning_effort,omitempty"`
+	Thinking            *ChatThinkingControl          `json:"thinking,omitempty"`
+}
+
+// ChatThinkingControl configures provider-native thinking mode for OpenAI-compatible
+// Chat Completions APIs that support the DeepSeek-style thinking extension.
+type ChatThinkingControl struct {
+	Type string `json:"type"`
 }
 
 type ChatCompletionMessage struct {

--- a/pkg/steps/ai/openai/chat_types.go
+++ b/pkg/steps/ai/openai/chat_types.go
@@ -40,11 +40,12 @@ type ChatThinkingControl struct {
 }
 
 type ChatCompletionMessage struct {
-	Role         string
-	Content      string
-	MultiContent []ChatMessagePart
-	ToolCalls    []ChatToolCall
-	ToolCallID   string
+	Role             string
+	Content          string
+	ReasoningContent string
+	MultiContent     []ChatMessagePart
+	ToolCalls        []ChatToolCall
+	ToolCallID       string
 }
 
 func (m ChatCompletionMessage) MarshalJSON() ([]byte, error) {
@@ -55,6 +56,9 @@ func (m ChatCompletionMessage) MarshalJSON() ([]byte, error) {
 		raw["content"] = m.MultiContent
 	} else if m.Content != "" {
 		raw["content"] = m.Content
+	}
+	if m.ReasoningContent != "" {
+		raw["reasoning_content"] = m.ReasoningContent
 	}
 	if len(m.ToolCalls) > 0 {
 		raw["tool_calls"] = m.ToolCalls

--- a/pkg/steps/ai/openai/chat_types_test.go
+++ b/pkg/steps/ai/openai/chat_types_test.go
@@ -35,6 +35,34 @@ func TestChatCompletionMessageMarshalJSON_UsesMultiContentArrayWhenPresent(t *te
 	}
 }
 
+func TestChatCompletionMessageMarshalJSON_IncludesReasoningContentWhenSet(t *testing.T) {
+	msg := ChatCompletionMessage{
+		Role:             "assistant",
+		ReasoningContent: "need a tool",
+		ToolCalls: []ChatToolCall{{
+			ID:   "call_1",
+			Type: chatToolTypeFunction,
+			Function: ChatFunctionCall{
+				Name:      "lookup",
+				Arguments: `{"q":"cats"}`,
+			},
+		}},
+	}
+
+	raw, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal message: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal message: %v", err)
+	}
+	if decoded["reasoning_content"] != "need a tool" {
+		t.Fatalf("expected reasoning_content, got %#v", decoded["reasoning_content"])
+	}
+}
+
 func TestChatCompletionRequestMarshalJSON_IncludesThinkingControlsWhenSet(t *testing.T) {
 	req := ChatCompletionRequest{
 		Model: "DeepSeek-V4-Pro",

--- a/pkg/steps/ai/openai/chat_types_test.go
+++ b/pkg/steps/ai/openai/chat_types_test.go
@@ -35,6 +35,39 @@ func TestChatCompletionMessageMarshalJSON_UsesMultiContentArrayWhenPresent(t *te
 	}
 }
 
+func TestChatCompletionRequestMarshalJSON_IncludesThinkingControlsWhenSet(t *testing.T) {
+	req := ChatCompletionRequest{
+		Model: "DeepSeek-V4-Pro",
+		Messages: []ChatCompletionMessage{
+			{Role: "user", Content: "hello"},
+		},
+		N:               1,
+		Stream:          true,
+		ReasoningEffort: "max",
+		Thinking:        &ChatThinkingControl{Type: "enabled"},
+	}
+
+	raw, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if decoded["reasoning_effort"] != "max" {
+		t.Fatalf("expected reasoning_effort=max, got %#v", decoded["reasoning_effort"])
+	}
+	thinking, ok := decoded["thinking"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected thinking object, got %#v", decoded["thinking"])
+	}
+	if thinking["type"] != "enabled" {
+		t.Fatalf("expected thinking.type=enabled, got %#v", thinking["type"])
+	}
+}
+
 func TestChatCompletionRequestMarshalJSON_PreservesExplicitFalseParallelToolCalls(t *testing.T) {
 	req := ChatCompletionRequest{
 		Model: "gpt-4o-mini",

--- a/pkg/steps/ai/openai/helpers.go
+++ b/pkg/steps/ai/openai/helpers.go
@@ -23,6 +23,32 @@ func GetToolCallString(toolCalls []ChatToolCall) string {
 	return msg
 }
 
+func normalizeChatThinkingType(v string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "auto":
+		return "", nil
+	case "enabled", "disabled":
+		return strings.ToLower(strings.TrimSpace(v)), nil
+	default:
+		return "", fmt.Errorf("unsupported openai chat thinking_type %q", v)
+	}
+}
+
+func normalizeChatReasoningEffort(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "auto":
+		return ""
+	case "low", "medium":
+		return "high"
+	case "xhigh":
+		return "max"
+	case "high", "max":
+		return strings.ToLower(strings.TrimSpace(v))
+	default:
+		return strings.ToLower(strings.TrimSpace(v))
+	}
+}
+
 type ToolCallMerger struct {
 	toolCalls map[int]ChatToolCall
 }
@@ -366,6 +392,18 @@ func (e *OpenAIEngine) MakeCompletionRequestFromTurn(
 	if settings.OpenAI.FrequencyPenalty != nil {
 		frequencyPenalty = *settings.OpenAI.FrequencyPenalty
 	}
+	thinkingType := ""
+	chatReasoningEffort := ""
+	if settings.OpenAI.ThinkingType != nil {
+		var err error
+		thinkingType, err = normalizeChatThinkingType(*settings.OpenAI.ThinkingType)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if settings.OpenAI.ChatReasoningEffort != nil {
+		chatReasoningEffort = normalizeChatReasoningEffort(*settings.OpenAI.ChatReasoningEffort)
+	}
 
 	if isReasoningModel(engine) {
 		maxCompletionTokens = maxTokens
@@ -388,6 +426,8 @@ func (e *OpenAIEngine) MakeCompletionRequestFromTurn(
 		Strs("stop", stop).
 		Float64("presence_penalty", presencePenalty).
 		Float64("frequency_penalty", frequencyPenalty).
+		Str("thinking_type", thinkingType).
+		Str("chat_reasoning_effort", chatReasoningEffort).
 		Msg("Making request to openai from turn blocks")
 
 	// Debug: summarize the final message sequence for adjacency and content previews
@@ -443,6 +483,10 @@ func (e *OpenAIEngine) MakeCompletionRequestFromTurn(
 		PresencePenalty:     float32(presencePenalty),
 		FrequencyPenalty:    float32(frequencyPenalty),
 		LogitBias:           nil,
+		ReasoningEffort:     chatReasoningEffort,
+	}
+	if thinkingType != "" {
+		req.Thinking = &ChatThinkingControl{Type: thinkingType}
 	}
 
 	// Apply provider-native structured output schema when configured.
@@ -501,6 +545,20 @@ func (e *OpenAIEngine) MakeCompletionRequestFromTurn(
 		if infCfg.Seed != nil {
 			req.Seed = infCfg.Seed
 		}
+		if infCfg.ReasoningEffort != nil {
+			req.ReasoningEffort = normalizeChatReasoningEffort(*infCfg.ReasoningEffort)
+		}
+		if infCfg.ThinkingType != nil {
+			thinkingType, err := normalizeChatThinkingType(*infCfg.ThinkingType)
+			if err != nil {
+				return nil, err
+			}
+			if thinkingType == "" {
+				req.Thinking = nil
+			} else {
+				req.Thinking = &ChatThinkingControl{Type: thinkingType}
+			}
+		}
 	}
 
 	// Apply OpenAI-specific per-turn overrides from Turn.Data.
@@ -518,6 +576,14 @@ func (e *OpenAIEngine) MakeCompletionRequestFromTurn(
 		if oaiCfg.FrequencyPenalty != nil {
 			req.FrequencyPenalty = float32(*oaiCfg.FrequencyPenalty)
 		}
+	}
+	if req.Thinking != nil && req.Thinking.Type == "enabled" {
+		// DeepSeek-style Chat Completions thinking mode does not support sampling
+		// controls. Omit them after all defaults and overrides have been applied.
+		req.Temperature = 0
+		req.TopP = 0
+		req.PresencePenalty = 0
+		req.FrequencyPenalty = 0
 	}
 
 	// Apply StructuredOutputConfig from Turn.Data (per-turn override).

--- a/pkg/steps/ai/openai/helpers.go
+++ b/pkg/steps/ai/openai/helpers.go
@@ -34,19 +34,23 @@ func normalizeChatThinkingType(v string) (string, error) {
 	}
 }
 
-func normalizeChatReasoningEffort(v string) string {
-	switch strings.ToLower(strings.TrimSpace(v)) {
-	case "", "auto":
-		return ""
-	case "low", "medium":
-		return "high"
-	case "xhigh":
-		return "max"
-	case "high", "max":
-		return strings.ToLower(strings.TrimSpace(v))
-	default:
-		return strings.ToLower(strings.TrimSpace(v))
+func chatReasoningEffortValue(v string) string {
+	return strings.TrimSpace(v)
+}
+
+func blockText(b turns.Block) string {
+	if v, ok := b.Payload[turns.PayloadKeyText]; ok {
+		switch sv := v.(type) {
+		case string:
+			return strings.TrimSpace(sv)
+		case []byte:
+			return strings.TrimSpace(string(sv))
+		default:
+			bb, _ := json.Marshal(v)
+			return strings.TrimSpace(string(bb))
+		}
 	}
+	return ""
 }
 
 type ToolCallMerger struct {
@@ -130,6 +134,7 @@ func (e *OpenAIEngine) MakeCompletionRequestFromTurn(
 
 	// Accumulate tool-calls and ensure any tool results are placed immediately after
 	pendingToolCalls := []ChatToolCall{}
+	pendingReasoningContent := ""
 	toolPhaseActive := false // true after flushing assistant tool_calls, until we exit tool result sequence
 	delayedChats := []ChatCompletionMessage{}
 	// Track expected tool_call ids after a flush so we do not end the tool phase
@@ -142,8 +147,9 @@ func (e *OpenAIEngine) MakeCompletionRequestFromTurn(
 			return
 		}
 		msgs_ = append(msgs_, ChatCompletionMessage{
-			Role:      "assistant",
-			ToolCalls: pendingToolCalls,
+			Role:             "assistant",
+			ReasoningContent: pendingReasoningContent,
+			ToolCalls:        pendingToolCalls,
 		})
 		// Enter tool phase and prepare expected ids; clear pending calls so we don't re-emit them later
 		expectedToolIDs = map[string]bool{}
@@ -156,6 +162,7 @@ func (e *OpenAIEngine) MakeCompletionRequestFromTurn(
 		log.Debug().Int("expected_tool_uses", remainingExpected).Msg("OpenAI request: flushed assistant tool_calls; starting tool phase")
 		toolPhaseActive = true
 		pendingToolCalls = nil
+		pendingReasoningContent = ""
 	}
 	endToolPhase := func() {
 		if toolPhaseActive {
@@ -175,7 +182,14 @@ func (e *OpenAIEngine) MakeCompletionRequestFromTurn(
 		for _, b := range t.Blocks {
 			switch b.Kind {
 			case turns.BlockKindReasoning:
-				// Skip reasoning blocks in ChatCompletions requests; only Responses API understands them.
+				text := blockText(b)
+				if text == "" {
+					continue
+				}
+				if pendingReasoningContent != "" {
+					pendingReasoningContent += "\n"
+				}
+				pendingReasoningContent += text
 				continue
 			case turns.BlockKindUser, turns.BlockKindLLMText, turns.BlockKindSystem:
 				// If we have pending tool calls but haven't emitted tool results yet,
@@ -255,6 +269,9 @@ func (e *OpenAIEngine) MakeCompletionRequestFromTurn(
 					delayedChats = append(delayedChats, msg)
 				} else {
 					msgs_ = append(msgs_, msg)
+				}
+				if role == "user" || role == "system" {
+					pendingReasoningContent = ""
 				}
 
 			case turns.BlockKindToolCall:
@@ -402,7 +419,7 @@ func (e *OpenAIEngine) MakeCompletionRequestFromTurn(
 		}
 	}
 	if settings.OpenAI.ChatReasoningEffort != nil {
-		chatReasoningEffort = normalizeChatReasoningEffort(*settings.OpenAI.ChatReasoningEffort)
+		chatReasoningEffort = chatReasoningEffortValue(*settings.OpenAI.ChatReasoningEffort)
 	}
 
 	if isReasoningModel(engine) {
@@ -546,7 +563,7 @@ func (e *OpenAIEngine) MakeCompletionRequestFromTurn(
 			req.Seed = infCfg.Seed
 		}
 		if infCfg.ReasoningEffort != nil {
-			req.ReasoningEffort = normalizeChatReasoningEffort(*infCfg.ReasoningEffort)
+			req.ReasoningEffort = chatReasoningEffortValue(*infCfg.ReasoningEffort)
 		}
 		if infCfg.ThinkingType != nil {
 			thinkingType, err := normalizeChatThinkingType(*infCfg.ThinkingType)

--- a/pkg/steps/ai/openai/helpers_test.go
+++ b/pkg/steps/ai/openai/helpers_test.go
@@ -110,6 +110,142 @@ func TestMakeCompletionRequestFromTurnReasoningModelSanitizesPenalties(t *testin
 	}
 }
 
+func TestMakeCompletionRequestFromTurnAddsChatThinkingControls(t *testing.T) {
+	engine := "DeepSeek-V4-Pro"
+	thinkingType := "enabled"
+	effort := "max"
+	st := &aisettings.InferenceSettings{
+		Client: &aisettings.ClientSettings{},
+		OpenAI: &aisettingsopenai.Settings{
+			ThinkingType:        &thinkingType,
+			ChatReasoningEffort: &effort,
+		},
+		Chat: &aisettings.ChatSettings{
+			Engine: &engine,
+		},
+	}
+	tu := &turns.Turn{Blocks: []turns.Block{
+		turns.NewUserTextBlock("hello"),
+	}}
+
+	e := newTestEngine(st)
+	req, err := e.MakeCompletionRequestFromTurn(tu)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Thinking == nil || req.Thinking.Type != "enabled" {
+		t.Fatalf("expected thinking enabled, got %#v", req.Thinking)
+	}
+	if req.ReasoningEffort != "max" {
+		t.Fatalf("expected reasoning_effort=max, got %q", req.ReasoningEffort)
+	}
+}
+
+func TestMakeCompletionRequestFromTurnThinkingDisabled(t *testing.T) {
+	engine := "DeepSeek-V4-Pro"
+	thinkingType := "disabled"
+	st := &aisettings.InferenceSettings{
+		Client: &aisettings.ClientSettings{},
+		OpenAI: &aisettingsopenai.Settings{ThinkingType: &thinkingType},
+		Chat:   &aisettings.ChatSettings{Engine: &engine},
+	}
+	tu := &turns.Turn{Blocks: []turns.Block{
+		turns.NewUserTextBlock("hello"),
+	}}
+
+	e := newTestEngine(st)
+	req, err := e.MakeCompletionRequestFromTurn(tu)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Thinking == nil || req.Thinking.Type != "disabled" {
+		t.Fatalf("expected thinking disabled, got %#v", req.Thinking)
+	}
+	if req.ReasoningEffort != "" {
+		t.Fatalf("expected no reasoning effort, got %q", req.ReasoningEffort)
+	}
+}
+
+func TestMakeCompletionRequestFromTurnOmitsChatThinkingByDefault(t *testing.T) {
+	engine := "gpt-4o-mini"
+	st := &aisettings.InferenceSettings{
+		Client: &aisettings.ClientSettings{},
+		OpenAI: &aisettingsopenai.Settings{},
+		Chat:   &aisettings.ChatSettings{Engine: &engine},
+	}
+	tu := &turns.Turn{Blocks: []turns.Block{
+		turns.NewUserTextBlock("hello"),
+	}}
+
+	e := newTestEngine(st)
+	req, err := e.MakeCompletionRequestFromTurn(tu)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Thinking != nil {
+		t.Fatalf("expected thinking to be omitted, got %#v", req.Thinking)
+	}
+	if req.ReasoningEffort != "" {
+		t.Fatalf("expected reasoning effort to be omitted, got %q", req.ReasoningEffort)
+	}
+}
+
+func TestMakeCompletionRequestFromTurnInferenceOverridesChatThinkingControls(t *testing.T) {
+	engine := "DeepSeek-V4-Pro"
+	thinkingType := "enabled"
+	effort := "high"
+	turnThinkingType := "disabled"
+	turnEffort := "xhigh"
+	st := &aisettings.InferenceSettings{
+		Client: &aisettings.ClientSettings{},
+		OpenAI: &aisettingsopenai.Settings{
+			ThinkingType:        &thinkingType,
+			ChatReasoningEffort: &effort,
+		},
+		Chat: &aisettings.ChatSettings{Engine: &engine},
+	}
+	tu := &turns.Turn{Blocks: []turns.Block{
+		turns.NewUserTextBlock("hello"),
+	}}
+	if err := infengine.KeyInferenceConfig.Set(&tu.Data, infengine.InferenceConfig{
+		ThinkingType:    &turnThinkingType,
+		ReasoningEffort: &turnEffort,
+	}); err != nil {
+		t.Fatalf("failed to set inference config: %v", err)
+	}
+
+	e := newTestEngine(st)
+	req, err := e.MakeCompletionRequestFromTurn(tu)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req.Thinking == nil || req.Thinking.Type != "disabled" {
+		t.Fatalf("expected turn thinking disabled, got %#v", req.Thinking)
+	}
+	if req.ReasoningEffort != "max" {
+		t.Fatalf("expected xhigh to normalize to max, got %q", req.ReasoningEffort)
+	}
+}
+
+func TestMakeCompletionRequestFromTurnRejectsInvalidThinkingType(t *testing.T) {
+	engine := "DeepSeek-V4-Pro"
+	thinkingType := "sometimes"
+	st := &aisettings.InferenceSettings{
+		Client: &aisettings.ClientSettings{},
+		OpenAI: &aisettingsopenai.Settings{ThinkingType: &thinkingType},
+		Chat:   &aisettings.ChatSettings{Engine: &engine},
+	}
+	tu := &turns.Turn{Blocks: []turns.Block{
+		turns.NewUserTextBlock("hello"),
+	}}
+
+	e := newTestEngine(st)
+	_, err := e.MakeCompletionRequestFromTurn(tu)
+	if err == nil {
+		t.Fatal("expected invalid thinking type error")
+	}
+}
+
 func TestMakeCompletionRequestFromTurnInferenceEmptyStopClearsChatStop(t *testing.T) {
 	engine := "gpt-4o-mini"
 	st := &aisettings.InferenceSettings{

--- a/pkg/steps/ai/openai/helpers_test.go
+++ b/pkg/steps/ai/openai/helpers_test.go
@@ -222,8 +222,71 @@ func TestMakeCompletionRequestFromTurnInferenceOverridesChatThinkingControls(t *
 	if req.Thinking == nil || req.Thinking.Type != "disabled" {
 		t.Fatalf("expected turn thinking disabled, got %#v", req.Thinking)
 	}
-	if req.ReasoningEffort != "max" {
-		t.Fatalf("expected xhigh to normalize to max, got %q", req.ReasoningEffort)
+	if req.ReasoningEffort != "xhigh" {
+		t.Fatalf("expected xhigh to be sent unchanged, got %q", req.ReasoningEffort)
+	}
+}
+
+func TestMakeCompletionRequestFromTurnPreservesReasoningContentForToolCalls(t *testing.T) {
+	engine := "DeepSeek-V4-Pro"
+	st := &aisettings.InferenceSettings{
+		Client: &aisettings.ClientSettings{},
+		OpenAI: &aisettingsopenai.Settings{},
+		Chat:   &aisettings.ChatSettings{Engine: &engine},
+	}
+	tu := &turns.Turn{Blocks: []turns.Block{
+		turns.NewUserTextBlock("lookup something"),
+		{Kind: turns.BlockKindReasoning, Payload: map[string]any{turns.PayloadKeyText: "need a tool"}},
+		turns.NewToolCallBlock("call_1", "lookup", map[string]any{"q": "something"}),
+		turns.NewToolUseBlock("call_1", "result"),
+		turns.NewUserTextBlock("continue"),
+	}}
+
+	e := newTestEngine(st)
+	req, err := e.MakeCompletionRequestFromTurn(tu)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var toolCallMsg *ChatCompletionMessage
+	for i := range req.Messages {
+		if len(req.Messages[i].ToolCalls) > 0 {
+			toolCallMsg = &req.Messages[i]
+			break
+		}
+	}
+	if toolCallMsg == nil {
+		t.Fatal("expected assistant tool call message")
+	}
+	if toolCallMsg.ReasoningContent != "need a tool" {
+		t.Fatalf("expected reasoning content on tool call message, got %q", toolCallMsg.ReasoningContent)
+	}
+}
+
+func TestMakeCompletionRequestFromTurnDoesNotCarryReasoningAcrossUserBoundary(t *testing.T) {
+	engine := "DeepSeek-V4-Pro"
+	st := &aisettings.InferenceSettings{
+		Client: &aisettings.ClientSettings{},
+		OpenAI: &aisettingsopenai.Settings{},
+		Chat:   &aisettings.ChatSettings{Engine: &engine},
+	}
+	tu := &turns.Turn{Blocks: []turns.Block{
+		turns.NewUserTextBlock("hello"),
+		{Kind: turns.BlockKindReasoning, Payload: map[string]any{turns.PayloadKeyText: "old thinking"}},
+		turns.NewAssistantTextBlock("hi"),
+		turns.NewUserTextBlock("lookup something"),
+		turns.NewToolCallBlock("call_1", "lookup", map[string]any{"q": "something"}),
+		turns.NewToolUseBlock("call_1", "result"),
+	}}
+
+	e := newTestEngine(st)
+	req, err := e.MakeCompletionRequestFromTurn(tu)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, msg := range req.Messages {
+		if len(msg.ToolCalls) > 0 && msg.ReasoningContent != "" {
+			t.Fatalf("expected old reasoning not to cross user boundary, got %q", msg.ReasoningContent)
+		}
 	}
 }
 

--- a/pkg/steps/ai/settings/flags/inference.yaml
+++ b/pkg/steps/ai/settings/flags/inference.yaml
@@ -13,16 +13,11 @@ flags:
       Token budget for model thinking/reasoning. Maps to Claude
       thinking.budget_tokens and OpenAI Responses reasoning.max_tokens.
   - name: inference-reasoning-effort
-    type: choice
-    choices:
-      - "low"
-      - "medium"
-      - "high"
-      - "max"
-      - "xhigh"
+    type: string
     help: >
       Reasoning effort level. Maps to OpenAI Responses reasoning.effort and
       provider-native OpenAI-compatible Chat Completions reasoning_effort when supported.
+      Chat Completions sends the value exactly as provided.
   - name: inference-thinking-type
     type: choice
     choices:

--- a/pkg/steps/ai/settings/flags/inference.yaml
+++ b/pkg/steps/ai/settings/flags/inference.yaml
@@ -18,8 +18,19 @@ flags:
       - "low"
       - "medium"
       - "high"
+      - "max"
+      - "xhigh"
     help: >
-      Reasoning effort level. Maps to OpenAI Responses reasoning.effort.
+      Reasoning effort level. Maps to OpenAI Responses reasoning.effort and
+      provider-native OpenAI-compatible Chat Completions reasoning_effort when supported.
+  - name: inference-thinking-type
+    type: choice
+    choices:
+      - "enabled"
+      - "disabled"
+    help: >
+      Provider-native thinking toggle for model APIs that support it, such as
+      DeepSeek-style OpenAI-compatible Chat Completions thinking.type.
   - name: inference-reasoning-summary
     type: choice
     choices:

--- a/pkg/steps/ai/settings/openai/chat.yaml
+++ b/pkg/steps/ai/settings/openai/chat.yaml
@@ -46,15 +46,8 @@ flags:
     help: Provider-native thinking toggle for OpenAI-compatible Chat Completions APIs that support it
     default: ""
   - name: openai-chat-reasoning-effort
-    type: choice
-    choices:
-      - ""
-      - "low"
-      - "medium"
-      - "high"
-      - "max"
-      - "xhigh"
-    help: Provider-native reasoning effort for OpenAI-compatible Chat Completions APIs that support it
+    type: string
+    help: Provider-native reasoning effort for OpenAI-compatible Chat Completions APIs that support it; sent exactly as provided
     default: ""
   - name: openai-parallel-tool-calls
     type: bool

--- a/pkg/steps/ai/settings/openai/chat.yaml
+++ b/pkg/steps/ai/settings/openai/chat.yaml
@@ -37,6 +37,25 @@ flags:
       - "high"
     help: Reasoning effort level for Responses API models
     default: "medium"
+  - name: openai-thinking-type
+    type: choice
+    choices:
+      - ""
+      - "enabled"
+      - "disabled"
+    help: Provider-native thinking toggle for OpenAI-compatible Chat Completions APIs that support it
+    default: ""
+  - name: openai-chat-reasoning-effort
+    type: choice
+    choices:
+      - ""
+      - "low"
+      - "medium"
+      - "high"
+      - "max"
+      - "xhigh"
+    help: Provider-native reasoning effort for OpenAI-compatible Chat Completions APIs that support it
+    default: ""
   - name: openai-parallel-tool-calls
     type: bool
     help: Hint for parallel tool execution when using Responses API

--- a/pkg/steps/ai/settings/openai/settings.go
+++ b/pkg/steps/ai/settings/openai/settings.go
@@ -20,6 +20,10 @@ type Settings struct {
 	LogitBias map[string]string `yaml:"logit_bias,omitempty" glazed:"openai-logit-bias"`
 	// ReasoningEffort for Responses API (low|medium|high)
 	ReasoningEffort *string `yaml:"reasoning_effort,omitempty" glazed:"openai-reasoning-effort"`
+	// ThinkingType controls provider-native thinking mode for OpenAI-compatible Chat Completions.
+	ThinkingType *string `yaml:"thinking_type,omitempty" glazed:"openai-thinking-type"`
+	// ChatReasoningEffort controls provider-native reasoning effort for OpenAI-compatible Chat Completions.
+	ChatReasoningEffort *string `yaml:"chat_reasoning_effort,omitempty" glazed:"openai-chat-reasoning-effort"`
 	// ParallelToolCalls is a hint for tool parallelization in Responses
 	ParallelToolCalls *bool `yaml:"parallel_tool_calls,omitempty" glazed:"openai-parallel-tool-calls"`
 	// ReasoningSummary requests a public reasoning summary ("auto" to enable)
@@ -37,6 +41,8 @@ func NewSettings() (*Settings, error) {
 		FrequencyPenalty:          nil,
 		LogitBias:                 map[string]string{},
 		ReasoningEffort:           nil,
+		ThinkingType:              nil,
+		ChatReasoningEffort:       nil,
 		ParallelToolCalls:         nil,
 		ReasoningSummary:          nil,
 		IncludeReasoningEncrypted: nil,

--- a/pkg/steps/ai/settings/settings-inference.go
+++ b/pkg/steps/ai/settings/settings-inference.go
@@ -267,6 +267,9 @@ func (ss *InferenceSettings) GetMetadata() map[string]interface{} {
 		if ss.Inference.ReasoningEffort != nil {
 			metadata["inference-reasoning-effort"] = *ss.Inference.ReasoningEffort
 		}
+		if ss.Inference.ThinkingType != nil {
+			metadata["inference-thinking-type"] = *ss.Inference.ThinkingType
+		}
 		if ss.Inference.ReasoningSummary != nil {
 			metadata["inference-reasoning-summary"] = *ss.Inference.ReasoningSummary
 		}

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/changelog.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/changelog.md
@@ -26,3 +26,25 @@ Validated ticket with docmgr doctor and uploaded implementation guide bundle to 
 
 - /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md — Added validation and reMarkable delivery step
 
+
+## 2026-05-03
+
+Implemented OpenAI Chat Completions thinking controls in commit 92c8400, validated focused and full pre-commit tests, added local Wafer thinking profiles, and captured redacted live validation evidence.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/pkg/steps/ai/openai/chat_types.go — Request fields for thinking/reasoning_effort
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/pkg/steps/ai/openai/helpers.go — Request construction wiring and override precedence
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md — Step 6 implementation diary
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/03-live-wafer-thinking-validation-redacted.md — Live validation evidence
+
+
+## 2026-05-03
+
+Uploaded updated implementation bundle with code implementation status and live validation evidence to reMarkable.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/design-doc/01-openai-chat-completions-thinking-mode-controls-analysis-and-implementation-guide.md — Updated bundle content
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/03-live-wafer-thinking-validation-redacted.md — Included live validation source
+

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/changelog.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/changelog.md
@@ -48,3 +48,13 @@ Uploaded updated implementation bundle with code implementation status and live 
 - /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/design-doc/01-openai-chat-completions-thinking-mode-controls-analysis-and-implementation-guide.md — Updated bundle content
 - /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/03-live-wafer-thinking-validation-redacted.md — Included live validation source
 
+
+## 2026-05-03
+
+Validated default wafer-deepseek-v4-pro profile with high-effort thinking, confirmed reasoning stream and final answer, and added redacted source evidence.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md — Step 7 default profile validation
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/04-live-wafer-deepseek-v4-pro-high-validation-redacted.md — Redacted default profile validation evidence
+

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/changelog.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/changelog.md
@@ -58,3 +58,24 @@ Validated default wafer-deepseek-v4-pro profile with high-effort thinking, confi
 - /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md — Step 7 default profile validation
 - /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/04-live-wafer-deepseek-v4-pro-high-validation-redacted.md — Redacted default profile validation evidence
 
+
+## 2026-05-03
+
+Addressed PR #339 review feedback: removed chat reasoning-effort normalization/pass-through restrictions and preserved reasoning_content for Chat Completions assistant tool-call history.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/pkg/steps/ai/openai/chat_types.go — reasoning_content message field
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/pkg/steps/ai/openai/helpers.go — Pass-through effort values and reasoning-content retention
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md — Step 8 PR feedback diary
+
+
+## 2026-05-03
+
+Committed PR #339 fixes as 41b6c47: pass through chat reasoning effort exactly and preserve reasoning_content on assistant tool-call messages.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/pkg/steps/ai/openai/helpers.go — Committed PR feedback fixes
+- /home/manuel/workspaces/2026-05-03/fix-404-wafer-ai/geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md — Updated Step 8 commit hash
+

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/design-doc/01-openai-chat-completions-thinking-mode-controls-analysis-and-implementation-guide.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/design-doc/01-openai-chat-completions-thinking-mode-controls-analysis-and-implementation-guide.md
@@ -28,6 +28,8 @@ RelatedFiles:
       Note: DeepSeek thinking mode API source
     - Path: geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/02-wafer-deepseek-thinking-probe-redacted.md
       Note: Live Wafer request-shape evidence
+    - Path: geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/03-live-wafer-thinking-validation-redacted.md
+      Note: Redacted live validation after implementing chat thinking controls
 ExternalSources:
     - https://api-docs.deepseek.com/guides/thinking_mode
 Summary: Design and implementation guide for adding DeepSeek-style thinking controls to Geppetto's OpenAI Chat Completions path.
@@ -35,6 +37,7 @@ LastUpdated: 2026-05-03T12:05:00-04:00
 WhatFor: Use when implementing provider-native thinking controls for OpenAI-compatible chat-completions models such as Wafer DeepSeek-V4-Pro.
 WhenToUse: Use before modifying OpenAI chat request structs, OpenAI settings, profile schema docs, and tests.
 ---
+
 
 
 
@@ -672,6 +675,73 @@ go test ./pkg/steps/ai/settings ./pkg/steps/ai/settings/openai -count=1
 ```
 
 8. A live Wafer smoke test confirms DeepSeek V4 accepts the generated fields.
+
+## Implementation status
+
+Implemented in commit:
+
+```text
+92c8400c34368a5e7d07a94d925b914d80454840 openai: add chat thinking controls
+```
+
+Implemented changes:
+
+1. `ChatCompletionRequest` now supports:
+
+```go
+ReasoningEffort string               `json:"reasoning_effort,omitempty"`
+Thinking        *ChatThinkingControl `json:"thinking,omitempty"`
+```
+
+2. OpenAI settings now include:
+
+```yaml
+openai:
+  thinking_type: enabled            # enabled|disabled|""
+  chat_reasoning_effort: max        # low|medium|high|max|xhigh|""
+```
+
+3. Generic inference overrides now include:
+
+```yaml
+inference:
+  thinking_type: disabled
+  reasoning_effort: max
+```
+
+4. Request construction now:
+
+- omits thinking fields by default;
+- sends `thinking: {type: ...}` only when configured;
+- sends chat-completions `reasoning_effort` only when configured;
+- lets per-turn inference config override profile defaults;
+- normalizes `low|medium -> high` and `xhigh -> max` for chat-completions effort;
+- removes sampling/penalty fields when `thinking_type=enabled`.
+
+5. Tests were added for:
+
+- request JSON marshalling;
+- enabled/disabled/default thinking controls;
+- per-turn override precedence;
+- invalid thinking type errors;
+- `InferenceConfig` merge behavior.
+
+Validation:
+
+```bash
+cd geppetto && go test ./pkg/steps/ai/openai ./pkg/steps/ai/settings ./pkg/steps/ai/settings/openai ./pkg/inference/engine -count=1
+```
+
+Pre-commit also ran full `go test ./...`, golangci-lint, and the custom Geppetto vet tool successfully.
+
+Live Wafer validation with local workspace Pinocchio confirmed:
+
+- `wafer-deepseek-v4-pro-fast` (`thinking_type: disabled`) streamed normal final content without visible thinking;
+- `wafer-deepseek-v4-pro-max` (`thinking_type: enabled`, `chat_reasoning_effort: max`) streamed reasoning text and emitted thinking start/end markers.
+
+The redacted live validation evidence is stored in:
+
+- `sources/03-live-wafer-thinking-validation-redacted.md`
 
 ## References
 

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/design-doc/01-openai-chat-completions-thinking-mode-controls-analysis-and-implementation-guide.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/design-doc/01-openai-chat-completions-thinking-mode-controls-analysis-and-implementation-guide.md
@@ -286,7 +286,7 @@ type Settings struct {
 
     // ReasoningEffort applies to providers that accept Chat Completions
     // reasoning_effort. OpenAI Responses also uses this setting.
-    // Known values should include low, medium, high, max, xhigh.
+    // Value is provider-native and sent exactly as configured on the Chat Completions path.
     ReasoningEffort *string `yaml:"reasoning_effort,omitempty" glazed:"openai-reasoning-effort"`
 }
 ```
@@ -312,7 +312,7 @@ Add to `chat.yaml`:
     - high
     - max
     - xhigh
-  help: Reasoning effort for providers that support it. For DeepSeek Chat Completions, high/max are native; low/medium map to high and xhigh maps to max.
+  help: Reasoning effort for providers that support it; sent exactly as provided on the Chat Completions path.
   default: ""
 ```
 
@@ -377,13 +377,13 @@ if settings.OpenAI != nil {
         thinkingType = strings.TrimSpace(*settings.OpenAI.ThinkingType)
     }
     if settings.OpenAI.ReasoningEffort != nil {
-        reasoningEffort = normalizeChatReasoningEffort(*settings.OpenAI.ReasoningEffort)
+        reasoningEffort = strings.TrimSpace(*settings.OpenAI.ChatReasoningEffort)
     }
 }
 
 if infCfg := engine.ResolveInferenceConfig(t, settings.Inference); infCfg != nil {
     if infCfg.ReasoningEffort != nil {
-        reasoningEffort = normalizeChatReasoningEffort(*infCfg.ReasoningEffort)
+        reasoningEffort = strings.TrimSpace(*infCfg.ReasoningEffort)
     }
     if infCfg.ThinkingType != nil {
         thinkingType = strings.TrimSpace(*infCfg.ThinkingType)
@@ -421,22 +421,11 @@ req := ChatCompletionRequest{
 }
 ```
 
-Suggested normalization for DeepSeek compatibility:
+Reasoning effort pass-through:
 
 ```go
-func normalizeChatReasoningEffort(v string) string {
-    switch strings.ToLower(strings.TrimSpace(v)) {
-    case "", "auto":
-        return ""
-    case "low", "medium":
-        return "high"
-    case "xhigh":
-        return "max"
-    case "high", "max":
-        return strings.ToLower(strings.TrimSpace(v))
-    default:
-        return strings.ToLower(strings.TrimSpace(v)) // or reject strictly
-    }
+func chatReasoningEffortValue(v string) string {
+    return strings.TrimSpace(v)
 }
 ```
 
@@ -523,7 +512,7 @@ go test ./pkg/steps/ai/settings/openai ./pkg/steps/ai/settings -count=1
 
 1. Add helper functions:
    - `normalizeChatThinkingType(string) (string, error)`
-   - `normalizeChatReasoningEffort(string) string`
+   - `chatReasoningEffortValue(string) string`
    - optionally `isDeepSeekV4Like(model string) bool`
 2. In `MakeCompletionRequestFromTurn`, resolve settings and per-turn overrides.
 3. Set `req.Thinking` only when configured.
@@ -545,7 +534,7 @@ Test cases:
 
 3. `thinking_type: enabled`, `reasoning_effort: high` → request JSON includes both fields.
 4. `reasoning_effort: max` is accepted.
-5. `reasoning_effort: low|medium|xhigh` normalization behavior is covered if implemented.
+5. `reasoning_effort` values such as `low`, `medium`, and `xhigh` are sent unchanged when configured.
 6. Invalid thinking type returns a clear error.
 
 Example test skeleton:
@@ -715,7 +704,7 @@ inference:
 - sends `thinking: {type: ...}` only when configured;
 - sends chat-completions `reasoning_effort` only when configured;
 - lets per-turn inference config override profile defaults;
-- normalizes `low|medium -> high` and `xhigh -> max` for chat-completions effort;
+- sends chat-completions reasoning effort exactly as configured;
 - removes sampling/penalty fields when `thinking_type=enabled`.
 
 5. Tests were added for:

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md
@@ -31,6 +31,8 @@ RelatedFiles:
       Note: Live Wafer request-shape evidence
     - Path: geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/03-live-wafer-thinking-validation-redacted.md
       Note: Redacted live validation after implementing chat thinking controls
+    - Path: geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/04-live-wafer-deepseek-v4-pro-high-validation-redacted.md
+      Note: Default wafer-deepseek-v4-pro high-thinking live validation evidence
 ExternalSources:
     - https://api-docs.deepseek.com/guides/thinking_mode
 Summary: Diary for the OAI-CHAT-THINKING analysis and implementation guide.
@@ -38,6 +40,7 @@ LastUpdated: 2026-05-03T12:05:00-04:00
 WhatFor: Records the investigation steps for enabling thinking controls in the OpenAI Chat Completions path.
 WhenToUse: Use when continuing implementation or reviewing evidence and decisions.
 ---
+
 
 
 
@@ -538,3 +541,102 @@ PINOCCHIO_PROFILE=wafer-deepseek-v4-pro-max go run ./cmd/pinocchio --log-level d
   - `92c8400c34368a5e7d07a94d925b914d80454840`
 - Live validation source:
   - `sources/03-live-wafer-thinking-validation-redacted.md`
+
+## Step 7: Validate the default `wafer-deepseek-v4-pro` profile
+
+The user asked to test the default Wafer DeepSeek V4 Pro profile specifically, not only the fast/max variants. I ran both settings resolution and a live streaming request through the workspace Pinocchio build.
+
+### Prompt Context
+
+**User prompt (verbatim):** "test it with wafer-deepseek-v4-pro"
+
+**Assistant interpretation:** Verify that the default `wafer-deepseek-v4-pro` profile resolves the new thinking settings and successfully streams from Wafer.
+
+**Inferred user intent:** Confirm the main profile the user actually uses works after the feature implementation.
+
+**Commit (code):** N/A — validation and documentation only after code commit `92c8400`.
+
+### What I did
+
+- Ran settings validation:
+
+```bash
+cd pinocchio
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro go run ./cmd/pinocchio code professional --print-inference-settings --non-interactive hello
+```
+
+- Ran live streaming validation:
+
+```bash
+cd pinocchio
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro go run ./cmd/pinocchio --log-level debug --with-caller code professional --non-interactive "Say hi"
+```
+
+- Added redacted source evidence:
+  - `sources/04-live-wafer-deepseek-v4-pro-high-validation-redacted.md`
+
+### Why
+
+- The previous validation covered `fast` and `max` variants. The default profile uses the intended normal DeepSeek setting: `thinking_type=enabled`, `chat_reasoning_effort=high`.
+
+### What worked
+
+- `--print-inference-settings` resolved:
+
+```yaml
+openai-base-url: https://pass.wafer.ai/v1
+api_type: openai
+engine: DeepSeek-V4-Pro
+chat_reasoning_effort: high
+thinking_type: enabled
+```
+
+- Live execution succeeded. The debug log showed:
+
+```text
+Making request to openai from turn blocks chat_reasoning_effort=high ... model=DeepSeek-V4-Pro ... thinking_type=enabled
+```
+
+- Wafer streamed reasoning text and Geppetto emitted thinking markers:
+
+```text
+--- Thinking started ---
+...
+Hi.
+OpenAI stream completed chunks_received=37
+--- Thinking ended ---
+OpenAI RunInference completed (streaming)
+```
+
+### What didn't work
+
+- N/A. The profile worked as intended.
+
+### What I learned
+
+- The default `wafer-deepseek-v4-pro` profile now exercises normal high-effort thinking mode correctly.
+
+### What was tricky to build
+
+- The live output included reasoning text and final answer interleaved in terminal output, so I stored a concise redacted Markdown summary rather than raw logs.
+
+### What warrants a second pair of eyes
+
+- Review whether the terminal renderer should separate final answer text more clearly when a provider emits reasoning text with tags such as `</think>`.
+
+### What should be done in the future
+
+- Consider adding a UI/output formatting follow-up if the interleaving of thinking and final text is confusing.
+
+### Code review instructions
+
+- Review source evidence:
+  - `sources/04-live-wafer-deepseek-v4-pro-high-validation-redacted.md`
+
+### Technical details
+
+- Profile tested:
+  - `wafer-deepseek-v4-pro`
+- Thinking settings:
+  - `thinking_type: enabled`
+  - `chat_reasoning_effort: high`

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md
@@ -29,6 +29,8 @@ RelatedFiles:
       Note: DeepSeek thinking mode API source
     - Path: geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/02-wafer-deepseek-thinking-probe-redacted.md
       Note: Live Wafer request-shape evidence
+    - Path: geppetto/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/03-live-wafer-thinking-validation-redacted.md
+      Note: Redacted live validation after implementing chat thinking controls
 ExternalSources:
     - https://api-docs.deepseek.com/guides/thinking_mode
 Summary: Diary for the OAI-CHAT-THINKING analysis and implementation guide.
@@ -36,6 +38,7 @@ LastUpdated: 2026-05-03T12:05:00-04:00
 WhatFor: Records the investigation steps for enabling thinking controls in the OpenAI Chat Completions path.
 WhenToUse: Use when continuing implementation or reviewing evidence and decisions.
 ---
+
 
 
 
@@ -413,3 +416,125 @@ remarquee cloud ls /ai/2026/05/03/OAI-CHAT-THINKING --long --non-interactive
   - `/ai/2026/05/03/OAI-CHAT-THINKING`
 - Uploaded bundle:
   - `OAI-CHAT-THINKING implementation guide`
+
+## Step 6: Implement chat-completions thinking controls
+
+After the user confirmed to proceed and asked for commits at appropriate intervals, I implemented the request-side feature in Geppetto. The implementation adds provider-native `thinking` and chat-completions `reasoning_effort` fields to OpenAI Chat Completions requests, exposes profile/flag settings, supports per-turn overrides, and validates with tests plus live Wafer profiles.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Yes, commit at appropriate intervals, keep a diary"
+
+**Assistant interpretation:** Proceed from the implementation guide into code, commit focused changes after validation, and keep this diary updated.
+
+**Inferred user intent:** Turn the guide into working Geppetto support while preserving review history and validation evidence.
+
+**Commit (code):** `92c8400c34368a5e7d07a94d925b914d80454840` — `openai: add chat thinking controls`
+
+### What I did
+
+- Added OpenAI Chat Completions request fields in `pkg/steps/ai/openai/chat_types.go`:
+  - `reasoning_effort`
+  - `thinking: {type: ...}`
+- Added settings in `pkg/steps/ai/settings/openai/settings.go` and `chat.yaml`:
+  - `openai-thinking-type`
+  - `openai-chat-reasoning-effort`
+- Extended generic inference overrides in `pkg/inference/engine/inference_config.go` and `pkg/steps/ai/settings/flags/inference.yaml`:
+  - `inference-thinking-type`
+  - expanded `inference-reasoning-effort` choices to include `max` and `xhigh`
+- Wired request construction in `pkg/steps/ai/openai/helpers.go`:
+  - profile defaults set chat thinking controls;
+  - turn-level `InferenceConfig` overrides profile defaults;
+  - `low|medium` normalize to `high` for chat-completions effort;
+  - `xhigh` normalizes to `max`;
+  - invalid `thinking_type` returns a clear error;
+  - when thinking is enabled, sampling/penalty fields are zeroed after all overrides so they are omitted.
+- Added tests in:
+  - `pkg/steps/ai/openai/helpers_test.go`
+  - `pkg/steps/ai/openai/chat_types_test.go`
+  - `pkg/inference/engine/inference_config_test.go`
+- Updated local profiles with a backup:
+  - `/home/manuel/.config/pinocchio/profiles.yaml.bak-20260503-121315-thinking-modes`
+  - added `wafer-deepseek-v4-pro-max`
+  - added `wafer-deepseek-v4-pro-fast`
+  - set base `wafer-deepseek-v4-pro` to `thinking_type: enabled`, `chat_reasoning_effort: high`
+- Added redacted live validation source:
+  - `sources/03-live-wafer-thinking-validation-redacted.md`
+
+### Why
+
+- DeepSeek/Wafer thinking is a Chat Completions extension, so the request JSON must carry `thinking` and `reasoning_effort` on the `openai` chat path, not only on the `openai-responses` path.
+- The controls must be opt-in so existing OpenAI-compatible providers do not receive unsupported fields by default.
+
+### What worked
+
+- Focused tests passed:
+
+```bash
+cd geppetto && go test ./pkg/steps/ai/openai ./pkg/steps/ai/settings ./pkg/steps/ai/settings/openai ./pkg/inference/engine -count=1
+```
+
+- Pre-commit hook ran the full Geppetto validation successfully before committing:
+  - `go test ./...`
+  - golangci-lint
+  - custom `go vet -vettool=/tmp/geppetto-lint ...`
+- Local profile settings resolved with workspace `go run`:
+  - `wafer-deepseek-v4-pro`: `thinking_type: enabled`, `chat_reasoning_effort: high`
+  - `wafer-deepseek-v4-pro-max`: `thinking_type: enabled`, `chat_reasoning_effort: max`
+  - `wafer-deepseek-v4-pro-fast`: `thinking_type: disabled`
+- Live Wafer validation succeeded:
+  - fast profile streamed normal content (`Hi.`) with no visible thinking block;
+  - max profile streamed thinking text and emitted thinking start/end markers before the final answer.
+
+### What didn't work
+
+- The first live log capture wrote raw `.log` files into `sources/`. I replaced them with a frontmatter-backed redacted Markdown source so docmgr can validate the ticket cleanly.
+
+### What I learned
+
+- The existing response-side reasoning handling was sufficient: once `thinking_type=enabled` and `chat_reasoning_effort=max` were sent, the OpenAI chat stream path emitted thinking events without additional changes.
+- Keeping `openai-chat-reasoning-effort` separate from existing `openai-reasoning-effort` avoided changing Responses API defaults.
+
+### What was tricky to build
+
+- Ordering mattered: thinking-mode sanitization has to run after generic and OpenAI-specific per-turn overrides, otherwise a later override could reintroduce unsupported sampling/penalty fields.
+- The existing `ReasoningEffort` setting has Responses semantics, so reusing it directly for Chat Completions would have risked sending `medium` to providers by default. The separate chat setting keeps this opt-in.
+
+### What warrants a second pair of eyes
+
+- Review whether omitting sampling controls for all `thinking_type=enabled` chat requests is too broad for future providers. It matches DeepSeek's documented behavior but is applied generically when the user opts into thinking.
+- Review whether `normalizeChatReasoningEffort` should reject unknown values rather than pass them through lowercased.
+
+### What should be done in the future
+
+- Update user-facing docs with the new `openai-thinking-type` and `openai-chat-reasoning-effort` examples.
+- Add a tool-call multi-turn regression for DeepSeek's requirement to pass back `reasoning_content` after tool calls.
+
+### Code review instructions
+
+- Start with:
+  - `pkg/steps/ai/openai/chat_types.go`
+  - `pkg/steps/ai/openai/helpers.go`
+  - `pkg/steps/ai/settings/openai/settings.go`
+  - `pkg/steps/ai/settings/openai/chat.yaml`
+- Validate with:
+
+```bash
+cd geppetto
+go test ./pkg/steps/ai/openai ./pkg/steps/ai/settings ./pkg/steps/ai/settings/openai ./pkg/inference/engine -count=1
+```
+
+- Optional live validation with workspace Pinocchio:
+
+```bash
+cd pinocchio
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro-fast go run ./cmd/pinocchio --log-level debug --with-caller code professional --non-interactive "Say hi"
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro-max go run ./cmd/pinocchio --log-level debug --with-caller code professional --non-interactive "Say hi"
+```
+
+### Technical details
+
+- Commit:
+  - `92c8400c34368a5e7d07a94d925b914d80454840`
+- Live validation source:
+  - `sources/03-live-wafer-thinking-validation-redacted.md`

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/reference/01-implementation-diary.md
@@ -448,8 +448,7 @@ After the user confirmed to proceed and asked for commits at appropriate interva
 - Wired request construction in `pkg/steps/ai/openai/helpers.go`:
   - profile defaults set chat thinking controls;
   - turn-level `InferenceConfig` overrides profile defaults;
-  - `low|medium` normalize to `high` for chat-completions effort;
-  - `xhigh` normalizes to `max`;
+  - chat-completions reasoning effort is sent exactly as provided;
   - invalid `thinking_type` returns a clear error;
   - when thinking is enabled, sampling/penalty fields are zeroed after all overrides so they are omitted.
 - Added tests in:
@@ -506,7 +505,7 @@ cd geppetto && go test ./pkg/steps/ai/openai ./pkg/steps/ai/settings ./pkg/steps
 ### What warrants a second pair of eyes
 
 - Review whether omitting sampling controls for all `thinking_type=enabled` chat requests is too broad for future providers. It matches DeepSeek's documented behavior but is applied generically when the user opts into thinking.
-- Review whether `normalizeChatReasoningEffort` should reject unknown values rather than pass them through lowercased.
+- Review whether unrestricted chat reasoning effort values should remain fully pass-through for every provider.
 
 ### What should be done in the future
 
@@ -640,3 +639,90 @@ OpenAI RunInference completed (streaming)
 - Thinking settings:
   - `thinking_type: enabled`
   - `chat_reasoning_effort: high`
+
+## Step 8: Address PR review feedback for effort pass-through and reasoning history
+
+After PR #339 received automated review feedback, I addressed both issues in the implementation. The first issue was that chat-completions reasoning effort should not be normalized: whatever the user configures should be what gets sent. The second issue was that enabling DeepSeek-style thinking made tool-call continuations risky because prior `reasoning_content` was not represented in Chat Completions assistant messages.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Address the issues raised here: https://github.com/go-go-golems/geppetto/pull/339
+
+Remove normalization of thinking level entirely, whatever the user provides is what gets sent."
+
+**Assistant interpretation:** Inspect PR #339 review comments, remove chat reasoning-effort normalization, and fix the reasoning history/tool-call issue raised by the reviewer.
+
+**Inferred user intent:** Make the PR acceptable by preserving user-specified provider-native values and supporting DeepSeek thinking-mode tool-call continuations.
+
+**Commit (code):** `41b6c471161a42c8cbb1544ad260931a64c7107c` — `openai: preserve chat reasoning history`
+
+### What I did
+
+- Queried PR #339 review comments with `gh`.
+- Removed chat reasoning-effort normalization from the OpenAI Chat Completions path:
+  - `low`, `medium`, `xhigh`, `max`, and any provider-native string are now sent as configured after whitespace trimming.
+  - `openai-chat-reasoning-effort` is now a string flag rather than a closed choice.
+  - `inference-reasoning-effort` is now a string flag so per-turn/provider-native values are not blocked by schema choices.
+- Added `reasoning_content` support to `ChatCompletionMessage` JSON marshalling.
+- Changed `MakeCompletionRequestFromTurn` so `BlockKindReasoning` text is retained and attached to the following assistant tool-call message as `reasoning_content`.
+- Added tests for:
+  - `reasoning_content` message JSON;
+  - reasoning content preserved on assistant tool-call messages;
+  - old reasoning not crossing a new user/system boundary;
+  - `xhigh` being sent unchanged rather than normalized.
+- Re-ran focused tests:
+
+```bash
+cd geppetto && go test ./pkg/steps/ai/openai ./pkg/steps/ai/settings ./pkg/steps/ai/settings/openai ./pkg/inference/engine -count=1
+```
+
+### Why
+
+- The review correctly identified that silently rewriting reasoning effort can violate user intent and increase latency/cost on providers that support lower effort values.
+- DeepSeek docs require `reasoning_content` to be passed back in subsequent turns when a thinking-mode assistant turn involved tool calls.
+
+### What worked
+
+- Focused tests passed.
+- The code now keeps chat-completions effort values provider-native instead of applying DeepSeek-specific mappings globally.
+- The OpenAI Chat Completions message type can now marshal `reasoning_content`.
+
+### What didn't work
+
+- N/A in this step.
+
+### What I learned
+
+- The official DeepSeek low/medium/xhigh mapping is useful documentation, but should be provider-side behavior, not client-side normalization in Geppetto.
+- The existing turn representation already had `BlockKindReasoning`; the missing piece was preserving it in Chat Completions assistant messages where providers require it.
+
+### What was tricky to build
+
+- Reasoning content should not leak across unrelated turns. The implementation clears pending reasoning when a new user or system message boundary is processed, while preserving it long enough to attach to the following tool-call assistant message.
+
+### What warrants a second pair of eyes
+
+- Review whether reasoning content should also be attached to non-tool assistant messages or only to assistant tool-call messages. The current fix targets DeepSeek's tool-call continuation requirement.
+- Review whether trimming whitespace from reasoning-effort values is acceptable under "whatever the user provides"; the implementation preserves the semantic value but removes surrounding whitespace.
+
+### What should be done in the future
+
+- Add an integration-style test with a full reasoning/tool-call/tool-use/user continuation sequence if a stable fixture exists.
+
+### Code review instructions
+
+- Start with:
+  - `pkg/steps/ai/openai/chat_types.go`
+  - `pkg/steps/ai/openai/helpers.go`
+  - `pkg/steps/ai/openai/helpers_test.go`
+- Validate with:
+
+```bash
+cd geppetto && go test ./pkg/steps/ai/openai ./pkg/steps/ai/settings ./pkg/steps/ai/settings/openai ./pkg/inference/engine -count=1
+```
+
+### Technical details
+
+- PR review comments addressed:
+  - preserve reasoning history when enabling thinking mode;
+  - respect user-provided reasoning effort values without normalization.

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/03-live-wafer-thinking-validation-redacted.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/03-live-wafer-thinking-validation-redacted.md
@@ -1,0 +1,85 @@
+---
+Title: Live Wafer thinking mode validation redacted
+Ticket: OAI-CHAT-THINKING
+Status: active
+Topics:
+    - llm
+    - openai
+    - inference
+DocType: source
+Intent: short-term
+Owners: []
+RelatedFiles:
+    - /home/manuel/.config/pinocchio/profiles.yaml
+ExternalSources: []
+Summary: "Redacted validation showing local Pinocchio profiles can resolve and exercise DeepSeek V4 thinking enabled/disabled modes after implementation."
+LastUpdated: 2026-05-03T12:15:00-04:00
+WhatFor: "Runtime validation evidence for OAI-CHAT-THINKING."
+WhenToUse: "Use when reviewing whether the implemented settings produce provider-visible thinking behavior."
+---
+
+# Live Wafer thinking mode validation redacted
+
+Validation used the local workspace build via:
+
+```bash
+cd pinocchio
+PINOCCHIO_PROFILE=<profile> go run ./cmd/pinocchio --log-level debug --with-caller code professional --non-interactive "Say hi"
+```
+
+The Authorization header/key remained in local config and is not stored here.
+
+## `wafer-deepseek-v4-pro-fast`
+
+Profile settings:
+
+```yaml
+openai:
+  thinking_type: disabled
+  chat_reasoning_effort: ""
+```
+
+Important log excerpt:
+
+```text
+Making request to openai from turn blocks chat_reasoning_effort= ... model=DeepSeek-V4-Pro ... thinking_type=disabled
+Hi.
+OpenAI stream completed chunks_received=5
+OpenAI RunInference completed (streaming)
+```
+
+Observation: response streamed normal final content without visible thinking blocks.
+
+## `wafer-deepseek-v4-pro-max`
+
+Profile settings:
+
+```yaml
+openai:
+  thinking_type: enabled
+  chat_reasoning_effort: max
+```
+
+Important log excerpt:
+
+```text
+Making request to openai from turn blocks chat_reasoning_effort=max ... model=DeepSeek-V4-Pro ... thinking_type=enabled
+
+--- Thinking started ---
+We are asked: "Say hi". The instruction is to give a concise answer ...
+Hi.
+OpenAI stream completed chunks_received=39
+
+--- Thinking ended ---
+OpenAI RunInference completed (streaming)
+```
+
+Observation: response streamed `reasoning_content`, and Geppetto emitted thinking start/end markers plus final answer text.
+
+## Local profile backup
+
+Before adding thinking-mode profile variants, the local profile file was backed up to:
+
+```text
+/home/manuel/.config/pinocchio/profiles.yaml.bak-20260503-121315-thinking-modes
+```

--- a/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/04-live-wafer-deepseek-v4-pro-high-validation-redacted.md
+++ b/ttmp/2026/05/03/OAI-CHAT-THINKING--enable-thinking-mode-controls-for-openai-compatible-chat-completions/sources/04-live-wafer-deepseek-v4-pro-high-validation-redacted.md
@@ -1,0 +1,67 @@
+---
+Title: Live Wafer DeepSeek V4 Pro high thinking validation redacted
+Ticket: OAI-CHAT-THINKING
+Status: active
+Topics:
+    - llm
+    - openai
+    - inference
+DocType: source
+Intent: short-term
+Owners: []
+RelatedFiles:
+    - /home/manuel/.config/pinocchio/profiles.yaml
+ExternalSources: []
+Summary: "Redacted validation showing wafer-deepseek-v4-pro resolves high-effort thinking settings and streams reasoning_content."
+LastUpdated: 2026-05-03T12:23:00-04:00
+WhatFor: "Runtime validation evidence for the default Wafer DeepSeek V4 Pro thinking profile."
+WhenToUse: "Use when reviewing whether wafer-deepseek-v4-pro itself, not only fast/max variants, works after implementation."
+---
+
+# Live Wafer DeepSeek V4 Pro high thinking validation redacted
+
+Validation used the local workspace build via:
+
+```bash
+cd pinocchio
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro go run ./cmd/pinocchio code professional --print-inference-settings --non-interactive hello
+PINOCCHIO_PROFILE=wafer-deepseek-v4-pro go run ./cmd/pinocchio --log-level debug --with-caller code professional --non-interactive "Say hi"
+```
+
+The Authorization header/key remained in local config and is not stored here.
+
+## Resolved settings
+
+Important settings excerpt:
+
+```yaml
+api:
+  base_urls:
+    openai-base-url: https://pass.wafer.ai/v1
+chat:
+  api_type: openai
+  engine: DeepSeek-V4-Pro
+openai:
+  chat_reasoning_effort: high
+  thinking_type: enabled
+```
+
+## Live run
+
+Important log excerpt:
+
+```text
+Making request to openai from turn blocks chat_reasoning_effort=high ... model=DeepSeek-V4-Pro ... thinking_type=enabled
+
+--- Thinking started ---
+We are: "You are an experienced technology professional and technical leader in software..."
+The user said: "Say hi"
+I need to respond concisely: a simple "Hi." is appropriate.
+Hi.
+OpenAI stream completed chunks_received=37
+
+--- Thinking ended ---
+OpenAI RunInference completed (streaming)
+```
+
+Observation: `wafer-deepseek-v4-pro` itself now uses enabled/high thinking settings, Wafer streams reasoning text, and Geppetto renders thinking start/end events plus final answer text.


### PR DESCRIPTION
## Summary

Extend the OpenAI Chat Completions integration to support provider-native
reasoning controls (`reasoning_effort` and `thinking`). This enables
operators to toggle thinking modes and set reasoning effort levels for
compatible APIs (e.g., DeepSeek).

## Changes

- **New inference configuration fields**
  - `ThinkingType` field on `InferenceConfig` to control thinking mode
    (`enabled`, `disabled`).
  - Extended `ReasoningEffort` to support `max` and `xhigh` values.
- **Chat Completions request types**
  - `ChatCompletionRequest` now includes `ReasoningEffort` and `Thinking`
    fields that serialize to the provider-native JSON shape.
- **Request construction logic**
  - Normalize thinking type values; reject unsupported inputs.
  - Normalize reasoning effort values (e.g., `xhigh` → `max`).
  - Apply settings from OpenAI-specific configuration and per-turn
    inference overrides.
  - When thinking mode is enabled, automatically suppress sampling
    parameters (temperature, top_p, presence/frequency penalties) that
    are incompatible with provider-native thinking.
- **Configuration flags**
  - Added `openai-thinking-type` and `openai-chat-reasoning-effort` flags
    for OpenAI-specific settings.
  - Added `inference-thinking-type` flag for per-turn inference overrides.

## Precedence

Per-turn `InferenceConfig` overrides take precedence over OpenAI-specific
settings. Both sources feed through normalization before being applied to
the outgoing request.

## Compatibility

These fields are omitted from the JSON payload when not explicitly set,
maintaining backward compatibility with APIs that do not support them.