### PR TITLE
Fix(claude): Prevent duplicate text segment on tool use

### DIFF
--- a/pkg/steps/ai/claude/content-block-merger.go
+++ b/pkg/steps/ai/claude/content-block-merger.go
@@ -75,6 +75,21 @@ func (cbm *ContentBlockMerger) Error() *api.Error {
 	return cbm.error
 }
 
+func (cbm *ContentBlockMerger) stopReasonIsToolUse() bool {
+	if cbm == nil {
+		return false
+	}
+	if cbm.metadata.StopReason != nil && *cbm.metadata.StopReason == "tool_use" {
+		return true
+	}
+	if cbm.metadata.Extra != nil {
+		if v, ok := cbm.metadata.Extra[StopReasonMetadataSlug].(string); ok && v == "tool_use" {
+			return true
+		}
+	}
+	return false
+}
+
 const ModelMetadataSlug = "claude_model"
 const StopReasonMetadataSlug = "claude_stop_reason"
 const StopSequenceMetadataSlug = "claude_stop_sequence"
@@ -170,7 +185,12 @@ func (cbm *ContentBlockMerger) Add(event api.StreamingEvent) ([]events.Event, er
 
 		cbm.updateUsage(event)
 
-		return []events.Event{events.NewPartialCompletionEvent(cbm.metadata, "", cbm.Text())}, nil
+		// Anthropic message_delta events can carry message-level metadata such as
+		// stop_reason and usage without carrying new text. Text is emitted from
+		// content_block_delta/content_block_stop events; emitting the accumulated
+		// text again here causes downstream consumers to create a duplicate text
+		// segment before tool execution.
+		return []events.Event{}, nil
 
 	case api.MessageStopType:
 		if cbm.response == nil {
@@ -197,7 +217,16 @@ func (cbm *ContentBlockMerger) Add(event api.StreamingEvent) ([]events.Event, er
 		d := time.Since(cbm.startTime).Milliseconds()
 		dm := int64(d)
 		cbm.metadata.DurationMs = &dm
-		return []events.Event{events.NewFinalEvent(cbm.metadata, cbm.Text())}, nil
+
+		finalText := cbm.Text()
+		if cbm.stopReasonIsToolUse() {
+			// For Claude tool-use turns, the preceding text block has already been
+			// streamed and block-finalized before the tool_use block. The
+			// message_stop event closes the provider message envelope; it must not
+			// re-emit the accumulated text as a new assistant segment.
+			finalText = ""
+		}
+		return []events.Event{events.NewFinalEvent(cbm.metadata, finalText)}, nil
 
 	case api.ContentBlockStartType:
 		if cbm.response == nil {

--- a/pkg/steps/ai/claude/content-block-merger.go
+++ b/pkg/steps/ai/claude/content-block-merger.go
@@ -218,15 +218,15 @@ func (cbm *ContentBlockMerger) Add(event api.StreamingEvent) ([]events.Event, er
 		dm := int64(d)
 		cbm.metadata.DurationMs = &dm
 
-		finalText := cbm.Text()
 		if cbm.stopReasonIsToolUse() {
 			// For Claude tool-use turns, the preceding text block has already been
 			// streamed and block-finalized before the tool_use block. The
-			// message_stop event closes the provider message envelope; it must not
-			// re-emit the accumulated text as a new assistant segment.
-			finalText = ""
+			// message_stop event closes the provider message envelope; publishing a
+			// final event here causes downstream consumers to finalize the cached
+			// text as a new assistant segment after the tool call.
+			return []events.Event{}, nil
 		}
-		return []events.Event{events.NewFinalEvent(cbm.metadata, finalText)}, nil
+		return []events.Event{events.NewFinalEvent(cbm.metadata, cbm.Text())}, nil
 
 	case api.ContentBlockStartType:
 		if cbm.response == nil {

--- a/pkg/steps/ai/claude/content-block-merger_test.go
+++ b/pkg/steps/ai/claude/content-block-merger_test.go
@@ -181,7 +181,6 @@ func TestContentBlockMerger(t *testing.T) {
 					Name:  "sql_doc",
 					Input: `{"topic":"inventory"}`,
 				}),
-				events.NewFinalEvent(events.EventMetadata{}, ""),
 			},
 			checkMetadata: func(t *testing.T, metadata map[string]interface{}) {
 				assert.Equal(t, "tool_use", metadata[StopReasonMetadataSlug])

--- a/pkg/steps/ai/claude/content-block-merger_test.go
+++ b/pkg/steps/ai/claude/content-block-merger_test.go
@@ -123,6 +123,78 @@ func TestContentBlockMerger(t *testing.T) {
 			},
 		},
 		{
+			name: "Test tool use stop does not duplicate finalized text",
+			events: []api.StreamingEvent{
+				{Type: api.MessageStartType, Message: &api.MessageResponse{}},
+				{
+					Type:         api.ContentBlockStartType,
+					Index:        0,
+					ContentBlock: &api.ContentBlock{Type: api.ContentTypeText},
+				},
+				{
+					Type:  api.ContentBlockDeltaType,
+					Index: 0,
+					Delta: &api.Delta{
+						Type: api.TextDeltaType,
+						Text: "I'll inspect the schema first.",
+					},
+				},
+				{
+					Type:  api.ContentBlockStopType,
+					Index: 0,
+				},
+				{
+					Type:  api.ContentBlockStartType,
+					Index: 1,
+					ContentBlock: &api.ContentBlock{
+						Type: api.ContentTypeToolUse,
+						ID:   "tool_1",
+						Name: "sql_doc",
+					},
+				},
+				{
+					Type:  api.ContentBlockDeltaType,
+					Index: 1,
+					Delta: &api.Delta{
+						Type:        api.InputJSONDeltaType,
+						PartialJSON: `{"topic":"inventory"}`,
+					},
+				},
+				{
+					Type:  api.ContentBlockStopType,
+					Index: 1,
+				},
+				{
+					Type: api.MessageDeltaType,
+					Delta: &api.Delta{
+						StopReason: "tool_use",
+					},
+				},
+				{Type: api.MessageStopType},
+			},
+			expectedEvents: []events.Event{
+				events.NewStartEvent(events.EventMetadata{}),
+				events.NewPartialCompletionEvent(events.EventMetadata{}, "I'll inspect the schema first.", "I'll inspect the schema first."),
+				events.NewPartialCompletionEvent(events.EventMetadata{}, "", "I'll inspect the schema first."),
+				events.NewToolCallEvent(events.EventMetadata{}, events.ToolCall{
+					ID:    "tool_1",
+					Name:  "sql_doc",
+					Input: `{"topic":"inventory"}`,
+				}),
+				events.NewFinalEvent(events.EventMetadata{}, ""),
+			},
+			checkMetadata: func(t *testing.T, metadata map[string]interface{}) {
+				assert.Equal(t, "tool_use", metadata[StopReasonMetadataSlug])
+			},
+			checkResponse: func(t *testing.T, response *api.MessageResponse) {
+				assert.Len(t, response.Content, 2)
+				assert.Equal(t, "I'll inspect the schema first.", response.Content[0].(api.TextContent).Text)
+				toolUseContent := response.Content[1].(api.ToolUseContent)
+				assert.Equal(t, "tool_1", toolUseContent.ID)
+				assert.Equal(t, "sql_doc", toolUseContent.Name)
+			},
+		},
+		{
 			name: "Test multiple content blocks (text and tool use)",
 			events: []api.StreamingEvent{
 				{Type: api.MessageStartType, Message: &api.MessageResponse{}},

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/README.md
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/README.md
@@ -1,0 +1,21 @@
+# Fix Claude tool-use duplicate text finalization
+
+This is the document workspace for ticket GP-CLAUDE-DUPLICATE-TEXT.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GP-CLAUDE-DUPLICATE-TEXT --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GP-CLAUDE-DUPLICATE-TEXT --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GP-CLAUDE-DUPLICATE-TEXT --field Status --value review`

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/changelog.md
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/changelog.md
@@ -21,7 +21,7 @@ LastUpdated: 2026-05-08T00:15:00-04:00
 - Created `GP-CLAUDE-DUPLICATE-TEXT` docmgr ticket with a bug analysis and implementation guide.
 - Added regression coverage for the Anthropic/Claude sequence `text block -> tool_use block -> message_delta stop_reason=tool_use -> message_stop`.
 - Changed `ContentBlockMerger` so `message_delta` updates stop/usage metadata without publishing a textual partial.
-- Changed `ContentBlockMerger` so `message_stop` emits an empty final text payload when the stop reason is `tool_use`, preventing downstream consumers from creating a duplicate assistant text segment.
+- Changed `ContentBlockMerger` so `message_stop` emits no final event when the stop reason is `tool_use`, preventing downstream consumers from finalizing cached text as a duplicate assistant segment.
 - Validated with:
   - `go test ./pkg/steps/ai/claude -run 'TestContentBlockMerger' -count=1`
   - `go test ./pkg/steps/ai/claude -count=1`

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/changelog.md
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/changelog.md
@@ -1,0 +1,32 @@
+---
+Title: Changelog
+Ticket: GP-CLAUDE-DUPLICATE-TEXT
+Status: active
+Topics:
+  - geppetto
+  - claude
+  - streaming
+DocType: changelog
+Intent: short-term
+Owners:
+  - manuel
+Summary: Changelog for Claude tool-use duplicate text finalization fix.
+LastUpdated: 2026-05-08T00:15:00-04:00
+---
+
+# Changelog
+
+## 2026-05-08
+
+- Created `GP-CLAUDE-DUPLICATE-TEXT` docmgr ticket with a bug analysis and implementation guide.
+- Added regression coverage for the Anthropic/Claude sequence `text block -> tool_use block -> message_delta stop_reason=tool_use -> message_stop`.
+- Changed `ContentBlockMerger` so `message_delta` updates stop/usage metadata without publishing a textual partial.
+- Changed `ContentBlockMerger` so `message_stop` emits an empty final text payload when the stop reason is `tool_use`, preventing downstream consumers from creating a duplicate assistant text segment.
+- Validated with:
+  - `go test ./pkg/steps/ai/claude -run 'TestContentBlockMerger' -count=1`
+  - `go test ./pkg/steps/ai/claude -count=1`
+  - `go test ./pkg/steps/ai/... -count=1`
+
+## 2026-05-07
+
+- Initial workspace created.

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/changelog.md
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/changelog.md
@@ -18,6 +18,9 @@ LastUpdated: 2026-05-08T00:15:00-04:00
 
 ## 2026-05-08
 
+- Uploaded the bug-analysis and provider-to-chatapp event-semantics guides to reMarkable at `/ai/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT` as `GP-CLAUDE-DUPLICATE-TEXT - event semantics guide`.
+- Added `design/02-provider-to-chatapp-event-semantics-guide.md`, a detailed intern-facing analysis of correct event semantics and current mappings for OpenAI Chat Completions, OpenAI Responses, Anthropic Claude, Geppetto events, Pinocchio chatapp events, tool/reasoning plugins, and documentation gaps.
+- Captured line-numbered source evidence under `sources/` for Geppetto provider engines, Pinocchio runtime sink/projections/plugins, and existing Pinocchio docs.
 - Created `GP-CLAUDE-DUPLICATE-TEXT` docmgr ticket with a bug analysis and implementation guide.
 - Added regression coverage for the Anthropic/Claude sequence `text block -> tool_use block -> message_delta stop_reason=tool_use -> message_stop`.
 - Changed `ContentBlockMerger` so `message_delta` updates stop/usage metadata without publishing a textual partial.

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/design/01-bug-analysis-and-implementation-guide.md
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/design/01-bug-analysis-and-implementation-guide.md
@@ -91,7 +91,7 @@ For Claude/Anthropic streams:
 - Text content block stop may publish the block-finalization partial used by downstream segment finalization.
 - Tool-use block stop should publish a tool-call event.
 - Message delta with only `stop_reason` / usage should update metadata but should not publish text.
-- Message stop should publish the final lifecycle event, but if the stop reason is `tool_use`, its text payload must be empty so downstream code does not create a duplicate text segment.
+- Message stop should publish the final lifecycle event for normal end-turn responses, but if the stop reason is `tool_use`, it must not publish a final event because downstream code treats final as a text-segment finalizer.
 
 In pseudocode:
 
@@ -103,7 +103,7 @@ on message_delta:
 on message_stop:
   update stop_reason / usage metadata
   if stop_reason == "tool_use":
-      return Final(text="")
+      return no event
   return Final(text=all accumulated text)
 ```
 
@@ -122,7 +122,7 @@ This preserves a final event for lifecycle consumers while preventing the messag
    - the text block stop emits the existing empty-delta partial;
    - the tool call is emitted;
    - `message_delta` emits no text event;
-   - the final event exists but has empty text.
+   - no final event is emitted for `tool_use` message stop.
 3. Run:
 
 ```bash

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/design/01-bug-analysis-and-implementation-guide.md
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/design/01-bug-analysis-and-implementation-guide.md
@@ -1,0 +1,134 @@
+---
+Title: Claude tool-use duplicate text finalization bug analysis and implementation guide
+Ticket: GP-CLAUDE-DUPLICATE-TEXT
+Status: active
+Topics:
+  - geppetto
+  - claude
+  - streaming
+  - observability
+DocType: design-doc
+Intent: long-term
+Owners:
+  - manuel
+RelatedFiles:
+  - Path: pkg/steps/ai/claude/content-block-merger.go
+    Note: Claude streaming merger that converts Anthropic SSE events into Geppetto events.
+  - Path: pkg/steps/ai/claude/content-block-merger_test.go
+    Note: Regression coverage for text/tool-use/message-stop event sequences.
+  - Path: pkg/steps/ai/claude/engine_claude.go
+    Note: Streaming loop that observes provider events and publishes merger output.
+Summary: Analysis and fix plan for duplicate assistant text after Claude/Haiku tool-use turns.
+LastUpdated: 2026-05-08T00:05:00-04:00
+---
+
+# Claude tool-use duplicate text finalization bug analysis and implementation guide
+
+## Summary
+
+CoinVault's Haiku browser smoke run showed the first assistant text twice around the first tool call. The correlation SQLite artifact proved that the duplicate was not created by the browser reducer. It was already present as a second backend `ChatMessageFinished` event sent over the websocket.
+
+The bug is in the Claude streaming conversion path. Anthropic sends one text content block, then one tool-use content block, then `message_delta` / `message_stop` with `stop_reason=tool_use`. Geppetto's `ContentBlockMerger` currently publishes the accumulated text again at message stop. Downstream code interprets that final text as another text segment after the tool call, producing `chat-msg-*:text:2` with the same text already finalized as `chat-msg-*:text:1`.
+
+## Evidence from the CoinVault artifact
+
+Artifact used for diagnosis:
+
+```text
+../2026-03-16--gec-rag/ttmp/2026/05/07/COINVAULT-OBSERVABILITY--add-observer-correlation-export-for-coinvault-web-chat/various/browser-runs/multimodel-correlation-20260507-233459/haiku/debug.sqlite
+```
+
+Provider sequence:
+
+```text
+content_block_start index=0 text
+content_block_delta index=0 "I'll help"
+content_block_delta index=0 " you compare ..."
+content_block_delta index=0 " to best query this data."
+content_block_stop  index=0
+content_block_start index=1 tool_use toolu_012...
+content_block_delta index=1 tool input JSON chunks
+content_block_stop  index=1
+message_delta stop_reason=tool_use
+message_stop
+```
+
+Backend/UI sequence:
+
+```text
+ordinal 6 ChatInferenceFinished chat-msg-7:text:1  # correct text block finalization
+ordinal 7 ChatToolCallStarted   toolu_012...
+ordinal 8 ChatInferenceFinished chat-msg-7:text:2  # duplicate text from message_stop
+```
+
+Transport/frontend sequence:
+
+```text
+ordinal 8 backend_transport ui_event_sent ChatMessageFinished
+ordinal 8 frontend raw websocket ChatMessageFinished chat-msg-7:text:2
+ordinal 8 frontend parsed frame ChatMessageFinished chat-msg-7:text:2
+ordinal 8 frontend UI mutation upsert chat-msg-7:text:2
+```
+
+## Root cause
+
+`pkg/steps/ai/claude/content-block-merger.go` treats message-level stop events as if they always carry final text that should be emitted downstream:
+
+```go
+case api.MessageStopType:
+    return []events.Event{events.NewFinalEvent(cbm.metadata, cbm.Text())}, nil
+```
+
+That is safe for a normal `end_turn` response, but it is wrong for a `tool_use` response. In a tool-use response, the assistant's text content block has already been streamed/finalized before the tool block starts. The message-level stop is the end of the provider message envelope, not a new assistant text segment.
+
+`MessageDeltaType` also emits an empty textual partial with the full accumulated text. For `stop_reason=tool_use`, that event does not represent new text and should not be published as a text event.
+
+## Implementation rule
+
+For Claude/Anthropic streams:
+
+- Text deltas should publish text partials.
+- Text content block stop may publish the block-finalization partial used by downstream segment finalization.
+- Tool-use block stop should publish a tool-call event.
+- Message delta with only `stop_reason` / usage should update metadata but should not publish text.
+- Message stop should publish the final lifecycle event, but if the stop reason is `tool_use`, its text payload must be empty so downstream code does not create a duplicate text segment.
+
+In pseudocode:
+
+```text
+on message_delta:
+  update stop_reason / usage metadata
+  return no text event
+
+on message_stop:
+  update stop_reason / usage metadata
+  if stop_reason == "tool_use":
+      return Final(text="")
+  return Final(text=all accumulated text)
+```
+
+This preserves a final event for lifecycle consumers while preventing the message-level event from re-emitting text that was already sent through content-block events.
+
+## Validation plan
+
+1. Add a unit test with this sequence:
+   - `message_start`
+   - text block start/delta/stop
+   - tool-use block start/input-delta/stop
+   - `message_delta stop_reason=tool_use`
+   - `message_stop`
+2. Assert that:
+   - the text delta is emitted once;
+   - the text block stop emits the existing empty-delta partial;
+   - the tool call is emitted;
+   - `message_delta` emits no text event;
+   - the final event exists but has empty text.
+3. Run:
+
+```bash
+go test ./pkg/steps/ai/claude -count=1
+```
+
+## Follow-up
+
+The CoinVault matrix also showed no non-empty normalized `correlation_key` values for Haiku provider rows. That is separate from the duplicate text bug. It should become a follow-up normalization ticket if Anthropic provider correlation keys need to match the OpenAI/Responses correlation experience.

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/design/02-provider-to-chatapp-event-semantics-guide.md
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/design/02-provider-to-chatapp-event-semantics-guide.md
@@ -1,0 +1,968 @@
+---
+Title: Provider-to-Geppetto-to-Pinocchio event semantics guide
+Ticket: GP-CLAUDE-DUPLICATE-TEXT
+Status: active
+Topics:
+    - geppetto
+    - claude
+    - openai
+    - open-responses
+    - pinocchio
+    - streaming
+    - observability
+DocType: design-doc
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles:
+    - Path: ../../../../../../../pinocchio/pkg/chatapp/plugins/toolcall.go
+      Note: Maps Geppetto tool lifecycle events to Pinocchio tool-call events
+    - Path: ../../../../../../../pinocchio/pkg/chatapp/runtime_sink.go
+      Note: Maps Geppetto events to Pinocchio chatapp backend events and text segment state
+    - Path: ../../../../../../../pinocchio/pkg/doc/topics/chatapp-protobuf-plugins.md
+      Note: Existing docs for segment-aware chatapp events that should be clarified
+    - Path: pkg/events/chat-events.go
+      Note: |-
+        Geppetto event vocabulary used by all provider engines.
+        Defines the current Geppetto event vocabulary and naming ambiguity
+    - Path: pkg/steps/ai/claude/content-block-merger.go
+      Note: |-
+        Anthropic Claude stream merger mapping provider content blocks to Geppetto events.
+        Maps Anthropic content blocks and message stops to Geppetto events
+    - Path: pkg/steps/ai/openai/engine_openai.go
+      Note: |-
+        OpenAI Chat Completions provider stream mapping to Geppetto events.
+        Maps OpenAI Chat Completions provider streams to Geppetto text
+    - Path: pkg/steps/ai/openai_responses/streaming.go
+      Note: |-
+        OpenAI Responses provider stream mapping to Geppetto events.
+        Maps OpenAI Responses SSE events to Geppetto text
+    - Path: ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/pinocchio/pkg/chatapp/plugins/reasoning.go
+      Note: Reasoning plugin mapping Geppetto thinking events to chatapp backend/UI/timeline events.
+    - Path: ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/pinocchio/pkg/chatapp/plugins/toolcall.go
+      Note: Tool-call plugin mapping Geppetto tool events to chatapp backend/UI/timeline events.
+    - Path: ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/pinocchio/pkg/chatapp/runtime_sink.go
+      Note: Pinocchio runtime sink mapping Geppetto events to chatapp backend events.
+ExternalSources: []
+Summary: Intern-facing guide for the correct cross-provider event model and current provider-to-chatapp mappings.
+LastUpdated: 2026-05-08T00:35:00-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+# Provider-to-Geppetto-to-Pinocchio event semantics guide
+
+## 1. Executive summary
+
+This guide explains how streaming provider events should become Geppetto events, how Geppetto events become Pinocchio chatapp events, and why the Haiku duplicate-message bug exposed a naming and boundary problem in the current system. The short version is that the system currently uses the name `ChatInferenceFinished` for something narrower than a whole inference run: it usually means "the current assistant text segment is finished." That is a workable legacy contract, but it becomes confusing once one assistant run can contain text, tool calls, tool results, reasoning, and more text.
+
+A correct event stream must preserve three distinct concepts:
+
+1. **Run lifecycle**: the assistant run begins and eventually becomes idle, stopped, or failed.
+2. **Text segment lifecycle**: a contiguous visible assistant text segment begins when text deltas arrive and ends when a boundary appears.
+3. **Tool lifecycle**: the model requests a tool, the host executes it, and the result becomes part of the transcript context.
+
+The Haiku bug happened because an Anthropic `message_stop` with `stop_reason=tool_use` was treated like a second text finalizer. The tool-call boundary had already closed the preceding text segment. The message stop was only the provider envelope ending. Turning it into a Geppetto `EventFinal` made Pinocchio manufacture another `ChatInferenceFinished` for a new text segment that did not really exist.
+
+The most important implementation rule is:
+
+```text
+A text-final event may close only an active text segment, or finalize text that has not already been emitted.
+A provider envelope stop is not a text-final event.
+```
+
+This guide is written for a new intern who needs to understand the whole chain before changing provider adapters, Pinocchio chatapp runtime sinks, or frontend trace analysis.
+
+## 2. Vocabulary: the three lifecycles that were conflated
+
+A streaming LLM UI looks like one thing to a user: an assistant is answering. Internally it is several interleaved lifecycles.
+
+### 2.1 Run lifecycle
+
+The **run** is the user-visible assistant turn. In Pinocchio/CoinVault it starts when the user submits a prompt and the chatapp publishes `ChatInferenceStarted`. A run may include several provider calls if the model requests tools and the host loops back with tool results.
+
+Current files:
+
+- `../pinocchio/pkg/chatapp/runtime_inference.go:75-81` publishes `ChatInferenceStarted` before Geppetto starts producing events.
+- `../pinocchio/pkg/chatapp/runtime_inference.go:140-153` has a fallback that publishes `ChatInferenceFinished` after the Geppetto session returns if the runtime sink has not already marked itself terminal.
+
+The current system does not have a clean, separate backend event named `ChatRunFinished`. That absence is one reason the word `InferenceFinished` is overloaded.
+
+### 2.2 Text segment lifecycle
+
+A **text segment** is one contiguous visible assistant text row. In a tool-using assistant run, there may be more than one text segment:
+
+```text
+text segment 1
+  -> tool call
+  -> tool result
+text segment 2
+  -> final answer
+```
+
+Pinocchio represents text segments with IDs like:
+
+```text
+chat-msg-7:text:1
+chat-msg-7:text:2
+```
+
+The segment logic lives in `../pinocchio/pkg/chatapp/runtime_sink.go`:
+
+- `ensureTextSegmentID()` allocates or reuses the current segment (`runtime_sink.go:96-107`).
+- `finishTextSegment()` closes an active segment and returns its accumulated text (`runtime_sink.go:139-150`).
+- transcript-boundary events such as tool calls call `finishTextSegment()` before the tool event is published (`runtime_sink.go:73-85`).
+
+### 2.3 Tool lifecycle
+
+A **tool lifecycle** starts when the model requests a tool. It is not text, but it is a transcript boundary. If assistant text was streaming before the tool request, that text segment must be closed before rendering the tool row.
+
+The tool plugin lives in `../pinocchio/pkg/chatapp/plugins/toolcall.go`:
+
+- `EventToolCall` becomes `ChatToolCallStarted` (`toolcall.go:71-81`).
+- `EventToolCallExecute` becomes `ChatToolCallUpdated` (`toolcall.go:83-91`).
+- `EventToolResult` becomes `ChatToolResultReady` and `ChatToolCallFinished` (`toolcall.go:93-109`).
+
+The runtime sink deliberately treats tool events as transcript boundaries:
+
+```go
+func isTranscriptBoundaryEvent(event gepevents.Event) bool {
+    switch event.(type) {
+    case *gepevents.EventToolCall,
+         *gepevents.EventToolCallExecute,
+         *gepevents.EventToolResult,
+         *gepevents.EventToolCallExecutionResult:
+        return true
+    default:
+        return false
+    }
+}
+```
+
+That boundary behavior is correct. The duplicate-message bug was not that tool calls close text. The bug was that provider message stop tried to close the same text again.
+
+## 3. The correct canonical event model
+
+Before discussing individual providers, it helps to define the model we want them all to implement.
+
+### 3.1 Ideal semantic events
+
+The ideal internal vocabulary would distinguish run events from text segment events:
+
+| Concept | Better semantic name | Current approximate name |
+|---|---|---|
+| Assistant run started | `AssistantRunStarted` / `ChatRunStarted` | `ChatInferenceStarted` |
+| Text segment delta | `AssistantTextDelta` / `ChatTextDelta` | `EventPartialCompletion` → `ChatTokensDelta` |
+| Text segment finished | `AssistantTextSegmentFinished` | `EventFinal` or tool-boundary `finishTextSegment()` → `ChatInferenceFinished` |
+| Tool call requested | `AssistantToolCallRequested` | `EventToolCall` → `ChatToolCallStarted` |
+| Tool execution started | `ToolExecutionStarted` | `EventToolCallExecute` → `ChatToolCallUpdated` |
+| Tool result ready | `ToolResultReady` | `EventToolResult` → `ChatToolResultReady` + `ChatToolCallFinished` |
+| Assistant run finished | `AssistantRunFinished` / `ChatRunFinished` | no clean equivalent today |
+| Assistant run stopped/failed | `AssistantRunStopped` / `ChatRunStopped` | `ChatInferenceStopped` |
+
+The current names are not fatal, but they invite mistakes. `ChatInferenceFinished` sounds like run completion, yet the code often uses it as text-segment completion. Interns should internalize this immediately: **in current Pinocchio, `ChatInferenceFinished` usually means text row finished, not necessarily whole run finished.**
+
+### 3.2 Correct sequence: text → tool → text → final
+
+The ideal user transcript is:
+
+```text
+Assistant: I will inspect the schema.
+Tool: sql_doc(...)
+Tool result: ...
+Assistant: The answer is ...
+```
+
+The event sequence should be:
+
+```text
+ChatInferenceStarted                 # run starts; legacy name
+
+ChatTokensDelta text:1               # first text segment opens
+ChatTokensDelta text:1
+ChatInferenceFinished text:1         # close text segment because a tool boundary arrives
+
+ChatToolCallStarted
+ChatToolCallUpdated                  # optional execution marker
+ChatToolResultReady
+ChatToolCallFinished
+
+ChatTokensDelta text:2               # second text segment opens only because real new text arrives
+ChatTokensDelta text:2
+ChatInferenceFinished text:2         # close second text segment at true final text boundary
+
+ChatRunFinished                      # recommended future event; absent today
+```
+
+With today's event vocabulary, the last `ChatInferenceFinished text:2` is doing double duty: it closes the final text segment and implies the run is no longer actively streaming. That is acceptable only when `text:2` exists because real post-tool text deltas arrived.
+
+### 3.3 Correct sequence: text → tool → final with no post-tool text
+
+Some provider calls end with a tool request and do not produce final assistant prose until the next provider call. In that case the sequence should be:
+
+```text
+ChatInferenceStarted
+
+ChatTokensDelta text:1
+ChatTokensDelta text:1
+ChatInferenceFinished text:1         # close text before tool
+
+ChatToolCallStarted
+ChatToolCallUpdated
+ChatToolResultReady
+ChatToolCallFinished
+
+ChatRunFinished                      # recommended future event if the whole run is done
+```
+
+There must not be:
+
+```text
+ChatInferenceFinished text:2
+```
+
+No second text segment opened. No second text segment should be finished.
+
+### 3.4 Practical invariant for current code
+
+Current Pinocchio can be kept safe with this invariant:
+
+```text
+Emit ChatInferenceFinished only when:
+  1. there is an active text segment to close, or
+  2. a final event carries non-empty text that has not already been emitted as a segment.
+
+Do not emit ChatInferenceFinished when:
+  1. there is no active text segment,
+  2. final text is empty, or
+  3. the provider event is only a tool-use message envelope stop.
+```
+
+That invariant belongs in both provider adapters and the runtime sink. Provider adapters should not emit misleading text-final events. The runtime sink should be defensive in case a provider adapter does.
+
+## 4. Current Pinocchio mapping from Geppetto events
+
+The current Pinocchio mapping is compact and important. Every provider eventually flows through `runtimeEventSink.PublishEvent` in `../pinocchio/pkg/chatapp/runtime_sink.go`.
+
+### 4.1 Text deltas
+
+Current code path:
+
+```text
+Geppetto EventPartialCompletion
+  -> runtimeEventSink.ensureTextSegmentID()
+  -> ChatTokensDelta
+  -> UI ChatMessageAppended
+  -> Timeline ChatMessage upsert
+```
+
+Relevant code:
+
+```go
+case *gepevents.EventPartialCompletion:
+    textMessageID, segment := s.ensureTextSegmentID()
+    s.lastText = ev.Completion
+    payload := newChatMessageDelta(textMessageID, ev.Delta, ev.Completion, ...)
+    return s.engine.publish(..., EventTokensDelta, payload)
+```
+
+Evidence: `pinocchio-runtime-sink.lines.txt:33-44`.
+
+### 4.2 Final text events
+
+Current code path:
+
+```text
+Geppetto EventFinal
+  -> runtimeEventSink.ensureTextSegmentID()
+  -> ChatInferenceFinished
+  -> UI ChatMessageFinished
+  -> Timeline ChatMessage status=finished
+```
+
+Relevant code:
+
+```go
+case *gepevents.EventFinal:
+    textMessageID, segment := s.ensureTextSegmentID()
+    s.lastText = ev.Text
+    s.terminal = true
+    s.textActive = false
+    payload := newChatMessageUpdate(textMessageID, "assistant", ev.Text, ev.Text, ...)
+    return s.engine.publish(..., EventInferenceFinished, payload)
+```
+
+Evidence: `pinocchio-runtime-sink.lines.txt:45-57`.
+
+This path is powerful and dangerous. It always allocates a text segment if none is active. That is useful for non-streaming providers that send only final text. It is wrong when an empty or provider-envelope-only final event arrives after a tool boundary.
+
+### 4.3 Transcript boundaries
+
+Current code path:
+
+```text
+Geppetto EventToolCall / EventToolResult / execution events
+  -> runtimeEventSink.finishTextSegment() if text is active
+  -> ChatInferenceFinished for the current text segment
+  -> ToolCallPlugin handles the actual tool event
+```
+
+Relevant code:
+
+```go
+if isTranscriptBoundaryEvent(event) {
+    if textMessageID, segment, text, ok := s.finishTextSegment(); ok {
+        payload := newChatMessageUpdate(textMessageID, "assistant", text, text, ...)
+        s.engine.publish(..., EventInferenceFinished, payload)
+    }
+}
+return s.engine.handleFeatureRuntimeEvent(...)
+```
+
+Evidence: `pinocchio-runtime-sink.lines.txt:73-85` and `pinocchio-runtime-sink.lines.txt:213-220`.
+
+This is the correct mechanism for `text -> tool`. It is also the reason provider adapters must not later send a second text final for the same provider message.
+
+### 4.4 UI and timeline projection
+
+Pinocchio's base projections are simple:
+
+| Backend event | UI event | Timeline effect |
+|---|---|---|
+| `ChatTokensDelta` | `ChatMessageAppended` | Upsert streaming `ChatMessage`. |
+| `ChatInferenceFinished` | `ChatMessageFinished` | Upsert finished `ChatMessage`. |
+| `ChatInferenceStopped` | `ChatMessageStopped` | Upsert stopped/error `ChatMessage`. |
+
+Evidence: `../pinocchio/pkg/chatapp/projections.go`, captured in `pinocchio-projections.lines.txt:1-120`.
+
+The frontend is not expected to infer semantic correctness. If backend sends `ChatMessageFinished chat-msg-7:text:2`, the frontend will render it.
+
+## 5. Provider-specific mappings today
+
+The three provider families use different provider APIs. They should converge to the same Geppetto event semantics, but today they do not all do it cleanly.
+
+## 5.1 OpenAI Chat Completions
+
+### Provider shape
+
+OpenAI-compatible Chat Completions streaming emits chunks with a `choices[]` array. Each choice delta may contain:
+
+- assistant text content;
+- reasoning/thinking text on some compatible providers;
+- tool call deltas, often split across many chunks;
+- a finish reason such as `tool_calls` or `stop`;
+- optional usage in a final stream-options chunk.
+
+### Current Geppetto mapping
+
+Current code: `pkg/steps/ai/openai/engine_openai.go`.
+
+The key mapping is:
+
+```text
+choice.delta.content
+  -> message += delta
+  -> EventPartialCompletion(delta, message)
+
+choice.delta.reasoning
+  -> EventThinkingPartial
+
+choice.delta.tool_calls
+  -> accumulated in ToolCallMerger
+
+stream EOF
+  -> publish EventToolCall for each merged tool call
+  -> publish EventFinal(message)
+```
+
+Evidence:
+
+- Text deltas become `EventPartialCompletion` at `geppetto-openai-chat-engine.lines.txt:291-331`.
+- Reasoning deltas become `EventThinkingPartial` at `geppetto-openai-chat-engine.lines.txt:295-307`.
+- Tool calls are accumulated during streaming at `geppetto-openai-chat-engine.lines.txt:309-312`.
+- Merged tool calls are published after the stream completes at `geppetto-openai-chat-engine.lines.txt:381-391`.
+- Final text is always published after tool calls at `geppetto-openai-chat-engine.lines.txt:417-433`.
+
+### Current behavior under the canonical model
+
+For a normal text-only answer, this maps well:
+
+```text
+OpenAI text delta -> EventPartialCompletion -> ChatTokensDelta
+OpenAI stream EOF -> EventFinal -> ChatInferenceFinished
+```
+
+For a tool-call answer, the current mapping is less clean:
+
+```text
+OpenAI text delta, if any -> EventPartialCompletion
+OpenAI tool deltas -> buffered
+stream EOF -> EventToolCall(s)
+stream EOF -> EventFinal(message)
+```
+
+This means a provider response that has both pre-tool text and tool calls can produce the same hazard seen in Claude:
+
+```text
+EventToolCall closes text segment via Pinocchio boundary
+EventFinal(message) can try to close that same text again
+```
+
+Many OpenAI-compatible providers produce tool calls with no assistant prose in the same provider message, so the bug may not show. But the semantic risk exists. The safer rule is: if finish reason is `tool_calls` and all text has already been emitted before the tool event, the provider adapter should not publish a text `EventFinal` after publishing tool calls unless there is genuinely unflushed text that has not been closed.
+
+## 5.2 OpenAI Responses API
+
+### Provider shape
+
+The Responses API emits typed SSE events such as:
+
+- `response.output_item.added`
+- `response.output_text.delta`
+- `response.output_item.done`
+- `response.function_call_arguments.delta`
+- `response.output_item.done` with `type=function_call`
+- `response.reasoning_text.delta`
+- `response.reasoning_summary_text.delta`
+- `response.completed`
+
+This API is more structured than Chat Completions. Text, reasoning, and function calls are separate output items.
+
+### Current Geppetto mapping
+
+Current code: `pkg/steps/ai/openai_responses/streaming.go`.
+
+The key mapping is:
+
+```text
+response.output_text.delta
+  -> appendAssistantChunk(delta)
+  -> EventPartialCompletion(delta, message)
+
+response.output_item.done type=message
+  -> backfill missing assistant text, if done payload carries text not seen as deltas
+
+response.output_item.done type=function_call
+  -> EventToolCall
+
+response.reasoning_text.delta / summary delta
+  -> EventThinkingPartial
+
+response.completed / EOF
+  -> EventFinal(message)
+```
+
+Evidence:
+
+- `appendAssistantChunk` publishes `EventPartialCompletion` at `geppetto-openai-responses-streaming.lines.txt:120-126`.
+- message item `done` backfills missing output text at `geppetto-openai-responses-streaming.lines.txt:486-516`.
+- function-call `done` publishes `EventToolCall` at `geppetto-openai-responses-streaming.lines.txt:517-549`.
+- text deltas map through `response.output_text.delta` at `geppetto-openai-responses-streaming.lines.txt:576-596`.
+- final `EventFinal(message)` is published at `geppetto-openai-responses-streaming.lines.txt:805`.
+
+### Current behavior under the canonical model
+
+Responses gives us enough structure to do the right thing, but the current adapter still emits a final text event at the end of the provider response regardless of whether a tool-call boundary already closed the current text.
+
+Ideal behavior should be item-aware:
+
+```text
+message item text deltas
+  -> EventPartialCompletion
+message item done
+  -> if needed, backfill missing text only
+function_call item done
+  -> EventToolCall, after closing any active text via Pinocchio boundary
+response.completed
+  -> run/provider-call metadata only, not text final, if no active text remains
+```
+
+Again, the problem is not the existence of `response.completed`. The problem is treating provider response completion as text segment completion.
+
+## 5.3 Anthropic Claude / Haiku
+
+### Provider shape
+
+Anthropic streaming uses a message envelope with content blocks:
+
+```text
+message_start
+content_block_start index=0 text
+content_block_delta index=0 text_delta
+content_block_stop  index=0
+content_block_start index=1 tool_use
+content_block_delta index=1 input_json_delta
+content_block_stop  index=1
+message_delta stop_reason=tool_use
+message_stop
+```
+
+For normal text-only answers, the message may end with `stop_reason=end_turn` instead of `tool_use`.
+
+### Current Geppetto mapping after this ticket
+
+Current code: `pkg/steps/ai/claude/content-block-merger.go`.
+
+The current mapping is:
+
+```text
+message_start
+  -> EventStart
+
+content_block_delta text
+  -> EventPartialCompletion(delta, fullText)
+
+content_block_stop text
+  -> EventPartialCompletion("", fullText)
+
+content_block_stop tool_use
+  -> EventToolCall
+
+message_delta
+  -> metadata only; no text event
+
+message_stop with stop_reason=tool_use
+  -> no event
+
+message_stop with normal end_turn
+  -> EventFinal(fullText)
+```
+
+Evidence:
+
+- `message_start` maps to `EventStart` at `geppetto-claude-content-block-merger.lines.txt:150-166`.
+- `message_delta` is now metadata-only at `geppetto-claude-content-block-merger.lines.txt:168-193`.
+- `message_stop` suppresses final event for `tool_use` at `geppetto-claude-content-block-merger.lines.txt:195-229`.
+- text deltas become `EventPartialCompletion` at `geppetto-claude-content-block-merger.lines.txt:263-269`.
+- text content-block stop emits an empty-delta partial at `geppetto-claude-content-block-merger.lines.txt:290-294`.
+- tool-use content-block stop emits `EventToolCall` at `geppetto-claude-content-block-merger.lines.txt:296-314`.
+
+### Why this is correct for the Haiku duplicate
+
+The provider did not send two text blocks. The tool call closed the first text segment through Pinocchio's transcript-boundary rule. Therefore `message_stop stop_reason=tool_use` must not publish another final text event. After commit `38af6ed`, it does not.
+
+## 6. Sequence diagrams
+
+### 6.1 Correct text → tool → text → final sequence
+
+```mermaid
+sequenceDiagram
+    participant Provider
+    participant Geppetto
+    participant Pinocchio
+    participant Sessionstream
+    participant Browser
+
+    Provider->>Geppetto: text delta "I will inspect..."
+    Geppetto->>Pinocchio: EventPartialCompletion(text:1)
+    Pinocchio->>Sessionstream: ChatTokensDelta text:1
+    Sessionstream->>Browser: ChatMessageAppended text:1
+
+    Provider->>Geppetto: tool call completed/requested
+    Geppetto->>Pinocchio: EventToolCall(sql_doc)
+    Pinocchio->>Sessionstream: ChatInferenceFinished text:1
+    Pinocchio->>Sessionstream: ChatToolCallStarted
+    Sessionstream->>Browser: ChatMessageFinished text:1
+    Sessionstream->>Browser: ChatToolCallStarted
+
+    Pinocchio->>Sessionstream: ChatToolResultReady
+    Pinocchio->>Sessionstream: ChatToolCallFinished
+    Sessionstream->>Browser: tool result + completed state
+
+    Provider->>Geppetto: post-tool text delta "The result is..."
+    Geppetto->>Pinocchio: EventPartialCompletion(text:2)
+    Pinocchio->>Sessionstream: ChatTokensDelta text:2
+    Sessionstream->>Browser: ChatMessageAppended text:2
+
+    Provider->>Geppetto: final text stop
+    Geppetto->>Pinocchio: EventFinal(text:2)
+    Pinocchio->>Sessionstream: ChatInferenceFinished text:2
+    Sessionstream->>Browser: ChatMessageFinished text:2
+```
+
+### 6.2 Correct text → tool → provider envelope stop sequence
+
+```mermaid
+sequenceDiagram
+    participant Provider
+    participant Geppetto
+    participant Pinocchio
+    participant Sessionstream
+    participant Browser
+
+    Provider->>Geppetto: text deltas
+    Geppetto->>Pinocchio: EventPartialCompletion
+    Pinocchio->>Sessionstream: ChatTokensDelta text:1
+    Sessionstream->>Browser: ChatMessageAppended text:1
+
+    Provider->>Geppetto: tool_use block stop
+    Geppetto->>Pinocchio: EventToolCall
+    Pinocchio->>Sessionstream: ChatInferenceFinished text:1
+    Pinocchio->>Sessionstream: ChatToolCallStarted
+    Sessionstream->>Browser: ChatMessageFinished text:1 + tool row
+
+    Provider->>Geppetto: message_delta stop_reason=tool_use
+    Geppetto-->>Geppetto: update metadata only
+
+    Provider->>Geppetto: message_stop
+    Geppetto-->>Geppetto: no text event
+
+    Note over Pinocchio,Browser: No ChatInferenceFinished text:2 is emitted.
+```
+
+### 6.3 Buggy sequence that caused the duplicate
+
+```mermaid
+sequenceDiagram
+    participant Provider
+    participant Geppetto
+    participant Pinocchio
+    participant Browser
+
+    Provider->>Geppetto: text block
+    Geppetto->>Pinocchio: EventPartialCompletion
+    Provider->>Geppetto: tool_use block stop
+    Geppetto->>Pinocchio: EventToolCall
+    Pinocchio->>Browser: ChatMessageFinished text:1
+    Pinocchio->>Browser: ChatToolCallStarted
+
+    Provider->>Geppetto: message_stop stop_reason=tool_use
+    Geppetto->>Pinocchio: EventFinal(previous text)
+    Pinocchio->>Browser: ChatMessageFinished text:2
+
+    Note over Browser: Duplicate visible assistant text.
+```
+
+## 7. Better names to reduce confusion
+
+The current system can remain compatible while docs and internal names are clarified. For a future breaking API or compatibility alias layer, use names that separate run lifecycle from segment lifecycle.
+
+### 7.1 Geppetto event names
+
+| Current | Recommended semantic alias | Why |
+|---|---|---|
+| `EventTypeStart` / `EventPartialCompletionStart` | `RunStarted` or `TextStreamStarted` depending on intended meaning | Current comment says start/final are for text completion, but engines use start for provider run start. |
+| `EventTypePartialCompletion` | `TextDelta` | It carries a delta and cumulative text, not a whole completion concept. |
+| `EventTypeFinal` | `TextFinal` | It should mean final text segment, not provider response completed. |
+| `EventTypeToolCall` | `ToolCallRequested` | More explicit: the model requested the tool; host execution has not necessarily begun. |
+| `EventTypeInfo` with `thinking-started/ended` | typed `ReasoningStarted/ReasoningFinished` | Reduces stringly-typed plugin behavior. |
+
+### 7.2 Pinocchio backend/UI event names
+
+| Current | Recommended future name | Compatibility strategy |
+|---|---|---|
+| `ChatInferenceStarted` | `ChatRunStarted` | Keep old name as alias until clients migrate. |
+| `ChatTokensDelta` | `ChatTextDelta` | Add alias or document as text-segment delta. |
+| `ChatInferenceFinished` | `ChatTextSegmentFinished` | This is the most important rename; current name is misleading. |
+| `ChatInferenceStopped` | `ChatRunStopped` / `ChatRunFailed` | Separate user stop from runtime failure in a future cleanup. |
+| none | `ChatRunFinished` | Add a true run-level final event so `ChatInferenceFinished` no longer has to imply run completion. |
+
+A migration does not need to be immediate. The minimum safe step is documentation and defensive guards. The better long-term step is to introduce new names while emitting legacy aliases during a transition period.
+
+## 8. Documentation verification and improvement notes
+
+I checked existing Pinocchio docs captured under `sources/`.
+
+### 8.1 What is already correct
+
+`pkg/doc/topics/chatapp-protobuf-plugins.md` already says:
+
+```text
+ChatInferenceFinished | ChatMessageFinished | Assistant text segment or final response finished.
+```
+
+Evidence: `pinocchio-chatapp-protobuf-plugins-doc.lines.txt:71-79`.
+
+It also explains segment-aware transcript rows and shows multiple text/thinking segments under one parent assistant run. Evidence: `pinocchio-chatapp-protobuf-plugins-doc.lines.txt:87-110`.
+
+That doc is directionally correct: it acknowledges that `ChatInferenceFinished` can mean a segment, not only a whole response.
+
+### 8.2 What is still ambiguous
+
+The phrase "Assistant text segment or final response finished" is too compressed. It should explicitly say:
+
+```text
+ChatInferenceFinished is a legacy name. In segment-aware chatapp flows, it closes one assistant text segment. It should not be emitted merely because a provider response envelope ended. Tool-call boundaries may emit ChatInferenceFinished to close active text before a tool row.
+```
+
+The tutorial `pkg/doc/tutorials/09-building-sessionstream-react-chat-apps.md` describes the simple flow:
+
+```text
+ChatTokensDelta
+ChatInferenceFinished
+```
+
+That is useful for a text-only tutorial, but it does not explain the tool loop case. The tutorial should add a short section for:
+
+```text
+Text segment -> tool call -> optional next text segment
+```
+
+and warn that `ChatInferenceFinished` is a text segment finalizer in that context.
+
+### 8.3 Documentation TODOs
+
+Recommended doc updates in Pinocchio:
+
+1. Expand `chatapp-protobuf-plugins.md` section "Base chatapp schema" with a note that `ChatInferenceFinished` is legacy naming for text segment finalization.
+2. Add a diagram to `09-building-sessionstream-react-chat-apps.md` showing `text:1 -> tool -> text:2`.
+3. Add a table titled "Provider envelope events are not transcript events" with examples:
+   - Anthropic `message_stop stop_reason=tool_use` → no text final.
+   - OpenAI Responses `response.completed` after function call → no text final if no active text.
+   - OpenAI Chat Completions finish reason `tool_calls` → tool request, not text final.
+4. Add a runtime sink comment around `EventFinal` handling explaining when it is allowed to allocate a new segment.
+
+## 9. Implementation guidance
+
+This section is the practical guide for changing the code safely.
+
+### 9.1 Provider adapters should emit semantic Geppetto events
+
+Provider adapters must not mechanically map every provider "done" event to Geppetto `EventFinal`. They must ask: what semantic thing ended?
+
+Pseudocode:
+
+```text
+on provider text delta:
+    emit EventPartialCompletion(delta, accumulatedText)
+
+on provider text block done:
+    if downstream needs a segment boundary marker:
+        emit EventPartialCompletion(delta="", accumulatedText)
+
+on provider tool call complete/requested:
+    emit EventToolCall(id, name, args)
+
+on provider response/message done:
+    update usage/stop metadata
+    if stop reason means normal text answer is complete:
+        emit EventFinal(accumulatedText)
+    if stop reason means tool call requested:
+        emit no text final
+```
+
+### 9.2 Runtime sink should guard final text events
+
+Even if provider adapters are fixed, Pinocchio should be defensive. Current `EventFinal` handling always calls `ensureTextSegmentID()`, which can manufacture a new text segment. A safer version would inspect whether text is active and whether final text is non-empty and new.
+
+Pseudocode for a future Pinocchio guard:
+
+```text
+on EventFinal(ev):
+    if textActive:
+        finish active segment with ev.Text or lastText
+        publish ChatInferenceFinished
+        mark terminal
+        return
+
+    if ev.Text is non-empty and no text segment has ever been created:
+        create one text segment
+        publish ChatInferenceFinished
+        mark terminal
+        return
+
+    if ev.Text is non-empty and ev.Text differs from the last closed segment:
+        create a new text segment
+        publish ChatInferenceFinished
+        mark terminal
+        return
+
+    mark terminal if this is truly run-final metadata
+    do not publish ChatInferenceFinished
+```
+
+The final branch needs a real run-level event eventually. Without one, the runtime has to choose between ignoring a run-level final and misusing a text-segment final.
+
+### 9.3 Add provider-specific regression tests
+
+The Claude regression test created in this ticket should become the pattern for all providers:
+
+```text
+text deltas
+provider tool-call indication
+tool call event
+provider envelope stop with tool-call stop reason
+assert no duplicate text final
+```
+
+Recommended new tests:
+
+- OpenAI Chat Completions: content deltas plus `finish_reason=tool_calls` should not produce a duplicate text final after `EventToolCall`.
+- OpenAI Responses: `output_text.delta`, then `function_call` item done, then `response.completed` should not produce duplicate text final.
+- Pinocchio runtime sink: receiving `EventFinal("")` with no active text segment should not publish `ChatInferenceFinished`.
+- Pinocchio runtime sink: receiving `EventFinal("new text")` with no prior segment should still publish a finished text segment for non-streaming compatibility.
+
+## 10. Provider mapping tables
+
+### 10.1 OpenAI Chat Completions mapping table
+
+| Provider stream event | Current Geppetto event | Current Pinocchio consequence | Desired rule |
+|---|---|---|---|
+| `choices[].delta.content` | `EventPartialCompletion` | `ChatTokensDelta` | Correct. |
+| reasoning delta fields | `EventThinkingPartial` plus info start/end | `ChatReasoning*` via plugin | Correct, subject to provider normalization. |
+| `choices[].delta.tool_calls` | buffered until stream end | no immediate event | Acceptable but less live than possible. |
+| stream end with merged tool calls | `EventToolCall` | closes active text, then `ChatToolCallStarted` | Correct boundary. |
+| stream end always | `EventFinal(message)` | may create/finish a text segment | Should be conditional when finish reason is `tool_calls`. |
+
+### 10.2 OpenAI Responses mapping table
+
+| Provider stream event | Current Geppetto event | Current Pinocchio consequence | Desired rule |
+|---|---|---|---|
+| `response.output_text.delta` | `EventPartialCompletion` | `ChatTokensDelta` | Correct. |
+| `response.output_item.done type=message` | backfill text through partials if missing | `ChatTokensDelta` for missing suffix | Correct if de-duplicated. |
+| `response.output_item.done type=function_call` | `EventToolCall` | closes active text, starts tool row | Correct. |
+| `response.reasoning_text.delta` / summary deltas | `EventThinkingPartial` | `ChatReasoning*` | Correct. |
+| `response.completed` / EOF | `EventFinal(message)` | may create/finish text segment | Should be conditional when current output ended in function call and no unclosed text remains. |
+
+### 10.3 Anthropic Claude mapping table
+
+| Provider stream event | Current Geppetto event after this ticket | Current Pinocchio consequence | Desired rule |
+|---|---|---|---|
+| `message_start` | `EventStart` | mostly ignored by runtime sink | OK, but naming should clarify run vs text. |
+| `content_block_delta text_delta` | `EventPartialCompletion` | `ChatTokensDelta` | Correct. |
+| `content_block_stop text` | empty-delta `EventPartialCompletion` | updates active segment with final cumulative text | Works as segment finalization hint. |
+| `content_block_stop tool_use` | `EventToolCall` | closes active text, starts tool row | Correct. |
+| `message_delta stop_reason=tool_use` | metadata only | no transcript event | Correct. |
+| `message_stop stop_reason=tool_use` | no event | no duplicate text final | Correct after commit `38af6ed`. |
+| `message_stop stop_reason=end_turn` | `EventFinal(fullText)` | closes final text segment | Correct for text-only answer. |
+
+## 11. How to verify with SQLite traces
+
+When a duplicate appears, do not inspect only the frontend. Use the debug SQLite to follow the evidence.
+
+### 11.1 Provider and Geppetto boundary
+
+```sql
+select
+  g.record_id,
+  g.stage,
+  g.event_type,
+  pe.provider_event_type,
+  g.output_index,
+  substr(coalesce(
+    json_extract(pe.object_json,'$.delta.text'),
+    json_extract(pe.object_json,'$.delta.stop_reason'),
+    json_extract(pe.object_json,'$.delta.partial_json'),
+    ''
+  ),1,120) as payload
+from geppetto_records g
+left join geppetto_provider_events pe on pe.record_id = g.record_id
+order by g.record_id;
+```
+
+Look for a pattern like:
+
+```text
+provider_routed_event message_stop
+geppetto_publish_started final
+```
+
+If the stop reason was `tool_use`, that final event is suspicious.
+
+### 11.2 Backend pipeline
+
+```sql
+select
+  br.ordinal,
+  p.event_name,
+  json_extract(e.payload_json,'$.messageId') as message_id,
+  substr(json_extract(e.payload_json,'$.content'),1,120) as content
+from backend_pipeline p
+join backend_records br on br.id = p.record_id
+left join backend_pipeline_ui_events e
+  on e.record_id = br.id
+ and e.source = 'uiEvents'
+where p.event_type = 'pinocchio.chatapp.v1.ChatMessageUpdate'
+order by cast(br.ordinal as int);
+```
+
+A duplicate text bug usually appears as:
+
+```text
+ChatInferenceFinished chat-msg-*:text:1  same text
+ChatToolCallStarted
+ChatInferenceFinished chat-msg-*:text:2  same text
+```
+
+### 11.3 Browser delivery chain
+
+```sql
+select ordinal, pipeline_event, transport_fanout, frontend_parsed
+from delivery_chain
+order by cast(ordinal as integer);
+```
+
+If `transport_fanout=yes` and `frontend_parsed=yes`, the frontend received what the backend sent.
+
+## 12. Near-term implementation plan
+
+### Phase 1: Finish validating the Claude fix
+
+1. Restart CoinVault using the workspace that includes local Geppetto.
+2. Re-run the Haiku Playwright smoke.
+3. Download a new debug SQLite.
+4. Verify that `message_stop stop_reason=tool_use` no longer produces `geppetto_publish_started final` and no longer produces `ChatInferenceFinished text:2` before post-tool text deltas.
+
+### Phase 2: Add Pinocchio defensive guard
+
+Implement a runtime sink guard for empty/no-active `EventFinal` events. This reduces blast radius if another provider emits a misleading final event.
+
+Candidate files:
+
+```text
+../pinocchio/pkg/chatapp/runtime_sink.go
+../pinocchio/pkg/chatapp/chat_test.go or runtime_sink_test.go
+```
+
+### Phase 3: Audit OpenAI Chat Completions and Responses
+
+Both OpenAI engines currently publish tool-call events and then publish `EventFinal(message)` at provider stream completion. Audit whether this can duplicate text in real tool-call responses.
+
+Candidate files:
+
+```text
+pkg/steps/ai/openai/engine_openai.go
+pkg/steps/ai/openai_responses/streaming.go
+```
+
+Provider-specific fix rule:
+
+```text
+If the provider stop/completion reason is a tool call and no unclosed post-tool text exists, do not publish text EventFinal.
+```
+
+### Phase 4: Improve naming and docs
+
+Start with documentation and comments. Do not force a breaking API rename immediately.
+
+1. Add explicit note to Pinocchio docs that `ChatInferenceFinished` is a legacy text-segment finalizer.
+2. Add sequence diagrams for text/tool/text and text/tool/final.
+3. Consider adding future events:
+   - `ChatTextSegmentFinished`
+   - `ChatRunFinished`
+4. Keep compatibility aliases for existing frontends.
+
+## 13. References
+
+### Geppetto source
+
+- `pkg/events/chat-events.go` — current event type vocabulary.
+- `pkg/steps/ai/openai/engine_openai.go` — OpenAI Chat Completions streaming event conversion.
+- `pkg/steps/ai/openai_responses/streaming.go` — OpenAI Responses streaming event conversion.
+- `pkg/steps/ai/claude/content-block-merger.go` — Claude/Anthropic content-block merger and tool-use message-stop fix.
+- `pkg/steps/ai/claude/content-block-merger_test.go` — regression coverage for Claude tool-use duplicate text finalization.
+
+### Pinocchio source
+
+- `../pinocchio/pkg/chatapp/runtime_inference.go` — run start and fallback finalization logic.
+- `../pinocchio/pkg/chatapp/runtime_sink.go` — Geppetto event sink and text segment state machine.
+- `../pinocchio/pkg/chatapp/projections.go` — backend event to UI/timeline projections.
+- `../pinocchio/pkg/chatapp/plugins/toolcall.go` — tool-call runtime event mapping.
+- `../pinocchio/pkg/chatapp/plugins/reasoning.go` — reasoning runtime event mapping.
+
+### Pinocchio docs to update
+
+- `../pinocchio/pkg/doc/topics/chatapp-protobuf-plugins.md`
+- `../pinocchio/pkg/doc/tutorials/09-building-sessionstream-react-chat-apps.md`
+
+The docs already contain the right ingredients: segment-aware message IDs and shared plugins. They need stronger language around the difference between provider/run completion and text-segment completion.

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/index.md
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/index.md
@@ -1,0 +1,66 @@
+---
+Title: Fix Claude tool-use duplicate text finalization
+Ticket: GP-CLAUDE-DUPLICATE-TEXT
+Status: active
+Topics:
+    - geppetto
+    - claude
+    - observability
+    - streaming
+DocType: index
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles:
+    - Path: pkg/steps/ai/claude/content-block-merger.go
+      Note: Claude stream merger that emits duplicate final text for tool-use turns
+    - Path: pkg/steps/ai/claude/content-block-merger_test.go
+      Note: Regression tests for Claude text/tool-use/message-stop sequences
+    - Path: pkg/steps/ai/claude/engine_claude.go
+      Note: Streaming loop publishing merger events and provider observability
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-05-07T23:49:06.043940424-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+# Fix Claude tool-use duplicate text finalization
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- geppetto
+- claude
+- observability
+- streaming
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/reference/01-implementation-diary.md
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/reference/01-implementation-diary.md
@@ -80,3 +80,33 @@ go test ./pkg/steps/ai/... -count=1
 ```
 
 It passed for Claude, Claude API, Gemini, OpenAI, OpenAI Responses, runtime attribution, settings, and stream helpers. This gives confidence that the changed final-text behavior did not break adjacent provider packages.
+
+## 2026-05-08 00:55 — Playwright retest showed empty final still duplicates downstream
+
+I re-ran CoinVault Haiku through Playwright after commit `ae94308`. Because the workspace has `../go.work` including `./geppetto`, CoinVault should have picked up the local Geppetto checkout. The retest still showed duplicate intro text.
+
+The new artifact was:
+
+```text
+../2026-03-16--gec-rag/ttmp/2026/05/07/COINVAULT-OBSERVABILITY--add-observer-correlation-export-for-coinvault-web-chat/various/browser-runs/haiku-after-geppetto-fix-20260507-235210/haiku/debug.sqlite
+```
+
+The Geppetto/provider sequence now showed:
+
+```text
+record 56 provider_routed_event message_delta stop_reason=tool_use
+record 57 provider_routed_event message_stop
+record 58 geppetto_publish_started final
+```
+
+Backend pipeline still had:
+
+```text
+ordinal 6 ChatInferenceFinished chat-msg-1:text:1
+ordinal 7 ChatToolCallStarted
+ordinal 8 ChatInferenceFinished chat-msg-1:text:2
+```
+
+This means the first fix was too weak. Emitting `EventFinal` with empty text still causes downstream Pinocchio/CoinVault logic to finalize cached accumulated text as a new segment. For `stop_reason=tool_use`, Claude `message_stop` must emit no final event at all. The lifecycle/tool-turn boundary is already represented by the tool-call event and the next inference turn.
+
+I updated the fix accordingly: `MessageStopType` now returns no events when the stop reason is `tool_use`, and the regression test now expects no final event for that case.

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/reference/01-implementation-diary.md
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/reference/01-implementation-diary.md
@@ -110,3 +110,52 @@ ordinal 8 ChatInferenceFinished chat-msg-1:text:2
 This means the first fix was too weak. Emitting `EventFinal` with empty text still causes downstream Pinocchio/CoinVault logic to finalize cached accumulated text as a new segment. For `stop_reason=tool_use`, Claude `message_stop` must emit no final event at all. The lifecycle/tool-turn boundary is already represented by the tool-call event and the next inference turn.
 
 I updated the fix accordingly: `MessageStopType` now returns no events when the stop reason is `tool_use`, and the regression test now expects no final event for that case.
+
+## 2026-05-08 00:35 — Wrote provider-to-chatapp event semantics intern guide
+
+After stepping back from the single Haiku duplicate and reviewing the whole provider-to-Geppetto-to-Pinocchio chain, I wrote a second design document:
+
+```text
+design/02-provider-to-chatapp-event-semantics-guide.md
+```
+
+The guide explains the distinction between run lifecycle, text segment lifecycle, and tool lifecycle. It maps current behavior for OpenAI Chat Completions, OpenAI Responses, and Anthropic Claude into Geppetto events and then into Pinocchio chatapp events. It also identifies the naming problem: `ChatInferenceFinished` is a legacy name that often means "text segment finished," not "whole assistant run finished."
+
+The guide includes:
+
+- canonical event sequences for `text -> tool -> text -> final` and `text -> tool -> final`;
+- current OpenAI Chat Completions mapping;
+- current OpenAI Responses mapping;
+- current Anthropic mapping after the fix in this ticket;
+- Pinocchio runtime sink details;
+- documentation verification against Pinocchio docs;
+- proposed clearer future event names;
+- SQLite verification SQL for tracing duplicates across the full pipeline.
+
+This was written as an onboarding document for a new intern so future debugging does not collapse provider envelope completion, text segment finalization, and run completion into one ambiguous concept.
+
+## 2026-05-08 00:45 — Uploaded event semantics guide to reMarkable
+
+I uploaded a bundled PDF containing both the original bug-analysis guide and the new provider-to-chatapp event semantics guide to reMarkable.
+
+### Commands
+
+```bash
+remarquee status
+remarquee cloud account --non-interactive
+remarquee upload bundle --dry-run \
+  ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/design/01-bug-analysis-and-implementation-guide.md \
+  ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/design/02-provider-to-chatapp-event-semantics-guide.md \
+  --name "GP-CLAUDE-DUPLICATE-TEXT - event semantics guide" \
+  --remote-dir "/ai/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT" \
+  --toc-depth 2
+remarquee upload bundle ...
+remarquee cloud ls /ai/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT --long --non-interactive
+```
+
+### Result
+
+```text
+OK: uploaded GP-CLAUDE-DUPLICATE-TEXT - event semantics guide.pdf -> /ai/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT
+[f]	GP-CLAUDE-DUPLICATE-TEXT - event semantics guide
+```

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/reference/01-implementation-diary.md
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/reference/01-implementation-diary.md
@@ -1,0 +1,82 @@
+---
+Title: Implementation diary
+Ticket: GP-CLAUDE-DUPLICATE-TEXT
+Status: active
+Topics:
+  - geppetto
+  - claude
+  - streaming
+DocType: reference
+Intent: long-term
+Owners:
+  - manuel
+Summary: Chronological diary for fixing Claude tool-use duplicate text finalization.
+LastUpdated: 2026-05-08T00:05:00-04:00
+---
+
+# Implementation diary
+
+## 2026-05-08 00:05 — Ticket creation and root-cause framing
+
+Created this ticket after correlating a CoinVault Haiku duplicate-message artifact through Geppetto provider records, backend pipeline records, transport fanout, frontend raw websocket records, parsed frames, UI mutations, and timeline entities.
+
+The duplicate appears when Anthropic/Claude streams one text block, then one tool-use block, then ends the provider message with `stop_reason=tool_use`. Geppetto's Claude `ContentBlockMerger` publishes the accumulated text again at message stop, which downstream consumers treat as a new text segment after the tool call.
+
+The implementation plan is to make `MessageDeltaType` metadata-only and make `MessageStopType` emit an empty final text payload when the stop reason is `tool_use`.
+
+## 2026-05-08 00:15 — Implemented Claude tool-use finalization fix
+
+I updated `pkg/steps/ai/claude/content-block-merger.go` and added a regression case in `pkg/steps/ai/claude/content-block-merger_test.go`.
+
+### What changed
+
+- `MessageDeltaType` now updates `stop_reason`, `stop_sequence`, and usage metadata but returns no text event. Anthropic `message_delta` can be metadata-only, and publishing accumulated text there risks downstream duplicate text updates.
+- `MessageStopType` still emits a final event for lifecycle consumers, but if the accumulated stop reason is `tool_use`, it emits `Final(text="")` instead of `Final(text=cbm.Text())`.
+- Added `stopReasonIsToolUse()` helper to keep the message-stop decision local to the merger.
+
+### Regression test
+
+The new test covers this provider sequence:
+
+```text
+message_start
+content_block_start index=0 text
+content_block_delta index=0 "I'll inspect the schema first."
+content_block_stop  index=0
+content_block_start index=1 tool_use sql_doc
+content_block_delta index=1 {"topic":"inventory"}
+content_block_stop  index=1
+message_delta stop_reason=tool_use
+message_stop
+```
+
+Expected emitted events:
+
+```text
+start
+partial text delta
+empty-delta block-finalization partial
+tool-call
+final with empty text
+```
+
+That preserves the tool-use lifecycle but prevents re-emitting the already-finalized text at message stop.
+
+### Validation
+
+```bash
+go test ./pkg/steps/ai/claude -run 'TestContentBlockMerger' -count=1
+go test ./pkg/steps/ai/claude -count=1
+```
+
+Both passed.
+
+## 2026-05-08 00:20 — Broader package validation
+
+After the targeted Claude package tests passed, I ran the broader AI steps test suite:
+
+```bash
+go test ./pkg/steps/ai/... -count=1
+```
+
+It passed for Claude, Claude API, Gemini, OpenAI, OpenAI Responses, runtime attribution, settings, and stream helpers. This gives confidence that the changed final-text behavior did not break adjacent provider packages.

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/geppetto-claude-content-block-merger.lines.txt
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/geppetto-claude-content-block-merger.lines.txt
@@ -1,0 +1,201 @@
+  120			}
+  121		}
+  122		if event.Usage != nil {
+  123			cbm.metadata.Usage = &events.Usage{
+  124				InputTokens:              event.Usage.InputTokens,
+  125				OutputTokens:             event.Usage.OutputTokens,
+  126				CacheCreationInputTokens: event.Usage.CacheCreationInputTokens,
+  127				CacheReadInputTokens:     event.Usage.CacheReadInputTokens,
+  128			}
+  129		}
+  130	
+  131		if cbm.metadata.Usage == nil {
+  132			return
+  133		}
+  134	
+  135		if cbm.metadata.Usage.InputTokens > 0 {
+  136			cbm.inputTokens = cbm.metadata.Usage.InputTokens
+  137		} else {
+  138			cbm.metadata.Usage.InputTokens = cbm.inputTokens
+  139		}
+  140	}
+  141	
+  142	func (cbm *ContentBlockMerger) Add(event api.StreamingEvent) ([]events.Event, error) {
+  143		// NOTE(manuel, 2024-06-04) This is where to continue: implement the block merger for claude, maybe test it in the main.go,
+  144		// then properly implement the step and try it out (maybe also in its own main.go, as an example of how to use steps on their own.
+  145	
+  146		switch event.Type {
+  147		case api.PingType:
+  148			return []events.Event{}, nil
+  149	
+  150		case api.MessageStartType:
+  151			if event.Message == nil {
+  152				return nil, errors.New("MessageStartType event must have a message")
+  153			}
+  154			cbm.response = event.Message
+  155			if cbm.metadata.Extra == nil {
+  156				cbm.metadata.Extra = map[string]interface{}{}
+  157			}
+  158			cbm.metadata.Extra[ModelMetadataSlug] = event.Message.Model
+  159			cbm.metadata.Extra[MessageIdMetadataSlug] = event.Message.ID
+  160			cbm.metadata.Extra[RoleMetadataSlug] = event.Message.Role
+  161	
+  162			// Update event metadata with common fields
+  163			// engine removed; model is sufficient
+  164			cbm.updateUsage(event)
+  165	
+  166			return []events.Event{events.NewStartEvent(cbm.metadata)}, nil
+  167	
+  168		case api.MessageDeltaType:
+  169			if event.Delta == nil {
+  170				return nil, errors.New("MessageDeltaType event must have a delta")
+  171			}
+  172			if event.Delta.StopReason != "" {
+  173				if cbm.metadata.Extra == nil {
+  174					cbm.metadata.Extra = map[string]interface{}{}
+  175				}
+  176				cbm.metadata.Extra[StopReasonMetadataSlug] = event.Delta.StopReason
+  177				cbm.metadata.StopReason = &event.Delta.StopReason
+  178			}
+  179			if event.Delta.StopSequence != "" {
+  180				if cbm.metadata.Extra == nil {
+  181					cbm.metadata.Extra = map[string]interface{}{}
+  182				}
+  183				cbm.metadata.Extra[StopSequenceMetadataSlug] = event.Delta.StopSequence
+  184			}
+  185	
+  186			cbm.updateUsage(event)
+  187	
+  188			// Anthropic message_delta events can carry message-level metadata such as
+  189			// stop_reason and usage without carrying new text. Text is emitted from
+  190			// content_block_delta/content_block_stop events; emitting the accumulated
+  191			// text again here causes downstream consumers to create a duplicate text
+  192			// segment before tool execution.
+  193			return []events.Event{}, nil
+  194	
+  195		case api.MessageStopType:
+  196			if cbm.response == nil {
+  197				return nil, errors.New("MessageStopType event must have a message to store the finished content block")
+  198			}
+  199	
+  200			if event.Message != nil {
+  201				if event.Message.StopReason != "" {
+  202					if cbm.metadata.Extra == nil {
+  203						cbm.metadata.Extra = map[string]interface{}{}
+  204					}
+  205					cbm.metadata.Extra[StopReasonMetadataSlug] = event.Message.StopReason
+  206					cbm.metadata.StopReason = &event.Message.StopReason
+  207				}
+  208				if event.Message.StopSequence != "" {
+  209					if cbm.metadata.Extra == nil {
+  210						cbm.metadata.Extra = map[string]interface{}{}
+  211					}
+  212					cbm.metadata.Extra[StopSequenceMetadataSlug] = event.Message.StopSequence
+  213				}
+  214			}
+  215	
+  216			// set duration on final
+  217			d := time.Since(cbm.startTime).Milliseconds()
+  218			dm := int64(d)
+  219			cbm.metadata.DurationMs = &dm
+  220	
+  221			if cbm.stopReasonIsToolUse() {
+  222				// For Claude tool-use turns, the preceding text block has already been
+  223				// streamed and block-finalized before the tool_use block. The
+  224				// message_stop event closes the provider message envelope; publishing a
+  225				// final event here causes downstream consumers to finalize the cached
+  226				// text as a new assistant segment after the tool call.
+  227				return []events.Event{}, nil
+  228			}
+  229			return []events.Event{events.NewFinalEvent(cbm.metadata, cbm.Text())}, nil
+  230	
+  231		case api.ContentBlockStartType:
+  232			if cbm.response == nil {
+  233				return nil, errors.New("ContentBlockStartType event must have a message to store the finished content block")
+  234			}
+  235			if event.ContentBlock == nil {
+  236				return nil, errors.New("ContentBlockStartType event must have a content block")
+  237			}
+  238			if event.Index < 0 {
+  239				return nil, errors.New("ContentBlockStartType event must have a positive index")
+  240			}
+  241			if _, exists := cbm.contentBlocks[event.Index]; exists {
+  242				return nil, errors.Errorf("ContentBlockStartType event with index %d already exists", event.Index)
+  243			}
+  244			cbm.contentBlocks[event.Index] = event.ContentBlock
+  245	
+  246			// TODO(manuel, 2024-07-04) We should have a proper BlockStart message here
+  247			return []events.Event{}, nil
+  248	
+  249		case api.ContentBlockDeltaType:
+  250			if cbm.response == nil {
+  251				return nil, errors.New("ContentBlockDeltaType event must have a message to store the finished content block")
+  252			}
+  253			if event.Delta == nil {
+  254				return nil, errors.New("ContentBlockDeltaType event must have a delta")
+  255			}
+  256			cb, exists := cbm.contentBlocks[event.Index]
+  257			if !exists {
+  258				return nil, errors.Errorf("ContentBlockDeltaType event with index %d does not exist", event.Index)
+  259			}
+  260	
+  261			cbm.updateUsage(event)
+  262	
+  263			delta := ""
+  264			switch event.Delta.Type {
+  265			case api.TextDeltaType:
+  266				delta = event.Delta.Text
+  267				cb.Text += event.Delta.Text
+  268				return []events.Event{events.NewPartialCompletionEvent(cbm.metadata, delta, cbm.Text())}, nil
+  269			case api.InputJSONDeltaType:
+  270				delta = event.Delta.PartialJSON
+  271				// Append to existing input string for tool use
+  272				if currentInput, ok := cb.Input.(string); ok {
+  273					cb.Input = currentInput + event.Delta.PartialJSON
+  274				} else {
+  275					cb.Input = event.Delta.PartialJSON
+  276				}
+  277				// TODO(manuel, 2024-07-04) This is where we would do partial tool call streaming
+  278				_ = delta
+  279			}
+  280			return []events.Event{}, nil
+  281	
+  282		case api.ContentBlockStopType:
+  283			if cbm.response == nil {
+  284				return nil, errors.New("ContentBlockStopType event must have a message to store the finished content block")
+  285			}
+  286			cb, exists := cbm.contentBlocks[event.Index]
+  287			if !exists {
+  288				return nil, errors.Errorf("ContentBlockStopType event with index %d does not exist", event.Index)
+  289			}
+  290			switch cb.Type {
+  291			case api.ContentTypeText:
+  292				cbm.response.Content = append(cbm.response.Content, api.NewTextContent(cb.Text))
+  293				// TODO(manuel, 2024-07-04) This shoudl be some sort of block stop type
+  294				return []events.Event{events.NewPartialCompletionEvent(cbm.metadata, "", cbm.Text())}, nil
+  295	
+  296			case api.ContentTypeToolUse:
+  297				// Convert Input to string for API compatibility
+  298				inputStr := ""
+  299				if cb.Input != nil {
+  300					if str, ok := cb.Input.(string); ok {
+  301						inputStr = str
+  302					} else {
+  303						// For non-string inputs, marshal to JSON
+  304						if inputBytes, err := json.Marshal(cb.Input); err == nil {
+  305							inputStr = string(inputBytes)
+  306						}
+  307					}
+  308				}
+  309				cbm.response.Content = append(cbm.response.Content, api.NewToolUseContent(cb.ID, cb.Name, inputStr))
+  310				return []events.Event{events.NewToolCallEvent(cbm.metadata, events.ToolCall{
+  311					ID:    cb.ID,
+  312					Name:  cb.Name,
+  313					Input: inputStr,
+  314				})}, nil
+  315	
+  316			case api.ContentTypeImage, api.ContentTypeToolResult:
+  317				return nil, errors.Errorf("Unsupported content block type: %s", cb.Type)
+  318			}
+  319	
+  320			return nil, errors.Errorf("Unknown content block type: %s", cb.Type)

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/geppetto-events-chat-events.lines.txt
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/geppetto-events-chat-events.lines.txt
@@ -1,0 +1,80 @@
+    1	package events
+    2	
+    3	import (
+    4		"encoding/json"
+    5		"fmt"
+    6	
+    7		"github.com/google/uuid"
+    8		"github.com/rs/zerolog"
+    9	)
+   10	
+   11	type EventType string
+   12	
+   13	const (
+   14		// EventTypeStart to EventTypeFinal are for text completion, actually
+   15		EventTypeStart             EventType = "start"
+   16		EventTypeFinal             EventType = "final"
+   17		EventTypePartialCompletion EventType = "partial"
+   18		// Separate partial stream for reasoning/summary thinking text
+   19		EventTypePartialThinking EventType = "partial-thinking"
+   20	
+   21		// TODO(manuel, 2024-07-04) I'm not sure if this is needed
+   22		EventTypeStatus EventType = "status"
+   23	
+   24		// TODO(manuel, 2024-07-04) Should potentially have a EventTypeText for a block stop here
+   25		// Model requested a tool call (received from provider stream)
+   26		EventTypeToolCall   EventType = "tool-call"
+   27		EventTypeToolResult EventType = "tool-result"
+   28	
+   29		// Execution-phase events (we are actually executing tools locally)
+   30		EventTypeToolCallExecute         EventType = "tool-call-execute"
+   31		EventTypeToolCallExecutionResult EventType = "tool-call-execution-result"
+   32		EventTypeError                   EventType = "error"
+   33		EventTypeInterrupt               EventType = "interrupt"
+   34	
+   35		// Informational/logging events (emitted by engines, middlewares or tools)
+   36		EventTypeLog  EventType = "log"
+   37		EventTypeInfo EventType = "info"
+   38	
+   39		// Debugger pause event (step-mode)
+   40		EventTypeDebuggerPause EventType = "debugger.pause"
+   41	
+   42		// Agent-mode custom event (exported so UIs can act upon it)
+   43		EventTypeAgentModeSwitch EventType = "agent-mode-switch"
+   44	
+   45		// Web search progress events (built-in/server tools)
+   46		EventTypeWebSearchStarted   EventType = "web-search-started"
+   47		EventTypeWebSearchSearching EventType = "web-search-searching"
+   48		EventTypeWebSearchOpenPage  EventType = "web-search-open-page"
+   49		EventTypeWebSearchDone      EventType = "web-search-done"
+   50	
+   51		// Citation annotations attached to output text
+   52		EventTypeCitation EventType = "citation"
+   53	
+   54		// File search progress events
+   55		EventTypeFileSearchStarted   EventType = "file-search-started"
+   56		EventTypeFileSearchSearching EventType = "file-search-searching"
+   57		EventTypeFileSearchDone      EventType = "file-search-done"
+   58	
+   59		// Code interpreter events
+   60		EventTypeCodeInterpreterStarted      EventType = "code-interpreter-started"
+   61		EventTypeCodeInterpreterInterpreting EventType = "code-interpreter-interpreting"
+   62		EventTypeCodeInterpreterDone         EventType = "code-interpreter-done"
+   63		EventTypeCodeInterpreterCodeDelta    EventType = "code-interpreter-code-delta"
+   64		EventTypeCodeInterpreterCodeDone     EventType = "code-interpreter-code-done"
+   65	
+   66		// MCP tools
+   67		EventTypeMCPArgsDelta      EventType = "mcp-args-delta"
+   68		EventTypeMCPArgsDone       EventType = "mcp-args-done"
+   69		EventTypeMCPInProgress     EventType = "mcp-in-progress"
+   70		EventTypeMCPCompleted      EventType = "mcp-completed"
+   71		EventTypeMCPFailed         EventType = "mcp-failed"
+   72		EventTypeMCPListInProgress EventType = "mcp-list-tools-in-progress"
+   73		EventTypeMCPListCompleted  EventType = "mcp-list-tools-completed"
+   74		EventTypeMCPListFailed     EventType = "mcp-list-tools-failed"
+   75	
+   76		// Image generation built-in
+   77		EventTypeImageGenInProgress   EventType = "image-generation-in-progress"
+   78		EventTypeImageGenGenerating   EventType = "image-generation-generating"
+   79		EventTypeImageGenPartialImage EventType = "image-generation-partial-image"
+   80		EventTypeImageGenCompleted    EventType = "image-generation-completed"

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/geppetto-openai-chat-engine.lines.txt
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/geppetto-openai-chat-engine.lines.txt
@@ -1,0 +1,161 @@
+  280				}
+  281				chunkCount++
+  282				if id := stringFromRawMap(response.RawPayload, "id"); id != "" {
+  283					currentResponseID = id
+  284				}
+  285				if response.ChoiceIndex != nil {
+  286					currentChoiceIndex = cloneIntPtr(response.ChoiceIndex)
+  287				}
+  288				response = toolCallIDTracker.Enrich(response)
+  289				e.observeProviderEvent(ctx, metadata, req.Model, response)
+  290	
+  291				delta := response.DeltaText
+  292				if delta != "" {
+  293					message += delta
+  294				}
+  295				if response.DeltaReasoning != "" {
+  296					providerData := chatProviderDataFromEvent(e.inferenceProvider(), response)
+  297					providerMetadata := metadataWithChatProviderData(metadata, providerData)
+  298					if !thinkingStarted {
+  299						thinkingStarted = true
+  300						e.publishEvent(ctx, events.NewInfoEvent(providerMetadata, "thinking-started", providerData))
+  301					}
+  302					before := thinkingBuf.Len()
+  303					normalized := streamhelpers.NormalizeReasoningDelta(thinkingBuf.String(), response.DeltaReasoning)
+  304					e.observeProviderNormalizeDelta(ctx, metadata, req.Model, response, len(response.DeltaReasoning), len(normalized), before+len(normalized))
+  305					thinkingBuf.WriteString(normalized)
+  306					e.publishEvent(ctx, events.NewThinkingPartialEvent(providerMetadata, response.DeltaReasoning, thinkingBuf.String()))
+  307				}
+  308	
+  309				// Tool call deltas
+  310				if len(response.ToolCalls) > 0 {
+  311					toolCallMerger.AddToolCalls(response.ToolCalls)
+  312				}
+  313	
+  314				// Extract usage and finish reason from normalized stream response
+  315				if response.Usage != nil {
+  316					usageInputTokens = response.Usage.promptTokens
+  317					usageOutputTokens = response.Usage.completionTokens
+  318					cachedTokens = response.Usage.cachedTokens
+  319					reasoningTokens = response.Usage.reasoningTokens
+  320				}
+  321				if response.FinishReason != nil && *response.FinishReason != "" {
+  322					stopReason = response.FinishReason
+  323				}
+  324	
+  325				// Publish intermediate streaming event only if we have a non-empty delta
+  326				if delta != "" {
+  327					partialEvent := events.NewPartialCompletionEvent(
+  328						metadataWithChatProviderData(metadata, chatProviderDataFromEvent(e.inferenceProvider(), response)),
+  329						delta, message,
+  330					)
+  331					e.publishEvent(ctx, partialEvent)
+  332				}
+  333			}
+  334		}
+  335	
+  336	streamingComplete:
+  337	
+  338		// Update event metadata with usage information
+  339		if usageInputTokens > 0 || usageOutputTokens > 0 || cachedTokens > 0 {
+  340			if metadata.Usage == nil {
+  341				metadata.Usage = &events.Usage{}
+  342			}
+  343			metadata.Usage.InputTokens = usageInputTokens
+  344			metadata.Usage.OutputTokens = usageOutputTokens
+  345			metadata.Usage.CachedTokens = cachedTokens
+  346		}
+  347		if metadata.Extra == nil {
+  348			metadata.Extra = map[string]any{}
+  349		}
+  350		metadata.Extra["thinking_text"] = thinkingBuf.String()
+  351		metadata.Extra["saying_text"] = message
+  352		if reasoningTokens > 0 {
+  353			metadata.Extra["reasoning_tokens"] = reasoningTokens
+  354		}
+  355		metadata.StopReason = stopReason
+  356		// set duration for successful completion
+  357		d := time.Since(startTime).Milliseconds()
+  358		dm := int64(d)
+  359		metadata.DurationMs = &dm
+  360	
+  361		log.Debug().
+  362			Int("input_tokens", usageInputTokens).
+  363			Int("output_tokens", usageOutputTokens).
+  364			Str("stop_reason", func() string {
+  365				if stopReason != nil {
+  366					return *stopReason
+  367				}
+  368				return ""
+  369			}()).
+  370			Msg("OpenAI metadata finalized")
+  371	
+  372		mergedToolCalls := toolCallMerger.GetToolCalls()
+  373		log.Debug().Int("final_text_length", len(message)).Int("tool_call_count", len(mergedToolCalls)).Msg("OpenAI streaming complete, preparing messages")
+  374	
+  375		if thinkingBuf.Len() > 0 {
+  376			if thinkingStarted {
+  377				e.publishEvent(ctx, events.NewInfoEvent(metadata, "thinking-ended", nil))
+  378			}
+  379		}
+  380	
+  381		// If we have tool calls, publish ToolCall events now
+  382		if len(mergedToolCalls) > 0 {
+  383			for _, tc := range mergedToolCalls {
+  384				inputStr := tc.Function.Arguments
+  385				providerData := chatProviderData(e.inferenceProvider(), currentResponseID, currentChoiceIndex, "tool_call", chatCorrelationKey(e.inferenceProvider(), currentResponseID, currentChoiceIndex, "tool_call", tc.ID, tc.Index), tc.ID, tc.Index)
+  386				toolCallEvent := events.NewToolCallEvent(
+  387					metadataWithChatProviderData(metadata, providerData),
+  388					events.ToolCall{ID: tc.ID, Name: tc.Function.Name, Input: inputStr},
+  389				)
+  390				e.publishEvent(ctx, toolCallEvent)
+  391			}
+  392		}
+  393	
+  394		// Append messages in order that keeps last message as tool-use when present
+  395		if thinkingBuf.Len() > 0 {
+  396			turns.AppendBlock(t, turns.Block{
+  397				ID:   uuid.NewString(),
+  398				Kind: turns.BlockKindReasoning,
+  399				Payload: map[string]any{
+  400					turns.PayloadKeyText: thinkingBuf.String(),
+  401				},
+  402			})
+  403		}
+  404		if len(message) > 0 {
+  405			turns.AppendBlock(t, turns.NewAssistantTextBlock(message))
+  406		}
+  407		for _, tc := range mergedToolCalls {
+  408			var args any
+  409			_ = json.Unmarshal([]byte(tc.Function.Arguments), &args)
+  410			turns.AppendBlock(t, turns.NewToolCallBlock(tc.ID, tc.Function.Name, args))
+  411		}
+  412		result := engine.BuildInferenceResultFromEventMetadata(metadata, "openai", len(mergedToolCalls) > 0)
+  413		if err := engine.PersistInferenceResult(t, result); err != nil {
+  414			log.Warn().Err(err).Msg("OpenAI: failed to persist canonical inference_result")
+  415		}
+  416	
+  417		// Publish final event for streaming
+  418		log.Debug().
+  419			Str("event_id", metadata.ID.String()).
+  420			Str("model", metadata.Model).
+  421			Interface("temperature", metadata.Temperature).
+  422			Interface("top_p", metadata.TopP).
+  423			Interface("max_tokens", metadata.MaxTokens).
+  424			Interface("usage", metadata.Usage).
+  425			Str("stop_reason", func() string {
+  426				if stopReason != nil {
+  427					return *stopReason
+  428				}
+  429				return ""
+  430			}()).
+  431			Msg("OpenAI publishing final event (streaming)")
+  432		finalEvent := events.NewFinalEvent(metadata, message)
+  433		e.publishEvent(ctx, finalEvent)
+  434	
+  435		log.Debug().Msg("OpenAI RunInference completed (streaming)")
+  436		return t, nil
+  437	}
+  438	
+  439	// publishEvent publishes an event to all configured sinks and any sinks carried in context.
+  440	func (e *OpenAIEngine) publishEvent(ctx context.Context, event events.Event) {

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/geppetto-openai-responses-streaming.lines.txt
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/geppetto-openai-responses-streaming.lines.txt
@@ -1,0 +1,709 @@
+  100			var m map[string]any
+  101			if err := json.Unmarshal([]byte(raw), &m); err != nil {
+  102				return nil
+  103			}
+  104			if respObj, ok := m["response"].(map[string]any); ok {
+  105				if id, ok := respObj["id"].(string); ok && id != "" {
+  106					currentResponseID = id
+  107				}
+  108			}
+  109			if id, ok := m["response_id"].(string); ok && id != "" {
+  110				currentResponseID = id
+  111			}
+  112			providerEventType := normalizeResponsesEventName(eventName)
+  113			if providerEventType == "" {
+  114				if typ, ok := m["type"].(string); ok {
+  115					providerEventType = normalizeResponsesEventName(typ)
+  116				}
+  117			}
+  118			e.observeProviderEvent(ctx, metadata, reqBody.Model, currentResponseID, providerEventType, m)
+  119			appendAssistantChunk := func(chunk string) {
+  120				if chunk == "" {
+  121					return
+  122				}
+  123				message += chunk
+  124				sayBuf.WriteString(chunk)
+  125				e.publishEvent(ctx, events.NewPartialCompletionEvent(metadata, chunk, message))
+  126			}
+  127			backfillAssistantChunk := func(itemID, fullChunk string) {
+  128				if fullChunk == "" {
+  129					return
+  130				}
+  131				current := message
+  132				if itemID != "" {
+  133					if streamed := assistantByItem[itemID]; streamed != "" {
+  134						current = streamed
+  135					}
+  136				}
+  137				if strings.HasSuffix(current, fullChunk) {
+  138					return
+  139				}
+  140				overlap := 0
+  141				maxOverlap := len(fullChunk)
+  142				if len(current) < maxOverlap {
+  143					maxOverlap = len(current)
+  144				}
+  145				for i := maxOverlap; i > 0; i-- {
+  146					if strings.HasSuffix(current, fullChunk[:i]) {
+  147						overlap = i
+  148						break
+  149					}
+  150				}
+  151				missing := fullChunk[overlap:]
+  152				if missing == "" {
+  153					return
+  154				}
+  155				if itemID != "" {
+  156					assistantByItem[itemID] += missing
+  157				}
+  158				appendAssistantChunk(missing)
+  159			}
+  160			backfillReasoningText := func(fullText string) {
+  161				if fullText == "" {
+  162					return
+  163				}
+  164				current := currentReasoningText.String()
+  165				if strings.HasSuffix(current, fullText) {
+  166					return
+  167				}
+  168				overlap := 0
+  169				maxOverlap := len(fullText)
+  170				if len(current) < maxOverlap {
+  171					maxOverlap = len(current)
+  172				}
+  173				for i := maxOverlap; i > 0; i-- {
+  174					if strings.HasSuffix(current, fullText[:i]) {
+  175						overlap = i
+  176						break
+  177					}
+  178				}
+  179				missing := fullText[overlap:]
+  180				if missing == "" {
+  181					return
+  182				}
+  183				currentReasoningText.WriteString(missing)
+  184				normalized := streamhelpers.NormalizeReasoningDelta(thinkBuf.String(), missing)
+  185				thinkBuf.WriteString(normalized)
+  186				e.publishEvent(ctx, events.NewThinkingPartialEvent(metadata, normalized, thinkBuf.String()))
+  187			}
+  188			chunkFromValue := func(v any) string {
+  189				switch tv := v.(type) {
+  190				case string:
+  191					return tv
+  192				default:
+  193					if tv == nil {
+  194						return ""
+  195					}
+  196					b, err := json.Marshal(tv)
+  197					if err != nil {
+  198						return ""
+  199					}
+  200					return string(b)
+  201				}
+  202			}
+  203			switch providerEventType {
+  204			case "response.output_item.added":
+  205				if it, ok := m["item"].(map[string]any); ok {
+  206					if typ, ok := it["type"].(string); ok {
+  207						switch typ {
+  208						case "reasoning":
+  209							currentReasoningItemID = ""
+  210							currentReasoningText.Reset()
+  211							currentReasoningSummary.Reset()
+  212							currentReasoningEncryptedContent = ""
+  213							currentReasoningOutputIndex = nil
+  214							currentReasoningSummaryIndex = nil
+  215							currentReasoningStatus = ""
+  216							if v, ok := it["id"].(string); ok && v != "" {
+  217								currentReasoningItemID = v
+  218							}
+  219							if status, ok := it["status"].(string); ok && status != "" {
+  220								currentReasoningStatus = status
+  221							}
+  222							if idx, ok := intFromProviderNumber(m["output_index"]); ok {
+  223								currentReasoningOutputIndex = &idx
+  224							}
+  225							e.publishEvent(ctx, events.NewInfoEvent(metadata, "thinking-started", providerData("openai_responses", currentResponseID, currentReasoningItemID, currentReasoningOutputIndex, currentReasoningSummaryIndex)))
+  226							// Capture encrypted reasoning content when present.
+  227							if enc, ok := it["encrypted_content"].(string); ok && enc != "" {
+  228								currentReasoningEncryptedContent = enc
+  229							}
+  230						case "message":
+  231							e.publishEvent(ctx, events.NewInfoEvent(metadata, "output-started", nil))
+  232							if v, ok := it["id"].(string); ok && v != "" {
+  233								latestMessageItemID = v
+  234							}
+  235							if status, ok := it["status"].(string); ok && status != "" {
+  236								latestMessageStatus = status
+  237							}
+  238							if idx, ok := intFromProviderNumber(m["output_index"]); ok {
+  239								latestMessageOutputIndex = &idx
+  240							}
+  241						case "web_search_call":
+  242							itemID := ""
+  243							if v, ok := it["id"].(string); ok {
+  244								itemID = v
+  245							}
+  246							if act, ok := it["action"].(map[string]any); ok {
+  247								if at, ok := act["type"].(string); ok && at == "search" {
+  248									q := ""
+  249									if v, ok := act["query"].(string); ok {
+  250										q = v
+  251									}
+  252									e.publishEvent(ctx, events.NewWebSearchStarted(metadata, itemID, q))
+  253								}
+  254								if at, ok := act["type"].(string); ok && at == "open_page" {
+  255									u := ""
+  256									if v, ok := act["url"].(string); ok {
+  257										u = v
+  258									}
+  259									e.publishEvent(ctx, events.NewWebSearchOpenPage(metadata, itemID, u))
+  260								}
+  261							}
+  262						}
+  263					}
+  264				}
+  265			case "response.web_search_call.in_progress":
+  266				itemID := ""
+  267				if v, ok := m["item_id"].(string); ok {
+  268					itemID = v
+  269				}
+  270				// Query will be available later in output_item.done, so emit without query for now
+  271				e.publishEvent(ctx, events.NewWebSearchStarted(metadata, itemID, ""))
+  272			case "response.web_search_call.searching":
+  273				itemID := ""
+  274				if v, ok := m["item_id"].(string); ok {
+  275					itemID = v
+  276				}
+  277				e.publishEvent(ctx, events.NewWebSearchSearching(metadata, itemID))
+  278			case "response.web_search_call.completed":
+  279				itemID := ""
+  280				if v, ok := m["item_id"].(string); ok {
+  281					itemID = v
+  282				}
+  283				e.publishEvent(ctx, events.NewWebSearchDone(metadata, itemID))
+  284			case "error":
+  285				// Provider-level error event during streaming
+  286				if errObj, ok := m["error"].(map[string]any); ok {
+  287					msgStr := ""
+  288					if v, ok := errObj["message"].(string); ok {
+  289						msgStr = v
+  290					}
+  291					codeStr := ""
+  292					if v, ok := errObj["code"].(string); ok {
+  293						codeStr = v
+  294					}
+  295					if msgStr == "" {
+  296						msgStr = "responses stream error"
+  297					}
+  298					if codeStr != "" {
+  299						streamErr = fmt.Errorf("responses stream error (%s): %s", codeStr, msgStr)
+  300					} else {
+  301						streamErr = errors.New(msgStr)
+  302					}
+  303				} else {
+  304					streamErr = fmt.Errorf("responses stream error")
+  305				}
+  306				e.publishEvent(ctx, events.NewErrorEvent(metadata, streamErr))
+  307				if tap != nil {
+  308					tap.OnProviderObject("stream.error", m)
+  309				}
+  310			case "response.failed":
+  311				// Response failed; try to extract nested error
+  312				if respObj, ok := m["response"].(map[string]any); ok {
+  313					if errObj, ok2 := respObj["error"].(map[string]any); ok2 {
+  314						msgStr := ""
+  315						if v, ok := errObj["message"].(string); ok {
+  316							msgStr = v
+  317						}
+  318						codeStr := ""
+  319						if v, ok := errObj["code"].(string); ok {
+  320							codeStr = v
+  321						}
+  322						if msgStr == "" {
+  323							msgStr = "responses failed"
+  324						}
+  325						if codeStr != "" {
+  326							streamErr = fmt.Errorf("responses failed (%s): %s", codeStr, msgStr)
+  327						} else {
+  328							streamErr = errors.New(msgStr)
+  329						}
+  330					} else {
+  331						streamErr = fmt.Errorf("responses failed")
+  332					}
+  333				} else {
+  334					streamErr = fmt.Errorf("responses failed")
+  335				}
+  336				e.publishEvent(ctx, events.NewErrorEvent(metadata, streamErr))
+  337				if tap != nil {
+  338					tap.OnProviderObject("response.failed", m)
+  339				}
+  340			case "response.reasoning_summary_part.added":
+  341				if itemID := itemIDFromProviderObject(m); itemID != "" {
+  342					currentReasoningItemID = itemID
+  343				}
+  344				if idx, ok := intFromProviderNumber(m["summary_index"]); ok {
+  345					currentReasoningSummaryIndex = &idx
+  346					lastReasoningSummaryIndex = &idx
+  347				}
+  348				// Start of a summary piece – forward as streaming info event
+  349				e.publishEvent(ctx, events.NewInfoEvent(metadata, "reasoning-summary-started", providerData("openai_responses", currentResponseID, currentReasoningItemID, currentReasoningOutputIndex, currentReasoningSummaryIndex)))
+  350			case "response.reasoning_summary_text.delta":
+  351				if itemID := itemIDFromProviderObject(m); itemID != "" {
+  352					currentReasoningItemID = itemID
+  353					lastReasoningItemID = itemID
+  354				}
+  355				if idx, ok := intFromProviderNumber(m["summary_index"]); ok {
+  356					currentReasoningSummaryIndex = &idx
+  357					lastReasoningSummaryIndex = &idx
+  358				}
+  359				if v, ok := m["delta"].(string); ok && v != "" {
+  360					before := summaryBuf.Len()
+  361					normalized := streamhelpers.NormalizeReasoningSummaryDelta(summaryBuf.String(), v)
+  362					e.observeProviderNormalizeDelta(ctx, metadata, reqBody.Model, currentResponseID, providerEventType, m, len(v), len(normalized), before+len(normalized))
+  363					summaryBuf.WriteString(normalized)
+  364					currentReasoningSummary.WriteString(normalized)
+  365					// Emit thinking partials for live reasoning summary text
+  366					e.publishEvent(ctx, events.NewThinkingPartialEvent(metadata, normalized, summaryBuf.String()))
+  367				} else if s, ok := m["text"].(string); ok && s != "" {
+  368					before := summaryBuf.Len()
+  369					normalized := streamhelpers.NormalizeReasoningSummaryDelta(summaryBuf.String(), s)
+  370					e.observeProviderNormalizeDelta(ctx, metadata, reqBody.Model, currentResponseID, providerEventType, m, len(s), len(normalized), before+len(normalized))
+  371					summaryBuf.WriteString(normalized)
+  372					currentReasoningSummary.WriteString(normalized)
+  373					e.publishEvent(ctx, events.NewThinkingPartialEvent(metadata, normalized, summaryBuf.String()))
+  374				}
+  375			case "response.reasoning_summary_part.done":
+  376				if itemID := itemIDFromProviderObject(m); itemID != "" {
+  377					currentReasoningItemID = itemID
+  378					lastReasoningItemID = itemID
+  379				}
+  380				if idx, ok := intFromProviderNumber(m["summary_index"]); ok {
+  381					currentReasoningSummaryIndex = &idx
+  382					lastReasoningSummaryIndex = &idx
+  383				}
+  384				// End of a summary piece – forward as streaming info event
+  385				e.publishEvent(ctx, events.NewInfoEvent(metadata, "reasoning-summary-ended", providerData("openai_responses", currentResponseID, currentReasoningItemID, currentReasoningOutputIndex, currentReasoningSummaryIndex)))
+  386			case "response.reasoning_text.delta":
+  387				if itemID := itemIDFromProviderObject(m); itemID != "" {
+  388					currentReasoningItemID = itemID
+  389					lastReasoningItemID = itemID
+  390				}
+  391				if idx, ok := intFromProviderNumber(m["output_index"]); ok {
+  392					currentReasoningOutputIndex = &idx
+  393					lastReasoningOutputIndex = &idx
+  394				}
+  395				if d, ok := m["delta"].(string); ok && d != "" {
+  396					before := thinkBuf.Len()
+  397					normalized := streamhelpers.NormalizeReasoningDelta(thinkBuf.String(), d)
+  398					e.observeProviderNormalizeDelta(ctx, metadata, reqBody.Model, currentResponseID, providerEventType, m, len(d), len(normalized), before+len(normalized))
+  399					thinkBuf.WriteString(normalized)
+  400					currentReasoningText.WriteString(d)
+  401					e.publishEvent(ctx, events.NewThinkingPartialEvent(metadata, d, thinkBuf.String()))
+  402				} else if s, ok := m["text"].(string); ok && s != "" {
+  403					before := thinkBuf.Len()
+  404					normalized := streamhelpers.NormalizeReasoningDelta(thinkBuf.String(), s)
+  405					e.observeProviderNormalizeDelta(ctx, metadata, reqBody.Model, currentResponseID, providerEventType, m, len(s), len(normalized), before+len(normalized))
+  406					thinkBuf.WriteString(normalized)
+  407					currentReasoningText.WriteString(s)
+  408					e.publishEvent(ctx, events.NewThinkingPartialEvent(metadata, s, thinkBuf.String()))
+  409				}
+  410			case "response.reasoning_text.done":
+  411				if s, ok := m["text"].(string); ok && s != "" {
+  412					// Done payloads can repeat already-streamed deltas for the current
+  413					// item, but some providers send reasoning text only in the done
+  414					// event. Backfill any missing suffix and emit the canonical
+  415					// EventThinkingPartial so live reasoning renderers see the update.
+  416					backfillReasoningText(s)
+  417				}
+  418			case "response.output_item.done":
+  419				if it, ok := m["item"].(map[string]any); ok {
+  420					if typ, ok := it["type"].(string); ok {
+  421						switch typ {
+  422						case "reasoning":
+  423							if itemID := itemIDFromProviderObject(m); itemID != "" {
+  424								currentReasoningItemID = itemID
+  425								lastReasoningItemID = itemID
+  426							}
+  427							if idx, ok := intFromProviderNumber(m["output_index"]); ok {
+  428								currentReasoningOutputIndex = &idx
+  429								lastReasoningOutputIndex = &idx
+  430							}
+  431							e.publishEvent(ctx, events.NewInfoEvent(metadata, "thinking-ended", providerData("openai_responses", currentResponseID, currentReasoningItemID, currentReasoningOutputIndex, currentReasoningSummaryIndex)))
+  432							// Append a reasoning block with encrypted content if present.
+  433							rb := turns.Block{Kind: turns.BlockKindReasoning}
+  434							payload := map[string]any{}
+  435							if id, ok := it["id"].(string); ok && id != "" {
+  436								rb.ID = id
+  437								payload[turns.PayloadKeyItemID] = id
+  438							}
+  439							if currentReasoningItemID != "" && rb.ID == "" {
+  440								rb.ID = currentReasoningItemID
+  441								payload[turns.PayloadKeyItemID] = currentReasoningItemID
+  442							}
+  443							if status, ok := it["status"].(string); ok && status != "" {
+  444								currentReasoningStatus = status
+  445							}
+  446							if idx, ok := intFromProviderNumber(m["output_index"]); ok {
+  447								currentReasoningOutputIndex = &idx
+  448								lastReasoningOutputIndex = &idx
+  449							}
+  450							if terminalText := reasoningTextFromProviderContent(it["content"]); terminalText != "" {
+  451								backfillReasoningText(terminalText)
+  452							}
+  453							if text := strings.TrimSpace(currentReasoningText.String()); text != "" {
+  454								payload[turns.PayloadKeyText] = text
+  455							}
+  456							enc := currentReasoningEncryptedContent
+  457							if v, ok := it["encrypted_content"].(string); ok && v != "" {
+  458								enc = v
+  459							}
+  460							if enc != "" {
+  461								payload[turns.PayloadKeyEncryptedContent] = enc
+  462							}
+  463							summary := reasoningSummaryEntriesFromPayload(it)
+  464							if len(summary) == 0 {
+  465								summary = reasoningSummaryEntriesFromText(currentReasoningSummary.String())
+  466							}
+  467							if len(summary) > 0 {
+  468								payload[turns.PayloadKeySummary] = summary
+  469							}
+  470							rb.Payload = payload
+  471							setOpenAIResponsesBlockMetadata(&rb, currentResponseID, currentReasoningOutputIndex, "reasoning", currentReasoningStatus)
+  472							turns.AppendBlock(t, rb)
+  473							currentReasoningItemID = ""
+  474							currentReasoningText.Reset()
+  475							currentReasoningSummary.Reset()
+  476							currentReasoningEncryptedContent = ""
+  477							currentReasoningOutputIndex = nil
+  478							currentReasoningSummaryIndex = nil
+  479							currentReasoningStatus = ""
+  480							if tap != nil {
+  481								tap.OnProviderObject("output.reasoning", it)
+  482							}
+  483						case "message":
+  484							e.publishEvent(ctx, events.NewInfoEvent(metadata, "output-ended", nil))
+  485							itemID := ""
+  486							if v, ok := it["id"].(string); ok && v != "" {
+  487								latestMessageItemID = v
+  488								itemID = v
+  489							}
+  490							if status, ok := it["status"].(string); ok && status != "" {
+  491								latestMessageStatus = status
+  492							}
+  493							if idx, ok := intFromProviderNumber(m["output_index"]); ok {
+  494								latestMessageOutputIndex = &idx
+  495							}
+  496							if rawContent, ok := it["content"].([]any); ok {
+  497								for _, item := range rawContent {
+  498									content, ok := item.(map[string]any)
+  499									if !ok {
+  500										continue
+  501									}
+  502									typ, _ := content["type"].(string)
+  503									switch typ {
+  504									case "output_text", "text":
+  505										if s, ok := content["text"].(string); ok && s != "" {
+  506											backfillAssistantChunk(itemID, s)
+  507										}
+  508									case "output_json":
+  509										backfillAssistantChunk(itemID, chunkFromValue(content["json"]))
+  510									}
+  511								}
+  512							}
+  513							if tap != nil {
+  514								tap.OnProviderObject("output.message", it)
+  515							}
+  516						case "function_call":
+  517							// finalize function_call and publish ToolCall event
+  518							name := ""
+  519							if v, ok := it["name"].(string); ok {
+  520								name = v
+  521							}
+  522							callID := ""
+  523							if v, ok := it["call_id"].(string); ok {
+  524								callID = v
+  525							}
+  526							itemID := ""
+  527							if v, ok := it["id"].(string); ok {
+  528								itemID = v
+  529							}
+  530							args := ""
+  531							if v, ok := it["arguments"].(string); ok && v != "" {
+  532								args = v
+  533							}
+  534							status := ""
+  535							if v, ok := it["status"].(string); ok && v != "" {
+  536								status = v
+  537							}
+  538							var outputIndex *int
+  539							if idx, ok := intFromProviderNumber(m["output_index"]); ok {
+  540								outputIndex = &idx
+  541							}
+  542							if args == "" {
+  543								if pc := callsByItem[itemID]; pc != nil {
+  544									args = pc.args.String()
+  545								}
+  546							}
+  547							if callID != "" && name != "" {
+  548								e.publishEvent(ctx, events.NewToolCallEvent(metadata, events.ToolCall{ID: callID, Name: name, Input: args}))
+  549								var b strings.Builder
+  550								b.WriteString(args)
+  551								finalCalls = append(finalCalls, pendingCall{callID: callID, name: name, itemID: itemID, outputIndex: outputIndex, status: status, args: b})
+  552							}
+  553						case "web_search_call":
+  554							// Extract search query from action if available
+  555							query := ""
+  556							if action, ok := it["action"].(map[string]any); ok {
+  557								if q, ok := action["query"].(string); ok {
+  558									query = q
+  559								}
+  560							}
+  561							itemID := ""
+  562							if v, ok := it["id"].(string); ok {
+  563								itemID = v
+  564							}
+  565							// Log the final query info at debug level
+  566							if query != "" {
+  567								log.Debug().Str("query", query).Str("item_id", itemID).Msg("Responses: web_search completed with query")
+  568							}
+  569							// Note: Don't emit another Done event here, already emitted by response.web_search_call.completed
+  570						}
+  571					}
+  572				}
+  573			case "response.output_text.delta":
+  574				// Stream assistant text deltas
+  575				itemID := ""
+  576				if v, ok := m["item_id"].(string); ok && v != "" {
+  577					itemID = v
+  578				}
+  579				if d, ok := m["delta"].(string); ok && d != "" {
+  580					if itemID != "" {
+  581						assistantByItem[itemID] += d
+  582					}
+  583					appendAssistantChunk(d)
+  584					log.Trace().Int("delta_len", len(d)).Int("message_len", len(message)).Msg("Responses: text delta")
+  585				} else if tv, ok := m["text"].(map[string]any); ok {
+  586					if d, ok := tv["delta"].(string); ok && d != "" {
+  587						if itemID != "" {
+  588							assistantByItem[itemID] += d
+  589						}
+  590						appendAssistantChunk(d)
+  591						log.Trace().Int("delta_len", len(d)).Int("message_len", len(message)).Msg("Responses: text delta (nested)")
+  592					}
+  593				}
+  594				if tap != nil {
+  595					tap.OnSSE(eventName, []byte(raw))
+  596				}
+  597			case "response.output_json.delta":
+  598				itemID := ""
+  599				if v, ok := m["item_id"].(string); ok && v != "" {
+  600					itemID = v
+  601				}
+  602				if d, ok := m["delta"].(string); ok && d != "" {
+  603					if itemID != "" {
+  604						assistantByItem[itemID] += d
+  605					}
+  606					appendAssistantChunk(d)
+  607				}
+  608				if tap != nil {
+  609					tap.OnSSE(eventName, []byte(raw))
+  610				}
+  611			case "response.output_json.done":
+  612				itemID := ""
+  613				if v, ok := m["item_id"].(string); ok && v != "" {
+  614					itemID = v
+  615				}
+  616				if j, ok := m["json"]; ok {
+  617					backfillAssistantChunk(itemID, chunkFromValue(j))
+  618				}
+  619				if tap != nil {
+  620					tap.OnSSE(eventName, []byte(raw))
+  621				}
+  622			case "response.output_text.annotation.added":
+  623				if ann, ok := m["annotation"].(map[string]any); ok {
+  624					title, _ := ann["title"].(string)
+  625					url, _ := ann["url"].(string)
+  626					var startPtr, endPtr, outPtr, contPtr, annPtr *int
+  627					if v, ok := ann["start_index"].(float64); ok {
+  628						i := int(v)
+  629						startPtr = &i
+  630					}
+  631					if v, ok := ann["end_index"].(float64); ok {
+  632						i := int(v)
+  633						endPtr = &i
+  634					}
+  635					if v, ok := m["output_index"].(float64); ok {
+  636						i := int(v)
+  637						outPtr = &i
+  638					}
+  639					if v, ok := m["content_index"].(float64); ok {
+  640						i := int(v)
+  641						contPtr = &i
+  642					}
+  643					if v, ok := m["annotation_index"].(float64); ok {
+  644						i := int(v)
+  645						annPtr = &i
+  646					}
+  647					e.publishEvent(ctx, events.NewCitation(metadata, title, url, startPtr, endPtr, outPtr, contPtr, annPtr))
+  648				}
+  649			case "response.function_call_arguments.delta":
+  650				// Accumulate function_call arguments by item_id
+  651				itemID := ""
+  652				if v, ok := m["item_id"].(string); ok {
+  653					itemID = v
+  654				}
+  655				if itemID != "" {
+  656					pc := callsByItem[itemID]
+  657					if pc == nil {
+  658						pc = &pendingCall{itemID: itemID}
+  659						callsByItem[itemID] = pc
+  660					}
+  661					if d, ok := m["delta"].(string); ok && d != "" {
+  662						pc.args.WriteString(d)
+  663					}
+  664				}
+  665			case "response.function_call_arguments.done":
+  666				itemID := ""
+  667				if v, ok := m["item_id"].(string); ok {
+  668					itemID = v
+  669				}
+  670				if d, ok := m["arguments"].(string); ok && d != "" {
+  671					if pc := callsByItem[itemID]; pc != nil {
+  672						pc.args.Reset()
+  673						pc.args.WriteString(d)
+  674					}
+  675				}
+  676			// No assistant text in this event; only arguments aggregation
+  677			case "response.completed":
+  678				if totals, ok := parseUsageTotalsFromEnvelope(m); ok {
+  679					inputTokens = totals.inputTokens
+  680					outputTokens = totals.outputTokens
+  681					cachedTokens = totals.cachedTokens
+  682					reasoningTokens = totals.reasoningTokens
+  683				}
+  684				// optional stop reason, sometimes nested
+  685				if sr, ok := m["stop_reason"].(string); ok && sr != "" {
+  686					stopReason = &sr
+  687				} else if respObj, ok := m["response"].(map[string]any); ok {
+  688					if sr, ok := respObj["stop_reason"].(string); ok && sr != "" {
+  689						stopReason = &sr
+  690					}
+  691				}
+  692				if tap != nil {
+  693					tap.OnProviderObject("response.completed", m)
+  694				}
+  695			}
+  696			return nil
+  697		}
+  698		for {
+  699			line, err := reader.ReadString('\n')
+  700			if err != nil && err != io.EOF {
+  701				log.Debug().Err(err).Msg("Responses: error reading SSE line")
+  702				break
+  703			}
+  704			line = strings.TrimRight(line, "\r\n")
+  705			if line == "" {
+  706				_ = flush()
+  707				eventName = ""
+  708				if err == io.EOF {
+  709					break
+  710				}
+  711				continue
+  712			}
+  713			if strings.HasPrefix(line, "event:") {
+  714				eventName = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+  715				continue
+  716			}
+  717			if strings.HasPrefix(line, "data:") {
+  718				if dataBuf.Len() > 0 {
+  719					dataBuf.WriteByte('\n')
+  720				}
+  721				dataBuf.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+  722				if tap != nil {
+  723					tap.OnSSE(eventName, []byte(strings.TrimSpace(strings.TrimPrefix(line, "data:"))))
+  724				}
+  725				if err == io.EOF {
+  726					_ = flush()
+  727					break
+  728				}
+  729				continue
+  730			}
+  731			if err == io.EOF {
+  732				_ = flush()
+  733				break
+  734			}
+  735		}
+  736	
+  737		if inputTokens > 0 || outputTokens > 0 || cachedTokens > 0 {
+  738			if metadata.Usage == nil {
+  739				metadata.Usage = &events.Usage{}
+  740			}
+  741			metadata.Usage.InputTokens = inputTokens
+  742			metadata.Usage.OutputTokens = outputTokens
+  743			metadata.Usage.CachedTokens = cachedTokens
+  744		}
+  745		if metadata.Extra == nil {
+  746			metadata.Extra = map[string]any{}
+  747		}
+  748		if reasoningTokens > 0 {
+  749			metadata.Extra["reasoning_tokens"] = reasoningTokens
+  750		}
+  751		metadata.Extra["thinking_text"] = thinkBuf.String()
+  752		metadata.Extra["saying_text"] = sayBuf.String()
+  753		if summaryBuf.Len() > 0 {
+  754			metadata.Extra["reasoning_summary_text"] = summaryBuf.String()
+  755			// Publish a friendly info event with the complete summary and provider identity when available.
+  756			data := providerData("openai_responses", currentResponseID, lastReasoningItemID, lastReasoningOutputIndex, lastReasoningSummaryIndex)
+  757			if data == nil {
+  758				data = map[string]any{}
+  759			}
+  760			data["text"] = summaryBuf.String()
+  761			e.publishEvent(ctx, events.NewInfoEvent(metadata, "reasoning-summary", data))
+  762		}
+  763		if stopReason != nil {
+  764			metadata.StopReason = stopReason
+  765		}
+  766		d := time.Since(startTime).Milliseconds()
+  767		dm := int64(d)
+  768		metadata.DurationMs = &dm
+  769		if streamErr != nil {
+  770			log.Debug().Err(streamErr).Msg("Responses: stream ended with provider error")
+  771			return nil, streamErr
+  772		}
+  773		if strings.TrimSpace(message) != "" {
+  774			ab := turns.NewAssistantTextBlock(message)
+  775			if latestMessageItemID != "" {
+  776				if ab.Payload == nil {
+  777					ab.Payload = map[string]any{}
+  778				}
+  779				ab.Payload[turns.PayloadKeyItemID] = latestMessageItemID
+  780			}
+  781			setOpenAIResponsesBlockMetadata(&ab, currentResponseID, latestMessageOutputIndex, "message", latestMessageStatus)
+  782			turns.AppendBlock(t, ab)
+  783		}
+  784		// Append tool_call blocks captured via Responses API
+  785		for _, pc := range finalCalls {
+  786			var args any
+  787			if err := json.Unmarshal([]byte(pc.args.String()), &args); err != nil {
+  788				args = map[string]any{}
+  789			}
+  790			b := turns.NewToolCallBlock(pc.callID, pc.name, args)
+  791			// Preserve provider output item id so we can reference it later if needed
+  792			if b.Payload == nil {
+  793				b.Payload = map[string]any{}
+  794			}
+  795			if pc.itemID != "" {
+  796				b.Payload[turns.PayloadKeyItemID] = pc.itemID
+  797			}
+  798			setOpenAIResponsesBlockMetadata(&b, currentResponseID, pc.outputIndex, "function_call", pc.status)
+  799			turns.AppendBlock(t, b)
+  800		}
+  801		result := engine.BuildInferenceResultFromEventMetadata(metadata, responsesInferenceProvider(e.settings), len(finalCalls) > 0)
+  802		if err := engine.PersistInferenceResult(t, result); err != nil {
+  803			log.Warn().Err(err).Msg("Responses: failed to persist canonical inference_result")
+  804		}
+  805		e.publishEvent(ctx, events.NewFinalEvent(metadata, message))
+  806		return t, nil
+  807	
+  808	}

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/pinocchio-chatapp-protobuf-plugins-doc.lines.txt
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/pinocchio-chatapp-protobuf-plugins-doc.lines.txt
@@ -1,0 +1,140 @@
+    1	---
+    2	Title: Chatapp Protobuf Schemas and Shared Plugins
+    3	Slug: chatapp-protobuf-plugins
+    4	Short: Reference for Pinocchio chatapp protobuf contracts, segment-aware message entities, and shared reasoning/tool-call plugins.
+    5	Topics:
+    6	- webchat
+    7	- chatapp
+    8	- protobuf
+    9	- sessionstream
+   10	- plugins
+   11	Commands:
+   12	- web-chat
+   13	IsTemplate: false
+   14	IsTopLevel: false
+   15	ShowPerDefault: true
+   16	SectionType: GeneralTopic
+   17	---
+   18	
+   19	## Overview
+   20	
+   21	`pinocchio/pkg/chatapp` is the reusable chat application layer on top of `sessionstream`. It owns the base chat command, event, UI-event, and timeline schemas, while application packages can add more behavior through `ChatPlugin` implementations.
+   22	
+   23	The current chatapp contract is protobuf-first:
+   24	
+   25	- source schema: `proto/pinocchio/chatapp/v1/chat.proto`
+   26	- generated Go package: `pkg/chatapp/pb/proto/pinocchio/chatapp/v1`
+   27	- generator config: `buf.chatapp.gen.yaml`
+   28	- runtime registration: `chatapp.RegisterSchemas(reg, plugins...)`
+   29	
+   30	Sessionstream still delivers browser frames as JSON over WebSocket, but those frames are the JSON form of registered protobuf messages. Backend code should publish concrete, feature-owned `proto.Message` payloads, not ad-hoc maps or generic `google.protobuf.Struct` objects.
+   31	
+   32	## Schema policy: concrete protobuf for every durable contract
+   33	
+   34	Every chatapp/sessionstream command, backend event, UI event, and timeline entity payload must have its own concrete protobuf message, including app-specific features. Treat the protobuf type as the durable API contract between:
+   35	
+   36	- runtime event producers;
+   37	- sessionstream projection code;
+   38	- persisted timeline snapshots;
+   39	- WebSocket JSON frames;
+   40	- frontend renderers and generated TypeScript types.
+   41	
+   42	Do not register `google.protobuf.Struct` for event/UI/timeline payloads just because a feature is app-local. App-local still means durable once it is persisted, hydrated, or rendered after reload.
+   43	
+   44	Good:
+   45	
+   46	```go
+   47	reg.RegisterUIEvent("ChatAgentModeCommitted", &chatappv1.AgentModeCommittedUpdate{})
+   48	reg.RegisterTimelineEntity("AgentMode", &chatappv1.AgentModeEntity{})
+   49	```
+   50	
+   51	Avoid:
+   52	
+   53	```go
+   54	reg.RegisterUIEvent("ChatAgentModeCommitted", &structpb.Struct{})
+   55	reg.RegisterTimelineEntity("AgentMode", &structpb.Struct{})
+   56	```
+   57	
+   58	Use `google.protobuf.Struct` only inside a typed message field when the field is intentionally open-ended metadata, for example provider-specific debug details or arbitrary tool input/output. The outer payload registered with sessionstream should still be a named protobuf message.
+   59	
+   60	A repository-level architecture test (`pkg/chatapp/schema_policy_test.go`) and vet analyzer (`pkg/analysis/sessionstreamschema`, runnable with `make schema-vet`) reject `RegisterEvent`, `RegisterUIEvent`, and `RegisterTimelineEntity` registrations that use `&structpb.Struct{}`.
+   61	
+   62	## Base chatapp schema
+   63	
+   64	The base chatapp registers these command messages:
+   65	
+   66	| Name | Protobuf message | Purpose |
+   67	|---|---|---|
+   68	| `ChatStartInference` | `StartInferenceCommand` | Start an assistant run for a prompt. |
+   69	| `ChatStopInference` | `StopInferenceCommand` | Stop the active assistant run for a session. |
+   70	
+   71	It registers these backend events and UI events with `ChatMessageUpdate` payloads:
+   72	
+   73	| Backend event | UI event | Purpose |
+   74	|---|---|---|
+   75	| `ChatUserMessageAccepted` | `ChatMessageAccepted` | User prompt was accepted and projected into the timeline. |
+   76	| `ChatInferenceStarted` | `ChatMessageStarted` | Assistant run started. |
+   77	| `ChatTokensDelta` | `ChatMessageAppended` | Assistant text changed during streaming. |
+   78	| `ChatInferenceFinished` | `ChatMessageFinished` | Assistant text segment or final response finished. |
+   79	| `ChatInferenceStopped` | `ChatMessageStopped` | Assistant run stopped or failed. |
+   80	
+   81	It registers one base timeline entity kind:
+   82	
+   83	| Kind | Protobuf message | Purpose |
+   84	|---|---|---|
+   85	| `ChatMessage` | `ChatMessageEntity` | User, assistant, thinking, and warning transcript rows. |
+   86	
+   87	## Segment-aware transcript rows
+   88	
+   89	`ChatMessageUpdate` and `ChatMessageEntity` include segment metadata:
+   90	
+   91	| Field | Meaning |
+   92	|---|---|
+   93	| `message_id` / JSON `messageId` | Stable entity ID for this concrete transcript row. |
+   94	| `parent_message_id` / JSON `parentMessageId` | Assistant run ID that owns this row, when the row is a segment. |
+   95	| `segment` | One-based segment number within the parent assistant run. |
+   96	| `segment_type` / JSON `segmentType` | Logical segment kind, for example `text` or `thinking`. |
+   97	| `final` | True only for the final assistant text row of the run. |
+   98	
+   99	This is important for tool loops. A single assistant run can produce:
+  100	
+  101	```text
+  102	chat-msg-1:thinking:1
+  103	chat-msg-1:text:2
+  104	ChatToolCall / ChatToolResult rows
+  105	chat-msg-1:thinking:3
+  106	chat-msg-1:text:4
+  107	```
+  108	
+  109	Timeline stores and Redux reducers upsert by entity ID. Therefore every distinct transcript row must have a distinct `messageId`. Do not reuse the parent assistant ID for multiple thinking blocks or for multiple interleaved assistant text blocks.
+  110	
+  111	## Shared ReasoningPlugin
+  112	
+  113	`pkg/chatapp/plugins.NewReasoningPlugin()` translates Geppetto reasoning events into chatapp/sessionstream events.
+  114	
+  115	It handles:
+  116	
+  117	- `*events.EventThinkingPartial`
+  118	- `*events.EventInfo` with `thinking-started`
+  119	- `*events.EventInfo` with `thinking-ended`
+  120	- reasoning summary info payloads when available
+  121	
+  122	It registers concrete `ReasoningUpdate` protobuf payloads:
+  123	
+  124	| Backend event | UI event | Payload |
+  125	|---|---|---|
+  126	| `ChatReasoningStarted` | `ChatReasoningStarted` | `ReasoningUpdate` |
+  127	| `ChatReasoningDelta` | `ChatReasoningAppended` | `ReasoningUpdate` |
+  128	| `ChatReasoningFinished` | `ChatReasoningFinished` | `ReasoningUpdate` |
+  129	
+  130	The payload contains chat-message-shaped fields such as `messageId`, `parentMessageId`, `segment`, `role: "thinking"`, `chunk`, `content`, `status`, and `streaming`. Each contiguous thinking phase gets a segment ID such as `chat-msg-5:thinking:1`.
+  131	
+  132	Use this shared plugin instead of defining app-local runtime-debug/reasoning projection code.
+  133	
+  134	## Shared ToolCallPlugin
+  135	
+  136	`pkg/chatapp/plugins.NewToolCallPlugin()` translates Geppetto tool lifecycle events into typed protobuf payloads.
+  137	
+  138	It handles:
+  139	
+  140	- `*events.EventToolCall`

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/pinocchio-projections.lines.txt
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/pinocchio-projections.lines.txt
@@ -1,0 +1,120 @@
+    1	package chatapp
+    2	
+    3	import (
+    4		"context"
+    5		"strings"
+    6	
+    7		chatappv1 "github.com/go-go-golems/pinocchio/pkg/chatapp/pb/proto/pinocchio/chatapp/v1"
+    8		sessionstream "github.com/go-go-golems/sessionstream/pkg/sessionstream"
+    9		"google.golang.org/protobuf/proto"
+   10	)
+   11	
+   12	func baseUIProjection(_ context.Context, ev sessionstream.Event, _ *sessionstream.Session, _ sessionstream.TimelineView) ([]sessionstream.UIEvent, error) {
+   13		payload, ok := ev.Payload.(*chatappv1.ChatMessageUpdate)
+   14		if !ok || payload == nil {
+   15			return nil, nil
+   16		}
+   17		cloned := proto.Clone(payload)
+   18		switch ev.Name {
+   19		case EventUserMessageAccepted:
+   20			return []sessionstream.UIEvent{{Name: UIMessageAccepted, Payload: cloned}}, nil
+   21		case EventInferenceStarted:
+   22			return []sessionstream.UIEvent{{Name: UIMessageStarted, Payload: cloned}}, nil
+   23		case EventTokensDelta:
+   24			return []sessionstream.UIEvent{{Name: UIMessageAppended, Payload: cloned}}, nil
+   25		case EventInferenceFinished:
+   26			return []sessionstream.UIEvent{{Name: UIMessageFinished, Payload: cloned}}, nil
+   27		case EventInferenceStopped:
+   28			return []sessionstream.UIEvent{{Name: UIMessageStopped, Payload: cloned}}, nil
+   29		default:
+   30			return nil, nil
+   31		}
+   32	}
+   33	
+   34	func baseTimelineProjection(_ context.Context, ev sessionstream.Event, _ *sessionstream.Session, view sessionstream.TimelineView) ([]sessionstream.TimelineEntity, error) {
+   35		payload, ok := ev.Payload.(*chatappv1.ChatMessageUpdate)
+   36		if !ok || payload == nil {
+   37			return nil, nil
+   38		}
+   39		messageID := strings.TrimSpace(payload.GetMessageId())
+   40		if messageID == "" {
+   41			return nil, nil
+   42		}
+   43		entity, hadEntity := currentChatMessageEntity(view, messageID)
+   44		switch ev.Name {
+   45		case EventUserMessageAccepted:
+   46			entity.MessageId = messageID
+   47			entity.Role = "user"
+   48			entity.Content = firstNonEmpty(payload.GetContent(), payload.GetText())
+   49			entity.Text = entity.Content
+   50			entity.Streaming = false
+   51		case EventInferenceStarted:
+   52			content := firstNonEmpty(payload.GetContent(), payload.GetText())
+   53			if content == "" && !hadEntity {
+   54				return nil, nil
+   55			}
+   56			entity.MessageId = messageID
+   57			entity.Role = firstNonEmpty(payload.GetRole(), "assistant")
+   58			entity.Status = "streaming"
+   59			entity.Streaming = true
+   60			if prompt := payload.GetPrompt(); prompt != "" {
+   61				entity.Prompt = prompt
+   62			}
+   63			if content != "" {
+   64				entity.Content = content
+   65				entity.Text = content
+   66			}
+   67		case EventTokensDelta:
+   68			content := firstNonEmpty(payload.GetContent(), payload.GetText())
+   69			if content == "" && !hadEntity {
+   70				return nil, nil
+   71			}
+   72			entity.MessageId = messageID
+   73			entity.Role = firstNonEmpty(payload.GetRole(), "assistant")
+   74			entity.Content = content
+   75			entity.Text = content
+   76			entity.Status = "streaming"
+   77			entity.Streaming = true
+   78			if prompt := payload.GetPrompt(); prompt != "" {
+   79				entity.Prompt = prompt
+   80			}
+   81		case EventInferenceFinished:
+   82			content := firstNonEmpty(payload.GetContent(), payload.GetText(), entity.GetContent(), entity.GetText())
+   83			if content == "" && !hadEntity {
+   84				return nil, nil
+   85			}
+   86			entity.MessageId = messageID
+   87			entity.Role = firstNonEmpty(payload.GetRole(), "assistant")
+   88			entity.Content = content
+   89			entity.Text = content
+   90			entity.Status = "finished"
+   91			entity.Streaming = false
+   92			if prompt := payload.GetPrompt(); prompt != "" {
+   93				entity.Prompt = prompt
+   94			}
+   95		case EventInferenceStopped:
+   96			content := firstNonEmpty(payload.GetContent(), payload.GetText(), entity.GetContent(), entity.GetText())
+   97			entity.MessageId = messageID
+   98			entity.Role = firstNonEmpty(payload.GetRole(), "assistant")
+   99			entity.Content = content
+  100			entity.Text = content
+  101			entity.Status = "stopped"
+  102			entity.Streaming = false
+  103			if prompt := payload.GetPrompt(); prompt != "" {
+  104				entity.Prompt = prompt
+  105			}
+  106			if errText := payload.GetError(); errText != "" {
+  107				entity.Error = errText
+  108			}
+  109		default:
+  110			return nil, nil
+  111		}
+  112		entity.ParentMessageId = payload.GetParentMessageId()
+  113		entity.Segment = payload.GetSegment()
+  114		entity.SegmentType = payload.GetSegmentType()
+  115		entity.Final = payload.GetFinal()
+  116		return []sessionstream.TimelineEntity{{Kind: TimelineEntityChatMessage, Id: messageID, Payload: entity}}, nil
+  117	}
+  118	
+  119	func currentChatMessageEntity(view sessionstream.TimelineView, id string) (*chatappv1.ChatMessageEntity, bool) {
+  120		entity, ok := view.Get(TimelineEntityChatMessage, id)

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/pinocchio-react-chat-apps-doc.lines.txt
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/pinocchio-react-chat-apps-doc.lines.txt
@@ -1,0 +1,51 @@
+  120	- `pinocchio/cmd/web-chat/web/src/ws/wsManager.test.ts`
+  121	- `pinocchio/cmd/web-chat/web/src/webchat/rendererRegistry.ts`
+  122	- `pinocchio/cmd/web-chat/web/src/webchat/cards.tsx`
+  123	- `pinocchio/cmd/web-chat/web/src/webchat/ChatWidget.tsx`
+  124	
+  125	## Architecture at a glance
+  126	
+  127	Here is the end-to-end flow you should be aiming for.
+  128	
+  129	```text
+  130	1. React submits a message
+  131	   -> POST /api/chat/sessions/:id/messages
+  132	
+  133	2. App server resolves runtime/profile
+  134	   -> pinocchio runtime composer
+  135	   -> geppetto engine + middleware chain
+  136	
+  137	3. App service submits a command to sessionstream
+  138	   -> ChatStartInference
+  139	
+  140	4. Chat handler publishes canonical backend events
+  141	   -> ChatUserMessageAccepted
+  142	   -> ChatInferenceStarted
+  143	   -> ChatTokensDelta
+  144	   -> ChatInferenceFinished
+  145	   -> app-owned feature events when applicable
+  146	
+  147	5. sessionstream projections derive outputs
+  148	   -> TimelineEntity records for hydration
+  149	   -> UIEvent frames for live delivery
+  150	
+  151	6. WebSocket transport fans UI events to subscribers
+  152	   -> snapshot first
+  153	   -> live UI events after subscribe
+  154	
+  155	7. React updates state from snapshot + UI events
+  156	   -> timeline entities map to cards/messages/widgets
+  157	```
+  158	
+  159	The virtue of this model is that the frontend does not invent truth. It renders truth derived by the backend.
+  160	
+  161	## Suggested application layout
+  162	
+  163	A practical layout for a new app looks like this:
+  164	
+  165	```text
+  166	cmd/my-chat-app/
+  167	  main.go
+  168	  app/
+  169	    server.go
+  170	    contracts.go

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/pinocchio-reasoning-plugin.lines.txt
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/pinocchio-reasoning-plugin.lines.txt
@@ -1,0 +1,111 @@
+  100				return err
+  101			}
+  102		}
+  103		return nil
+  104	}
+  105	
+  106	// HandleRuntimeEvent handles EventThinkingPartial and EventInfo events.
+  107	func (p *ReasoningPlugin) HandleRuntimeEvent(ctx context.Context, runtime chatapp.RuntimeEventContext, event gepevents.Event) (bool, error) {
+  108		parentMessageID := strings.TrimSpace(runtime.MessageID)
+  109		if parentMessageID == "" {
+  110			return false, nil
+  111		}
+  112	
+  113		switch ev := event.(type) {
+  114		case *gepevents.EventThinkingPartial:
+  115			providerInfo := reasoningProviderInfoFromMetadata(ev.Metadata())
+  116			reasoningMessageID, segment, providerInfo := p.ensureReasoningSegment(parentMessageID, providerInfo)
+  117			return true, runtime.Publish(ctx, ReasoningDeltaEventName, applyReasoningProviderInfo(&chatappv1.ReasoningUpdate{
+  118				MessageId:       reasoningMessageID,
+  119				ParentMessageId: parentMessageID,
+  120				Segment:         segment,
+  121				Role:            "thinking",
+  122				Chunk:           ev.Delta,
+  123				Content:         ev.Completion,
+  124				Text:            ev.Completion,
+  125				Status:          "streaming",
+  126				Streaming:       true,
+  127				Source:          "thinking",
+  128				SegmentType:     "thinking",
+  129			}, providerInfo))
+  130		case *gepevents.EventInfo:
+  131			switch ev.Message {
+  132			case "thinking-started":
+  133				providerInfo := reasoningProviderInfoFromData(ev.Data)
+  134				reasoningMessageID, segment, providerInfo := p.startReasoningSegment(parentMessageID, providerInfo)
+  135				return true, runtime.Publish(ctx, ReasoningStartedEventName, applyReasoningProviderInfo(&chatappv1.ReasoningUpdate{
+  136					MessageId:       reasoningMessageID,
+  137					ParentMessageId: parentMessageID,
+  138					Segment:         segment,
+  139					Role:            "thinking",
+  140					Status:          "streaming",
+  141					Streaming:       true,
+  142					Source:          "thinking",
+  143					SegmentType:     "thinking",
+  144				}, providerInfo))
+  145			case "thinking-ended":
+  146				providerInfo := reasoningProviderInfoFromData(ev.Data)
+  147				reasoningMessageID, segment, providerInfo, key, ok := p.currentReasoningSegment(parentMessageID, providerInfo)
+  148				if !ok {
+  149					return false, nil
+  150				}
+  151				p.finishReasoningSegment(key)
+  152				return true, runtime.Publish(ctx, ReasoningFinishedEventName, applyReasoningProviderInfo(&chatappv1.ReasoningUpdate{
+  153					MessageId:       reasoningMessageID,
+  154					ParentMessageId: parentMessageID,
+  155					Segment:         segment,
+  156					Role:            "thinking",
+  157					Status:          "finished",
+  158					Streaming:       false,
+  159					Source:          "thinking",
+  160					SegmentType:     "thinking",
+  161				}, providerInfo))
+  162			case "reasoning-summary-started", "reasoning-summary-ended":
+  163				p.updateReasoningProviderInfo(parentMessageID, reasoningProviderInfoFromData(ev.Data))
+  164				return false, nil
+  165			case "reasoning-summary":
+  166				providerInfo := reasoningProviderInfoFromData(ev.Data)
+  167				reasoningMessageID, segment, providerInfo, key := p.summaryReasoningSegment(parentMessageID, providerInfo)
+  168				p.finishReasoningSegment(key)
+  169				text := infoText(ev.Data)
+  170				return true, runtime.Publish(ctx, ReasoningFinishedEventName, applyReasoningProviderInfo(&chatappv1.ReasoningUpdate{
+  171					MessageId:       reasoningMessageID,
+  172					ParentMessageId: parentMessageID,
+  173					Segment:         segment,
+  174					Role:            "thinking",
+  175					Content:         text,
+  176					Text:            text,
+  177					Status:          "finished",
+  178					Streaming:       false,
+  179					Source:          "summary",
+  180					SegmentType:     "thinking",
+  181				}, providerInfo))
+  182			default:
+  183				return false, nil
+  184			}
+  185		default:
+  186			return false, nil
+  187		}
+  188	}
+  189	
+  190	// ProjectUI projects reasoning backend events into UI events.
+  191	func (p *ReasoningPlugin) ProjectUI(_ context.Context, ev sessionstream.Event, _ *sessionstream.Session, view sessionstream.TimelineView) ([]sessionstream.UIEvent, bool, error) {
+  192		payload, ok := reasoningProjectedPayload(ev, view)
+  193		if !ok {
+  194			return nil, false, nil
+  195		}
+  196		switch ev.Name {
+  197		case ReasoningStartedEventName:
+  198			return []sessionstream.UIEvent{{Name: ReasoningStartedUIName, Payload: payload}}, true, nil
+  199		case ReasoningDeltaEventName:
+  200			return []sessionstream.UIEvent{{Name: ReasoningAppendedUIName, Payload: payload}}, true, nil
+  201		case ReasoningFinishedEventName:
+  202			return []sessionstream.UIEvent{{Name: ReasoningFinishedUIName, Payload: payload}}, true, nil
+  203		default:
+  204			return nil, false, nil
+  205		}
+  206	}
+  207	
+  208	// ProjectTimeline projects reasoning backend events into ChatMessage timeline entities.
+  209	// Thinking entities use role "thinking" and accumulate content across deltas.
+  210	func (p *ReasoningPlugin) ProjectTimeline(_ context.Context, ev sessionstream.Event, _ *sessionstream.Session, view sessionstream.TimelineView) ([]sessionstream.TimelineEntity, bool, error) {

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/pinocchio-runtime-inference.lines.txt
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/pinocchio-runtime-inference.lines.txt
@@ -1,0 +1,106 @@
+   70		if err := e.publish(ctx, sid, pub, EventInferenceStarted, started); err != nil {
+   71			return
+   72		}
+   73	
+   74		baseSink := gepevents.EventSink(&runtimeEventSink{publishCtx: publishContext(ctx), sessionID: sid, messageID: messageID, prompt: prompt, pub: pub, engine: e})
+   75		eventSink := baseSink
+   76		if runtime.WrapSink != nil {
+   77			wrapped, err := runtime.WrapSink(baseSink)
+   78			if err != nil {
+   79				_ = e.publish(publishContext(ctx), sid, pub, EventInferenceStopped, newChatMessageUpdate(messageID, "assistant", "", "", prompt, "stopped", false, err.Error()))
+   80				return
+   81			}
+   82			eventSink = wrapped
+   83		}
+   84		sink, ok := baseSink.(*runtimeEventSink)
+   85		if !ok {
+   86			_ = e.publish(publishContext(ctx), sid, pub, EventInferenceStopped, newChatMessageUpdate(messageID, "assistant", "", "", prompt, "stopped", false, "internal runtime sink type assertion failed"))
+   87			return
+   88		}
+   89		sess := gepsession.NewSessionWithID(string(sid))
+   90		sess.Builder = &enginebuilder.Builder{
+   91			Base:       runtime.Engine,
+   92			EventSinks: []gepevents.EventSink{eventSink},
+   93		}
+   94	
+   95		// Load conversation history: the last persisted turn contains the full
+   96		// conversation as an accumulator. AppendNewTurnFromUserPrompt will clone
+   97		// it and add the new user block, giving the LLM the full context.
+   98		if e.turnStore != nil {
+   99			snapshot, err := e.turnStore.LoadLatestTurn(ctx, string(sid), "final")
+  100			if err != nil {
+  101				_ = e.publish(publishContext(ctx), sid, pub, EventInferenceStopped, sink.stoppedMessageUpdate(messageID, fmt.Sprintf("load conversation history: %v", err)))
+  102				return
+  103			}
+  104			if snapshot != nil {
+  105				turn, err := serde.FromYAML([]byte(snapshot.Payload))
+  106				if err != nil {
+  107					_ = e.publish(publishContext(ctx), sid, pub, EventInferenceStopped, sink.stoppedMessageUpdate(messageID, fmt.Sprintf("decode conversation history: %v", err)))
+  108					return
+  109				}
+  110				if turn == nil {
+  111					_ = e.publish(publishContext(ctx), sid, pub, EventInferenceStopped, sink.stoppedMessageUpdate(messageID, "decode conversation history: empty turn"))
+  112					return
+  113				}
+  114				sess.Append(turn)
+  115			}
+  116		}
+  117	
+  118		_, err := sess.AppendNewTurnFromUserPrompt(prompt)
+  119		if err != nil {
+  120			_ = e.publish(publishContext(ctx), sid, pub, EventInferenceStopped, sink.stoppedMessageUpdate(messageID, err.Error()))
+  121			return
+  122		}
+  123		handle, err := sess.StartInference(ctx)
+  124		if err != nil {
+  125			_ = e.publish(publishContext(ctx), sid, pub, EventInferenceStopped, sink.stoppedMessageUpdate(messageID, err.Error()))
+  126			return
+  127		}
+  128		output, err := handle.Wait()
+  129		if err != nil {
+  130			if !sink.IsTerminal() {
+  131				if isMaxIterationsError(err) {
+  132					_ = e.publish(publishContext(ctx), sid, pub, EventInferenceFinished, newChatMessageUpdate(runtimeWarningMessageID(messageID), "warning", maxIterationsWarningText(err), maxIterationsWarningText(err), prompt, "finished", false, ""))
+  133				}
+  134				_ = e.publish(publishContext(ctx), sid, pub, EventInferenceStopped, sink.stoppedMessageUpdate(messageID, err.Error()))
+  135			}
+  136			return
+  137		}
+  138		if sink.IsTerminal() {
+  139			return
+  140		}
+  141		finalText := sink.LastText()
+  142		if finalText == "" {
+  143			finalText = assistantTextFromTurn(output)
+  144		}
+  145		textMessageID, segment := sink.ensureTextSegmentID()
+  146		finished := newChatMessageUpdate(textMessageID, "assistant", finalText, finalText, prompt, "finished", false, "")
+  147		finished.ParentMessageId = messageID
+  148		finished.Segment = segment
+  149		finished.SegmentType = "text"
+  150		finished.Final = true
+  151		_ = e.publish(publishContext(ctx), sid, pub, EventInferenceFinished, finished)
+  152	}
+  153	
+  154	func publishContext(ctx context.Context) context.Context {
+  155		if ctx == nil {
+  156			return context.Background()
+  157		}
+  158		return context.WithoutCancel(ctx)
+  159	}
+  160	
+  161	func (e *Engine) publish(ctx context.Context, sid sessionstream.SessionId, pub sessionstream.EventPublisher, name string, payload proto.Message) error {
+  162		if payload == nil {
+  163			return fmt.Errorf("event %s payload is nil", name)
+  164		}
+  165		if e.hooks.OnBackendEvent != nil {
+  166			e.hooks.OnBackendEvent(string(sid), name, protoMessageAsMap(payload))
+  167		}
+  168		return pub.Publish(ctx, sessionstream.Event{Name: name, SessionId: sid, Payload: payload})
+  169	}
+  170	
+  171	func assistantTextFromTurn(turn *turns.Turn) string {
+  172		if turn == nil {
+  173			return ""
+  174		}
+  175		parts := make([]string, 0, len(turn.Blocks))

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/pinocchio-runtime-sink.lines.txt
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/pinocchio-runtime-sink.lines.txt
@@ -1,0 +1,230 @@
+    1	package chatapp
+    2	
+    3	import (
+    4		"context"
+    5		"fmt"
+    6		"strconv"
+    7		"strings"
+    8		"sync"
+    9	
+   10		gepevents "github.com/go-go-golems/geppetto/pkg/events"
+   11		chatappv1 "github.com/go-go-golems/pinocchio/pkg/chatapp/pb/proto/pinocchio/chatapp/v1"
+   12		sessionstream "github.com/go-go-golems/sessionstream/pkg/sessionstream"
+   13	)
+   14	
+   15	type runtimeEventSink struct {
+   16		mu          sync.Mutex
+   17		publishCtx  context.Context
+   18		sessionID   sessionstream.SessionId
+   19		messageID   string
+   20		prompt      string
+   21		pub         sessionstream.EventPublisher
+   22		engine      *Engine
+   23		lastText    string
+   24		terminal    bool
+   25		textSegment int32
+   26		textActive  bool
+   27	}
+   28	
+   29	func (s *runtimeEventSink) PublishEvent(event gepevents.Event) error {
+   30		if s == nil || s.pub == nil || s.engine == nil {
+   31			return nil
+   32		}
+   33		switch ev := event.(type) {
+   34		case *gepevents.EventPartialCompletion:
+   35			textMessageID, segment := s.ensureTextSegmentID()
+   36			s.mu.Lock()
+   37			s.lastText = ev.Completion
+   38			s.mu.Unlock()
+   39			payload := newChatMessageDelta(textMessageID, ev.Delta, ev.Completion, s.prompt, "streaming", true, "")
+   40			payload.ParentMessageId = s.messageID
+   41			payload.Segment = segment
+   42			payload.SegmentType = "text"
+   43			applyChatMessageProviderInfo(payload, ev.Metadata())
+   44			return s.engine.publish(s.publishContext(), s.sessionID, s.pub, EventTokensDelta, payload)
+   45		case *gepevents.EventFinal:
+   46			textMessageID, segment := s.ensureTextSegmentID()
+   47			s.mu.Lock()
+   48			s.lastText = ev.Text
+   49			s.terminal = true
+   50			s.textActive = false
+   51			s.mu.Unlock()
+   52			payload := newChatMessageUpdate(textMessageID, "assistant", ev.Text, ev.Text, s.prompt, "finished", false, "")
+   53			payload.ParentMessageId = s.messageID
+   54			payload.Segment = segment
+   55			payload.SegmentType = "text"
+   56			payload.Final = true
+   57			return s.engine.publish(s.publishContext(), s.sessionID, s.pub, EventInferenceFinished, payload)
+   58		case *gepevents.EventError:
+   59			return s.engine.publish(s.publishContext(), s.sessionID, s.pub, EventInferenceStopped, s.stoppedMessageUpdate(s.messageID, ev.ErrorString))
+   60		case *gepevents.EventInterrupt:
+   61			textMessageID, segment := s.ensureTextSegmentID()
+   62			s.mu.Lock()
+   63			s.lastText = ev.Text
+   64			s.terminal = true
+   65			s.textActive = false
+   66			s.mu.Unlock()
+   67			payload := newChatMessageUpdate(textMessageID, "assistant", ev.Text, ev.Text, s.prompt, "stopped", false, "")
+   68			payload.ParentMessageId = s.messageID
+   69			payload.Segment = segment
+   70			payload.SegmentType = "text"
+   71			payload.Final = true
+   72			return s.engine.publish(s.publishContext(), s.sessionID, s.pub, EventInferenceStopped, payload)
+   73		default:
+   74			if isTranscriptBoundaryEvent(event) {
+   75				if textMessageID, segment, text, ok := s.finishTextSegment(); ok {
+   76					payload := newChatMessageUpdate(textMessageID, "assistant", text, text, s.prompt, "finished", false, "")
+   77					payload.ParentMessageId = s.messageID
+   78					payload.Segment = segment
+   79					payload.SegmentType = "text"
+   80					if err := s.engine.publish(s.publishContext(), s.sessionID, s.pub, EventInferenceFinished, payload); err != nil {
+   81						return err
+   82					}
+   83				}
+   84			}
+   85			return s.engine.handleFeatureRuntimeEvent(s.publishContext(), s.sessionID, s.messageID, s.pub, event)
+   86		}
+   87	}
+   88	
+   89	func (s *runtimeEventSink) publishContext() context.Context {
+   90		if s == nil {
+   91			return context.Background()
+   92		}
+   93		return publishContext(s.publishCtx)
+   94	}
+   95	
+   96	func (s *runtimeEventSink) ensureTextSegmentID() (string, int32) {
+   97		if s == nil {
+   98			return "", 0
+   99		}
+  100		s.mu.Lock()
+  101		defer s.mu.Unlock()
+  102		if !s.textActive {
+  103			s.textSegment++
+  104			s.textActive = true
+  105		}
+  106		return textSegmentMessageID(s.messageID, s.textSegment), s.textSegment
+  107	}
+  108	
+  109	func (s *runtimeEventSink) stoppedMessageUpdate(defaultMessageID, errText string) *chatappv1.ChatMessageUpdate {
+  110		if s == nil {
+  111			return newChatMessageUpdate(defaultMessageID, "assistant", "", "", "", "stopped", false, errText)
+  112		}
+  113		s.mu.Lock()
+  114		text := s.lastText
+  115		segment := s.textSegment
+  116		active := s.textActive && segment > 0
+  117		if active {
+  118			s.textActive = false
+  119		}
+  120		s.terminal = true
+  121		s.mu.Unlock()
+  122	
+  123		if !active {
+  124			// If a prior text segment was already closed by a tool/reasoning boundary,
+  125			// do not duplicate that segment's content into the parent run-level stopped row.
+  126			if segment > 0 {
+  127				text = ""
+  128			}
+  129			return newChatMessageUpdate(defaultMessageID, "assistant", text, text, s.prompt, "stopped", false, errText)
+  130		}
+  131		payload := newChatMessageUpdate(textSegmentMessageID(s.messageID, segment), "assistant", text, text, s.prompt, "stopped", false, errText)
+  132		payload.ParentMessageId = s.messageID
+  133		payload.Segment = segment
+  134		payload.SegmentType = "text"
+  135		payload.Final = true
+  136		return payload
+  137	}
+  138	
+  139	func (s *runtimeEventSink) finishTextSegment() (string, int32, string, bool) {
+  140		if s == nil {
+  141			return "", 0, "", false
+  142		}
+  143		s.mu.Lock()
+  144		defer s.mu.Unlock()
+  145		if !s.textActive || s.textSegment <= 0 || strings.TrimSpace(s.lastText) == "" {
+  146			s.textActive = false
+  147			return "", 0, "", false
+  148		}
+  149		s.textActive = false
+  150		return textSegmentMessageID(s.messageID, s.textSegment), s.textSegment, s.lastText, true
+  151	}
+  152	
+  153	func textSegmentMessageID(messageID string, segment int32) string {
+  154		messageID = strings.TrimSpace(messageID)
+  155		if messageID == "" || segment <= 0 {
+  156			return ""
+  157		}
+  158		return fmt.Sprintf("%s:text:%d", messageID, segment)
+  159	}
+  160	
+  161	func applyChatMessageProviderInfo(update *chatappv1.ChatMessageUpdate, metadata gepevents.EventMetadata) {
+  162		if update == nil || metadata.Extra == nil {
+  163			return
+  164		}
+  165		if v, ok := metadata.Extra["provider"].(string); ok {
+  166			update.Provider = strings.TrimSpace(v)
+  167		}
+  168		if v, ok := metadata.Extra["response_id"].(string); ok {
+  169			update.ResponseId = strings.TrimSpace(v)
+  170		}
+  171		if v, ok := int32FromMetadata(metadata.Extra["choice_index"]); ok {
+  172			update.ChoiceIndex = &v
+  173		}
+  174		if v, ok := metadata.Extra["stream_kind"].(string); ok {
+  175			update.StreamKind = strings.TrimSpace(v)
+  176		}
+  177		if v, ok := metadata.Extra["correlation_key"].(string); ok {
+  178			update.CorrelationKey = strings.TrimSpace(v)
+  179		}
+  180	}
+  181	
+  182	func int32FromMetadata(v any) (int32, bool) {
+  183		switch tv := v.(type) {
+  184		case int:
+  185			parsed, err := strconv.ParseInt(strconv.Itoa(tv), 10, 32)
+  186			if err != nil {
+  187				return 0, false
+  188			}
+  189			return int32(parsed), true
+  190		case int32:
+  191			return tv, true
+  192		case int64:
+  193			if tv < int64(-1<<31) || tv > int64(1<<31-1) {
+  194				return 0, false
+  195			}
+  196			return int32(tv), true
+  197		case float64:
+  198			if tv < float64(-1<<31) || tv > float64(1<<31-1) || tv != float64(int32(tv)) {
+  199				return 0, false
+  200			}
+  201			return int32(tv), true
+  202		case string:
+  203			parsed, err := strconv.ParseInt(strings.TrimSpace(tv), 10, 32)
+  204			if err != nil {
+  205				return 0, false
+  206			}
+  207			return int32(parsed), true
+  208		default:
+  209			return 0, false
+  210		}
+  211	}
+  212	
+  213	func isTranscriptBoundaryEvent(event gepevents.Event) bool {
+  214		switch event.(type) {
+  215		case *gepevents.EventToolCall, *gepevents.EventToolCallExecute, *gepevents.EventToolResult, *gepevents.EventToolCallExecutionResult:
+  216			return true
+  217		default:
+  218			return false
+  219		}
+  220	}
+  221	
+  222	func (s *runtimeEventSink) LastText() string {
+  223		if s == nil {
+  224			return ""
+  225		}
+  226		s.mu.Lock()
+  227		defer s.mu.Unlock()
+  228		return s.lastText
+  229	}
+  230	

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/pinocchio-toolcall-plugin.lines.txt
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/sources/pinocchio-toolcall-plugin.lines.txt
@@ -1,0 +1,76 @@
+   60			reg.RegisterUIEvent(UIToolResultReady, &chatappv1.ToolResultUpdate{}),
+   61			reg.RegisterTimelineEntity(TimelineEntityToolCall, &chatappv1.ToolCallEntity{}),
+   62			reg.RegisterTimelineEntity(TimelineEntityToolResult, &chatappv1.ToolResultEntity{}),
+   63		} {
+   64			if err != nil {
+   65				return err
+   66			}
+   67		}
+   68		return nil
+   69	}
+   70	
+   71	// HandleRuntimeEvent handles tool call events from the geppetto engine.
+   72	func (p *ToolCallPlugin) HandleRuntimeEvent(ctx context.Context, runtime chatapp.RuntimeEventContext, event gepevents.Event) (bool, error) {
+   73		switch ev := event.(type) {
+   74		case *gepevents.EventToolCall:
+   75			return true, runtime.Publish(ctx, EventToolCallStarted, applyToolCallProviderInfo(&chatappv1.ToolCallUpdate{
+   76				MessageId:  runtime.MessageID,
+   77				ToolCallId: ev.ToolCall.ID,
+   78				ToolName:   ev.ToolCall.Name,
+   79				Input:      ev.ToolCall.Input,
+   80				Status:     "pending",
+   81			}, reasoningProviderInfoFromMetadata(ev.Metadata())))
+   82	
+   83		case *gepevents.EventToolCallExecute:
+   84			return true, runtime.Publish(ctx, EventToolCallUpdated, applyToolCallProviderInfo(&chatappv1.ToolCallUpdate{
+   85				MessageId:  runtime.MessageID,
+   86				ToolCallId: ev.ToolCall.ID,
+   87				ToolName:   ev.ToolCall.Name,
+   88				Input:      ev.ToolCall.Input,
+   89				Executing:  true,
+   90				Status:     "executing",
+   91			}, reasoningProviderInfoFromMetadata(ev.Metadata())))
+   92	
+   93		case *gepevents.EventToolResult:
+   94			providerInfo := reasoningProviderInfoFromMetadata(ev.Metadata())
+   95			if err := runtime.Publish(ctx, EventToolResultReady, applyToolResultProviderInfo(&chatappv1.ToolResultUpdate{
+   96				MessageId:  runtime.MessageID,
+   97				ToolCallId: ev.ToolResult.ID,
+   98				ToolName:   ev.ToolResult.Name,
+   99				Result:     ev.ToolResult.Result,
+  100				Status:     "success",
+  101			}, providerInfo)); err != nil {
+  102				return true, err
+  103			}
+  104			return true, runtime.Publish(ctx, EventToolCallFinished, applyToolCallProviderInfo(&chatappv1.ToolCallUpdate{
+  105				MessageId:  runtime.MessageID,
+  106				ToolCallId: ev.ToolResult.ID,
+  107				ToolName:   ev.ToolResult.Name,
+  108				Status:     "completed",
+  109			}, providerInfo))
+  110	
+  111		case *gepevents.EventToolCallExecutionResult:
+  112			providerInfo := reasoningProviderInfoFromMetadata(ev.Metadata())
+  113			if err := runtime.Publish(ctx, EventToolResultReady, applyToolResultProviderInfo(&chatappv1.ToolResultUpdate{
+  114				MessageId:  runtime.MessageID,
+  115				ToolCallId: ev.ToolResult.ID,
+  116				ToolName:   ev.ToolResult.Name,
+  117				Result:     ev.ToolResult.Result,
+  118				Status:     "success",
+  119			}, providerInfo)); err != nil {
+  120				return true, err
+  121			}
+  122			return true, runtime.Publish(ctx, EventToolCallFinished, applyToolCallProviderInfo(&chatappv1.ToolCallUpdate{
+  123				MessageId:  runtime.MessageID,
+  124				ToolCallId: ev.ToolResult.ID,
+  125				ToolName:   ev.ToolResult.Name,
+  126				Status:     "completed",
+  127			}, providerInfo))
+  128	
+  129		default:
+  130			return false, nil
+  131		}
+  132	}
+  133	
+  134	// ProjectUI projects tool call backend events into UI events.
+  135	func (p *ToolCallPlugin) ProjectUI(_ context.Context, ev sessionstream.Event, _ *sessionstream.Session, _ sessionstream.TimelineView) ([]sessionstream.UIEvent, bool, error) {

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/tasks.md
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/tasks.md
@@ -22,7 +22,7 @@ LastUpdated: 2026-05-08T00:15:00-04:00
 - [x] Correlate CoinVault Haiku duplicate through provider, backend, transport, frontend, and timeline records.
 - [x] Add regression coverage for Claude `tool_use` stop finalization.
 - [x] Change Claude `message_delta` handling to metadata-only.
-- [x] Change Claude `message_stop` with `stop_reason=tool_use` to emit an empty final text payload.
+- [x] Change Claude `message_stop` with `stop_reason=tool_use` to emit no final event.
 - [x] Run `go test ./pkg/steps/ai/claude -run 'TestContentBlockMerger' -count=1`.
 - [x] Run `go test ./pkg/steps/ai/claude -count=1`.
 - [x] Run `go test ./pkg/steps/ai/... -count=1`.

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/tasks.md
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/tasks.md
@@ -18,6 +18,9 @@ LastUpdated: 2026-05-08T00:15:00-04:00
 
 ## Done
 
+- [x] Upload bug-analysis and event-semantics guide bundle to reMarkable.
+- [x] Write provider-to-Geppetto-to-Pinocchio event semantics intern guide.
+- [x] Capture source evidence snippets for Geppetto and Pinocchio mapping code/docs.
 - [x] Create docmgr ticket workspace and bug analysis guide.
 - [x] Correlate CoinVault Haiku duplicate through provider, backend, transport, frontend, and timeline records.
 - [x] Add regression coverage for Claude `tool_use` stop finalization.

--- a/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/tasks.md
+++ b/ttmp/2026/05/07/GP-CLAUDE-DUPLICATE-TEXT--fix-claude-tool-use-duplicate-text-finalization/tasks.md
@@ -1,0 +1,33 @@
+---
+Title: Tasks
+Ticket: GP-CLAUDE-DUPLICATE-TEXT
+Status: active
+Topics:
+  - geppetto
+  - claude
+  - streaming
+DocType: tasks
+Intent: short-term
+Owners:
+  - manuel
+Summary: Task list for Claude tool-use duplicate text finalization fix.
+LastUpdated: 2026-05-08T00:15:00-04:00
+---
+
+# Tasks
+
+## Done
+
+- [x] Create docmgr ticket workspace and bug analysis guide.
+- [x] Correlate CoinVault Haiku duplicate through provider, backend, transport, frontend, and timeline records.
+- [x] Add regression coverage for Claude `tool_use` stop finalization.
+- [x] Change Claude `message_delta` handling to metadata-only.
+- [x] Change Claude `message_stop` with `stop_reason=tool_use` to emit an empty final text payload.
+- [x] Run `go test ./pkg/steps/ai/claude -run 'TestContentBlockMerger' -count=1`.
+- [x] Run `go test ./pkg/steps/ai/claude -count=1`.
+- [x] Run `go test ./pkg/steps/ai/... -count=1`.
+
+## TODO
+
+- [ ] Re-run CoinVault Haiku browser smoke after Geppetto dependency/workspace integration picks up this fix.
+- [ ] Consider a separate Anthropic provider correlation-key ticket; the Haiku artifact had provider records but no non-empty normalized `correlation_key` values.

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -103,6 +103,8 @@ topics:
       description: Intern-focused onboarding, architecture orientation, and contributor guides
     - slug: observability
       description: Runtime observability, trace records, debug evidence, and telemetry-style diagnostics
+    - slug: claude
+      description: Anthropic Claude provider integration and streaming behavior
 docTypes:
     - slug: index
       description: Ticket index


### PR DESCRIPTION
### Summary

Fixes a bug where assistant messages from Anthropic (Claude) models were
duplicated in the UI when making a tool call. The text preceding the tool
call would appear a second time after the tool call was initiated.

### Root Cause

The Claude event stream processor was incorrectly handling `message_delta` and
`message_stop` events when the stop reason was `tool_use`. It re-emitted the
entire accumulated text buffer, causing downstream consumers to create a
duplicate text segment. The text had already been finalized by a preceding
`content_block_stop` event.

### Changes

- The `ContentBlockMerger` now suppresses text-based events for `message_delta`.
  These events now only update internal metadata (like stop reason or usage).
- The merger also suppresses the final completion event on `message_stop` when
  the stop reason is `tool_use`.
- This prevents re-finalizing a text segment that has already been completed
  before the tool call.
- Adds a new regression test to verify the fix for this specific tool-use
  event sequence.