### PR TITLE
Fix segment index overwriting in multi-step inferences

### DIFF
--- a/pkg/events/canonical_events_test.go
+++ b/pkg/events/canonical_events_test.go
@@ -6,27 +6,13 @@ import (
 )
 
 func sampleCorrelation() Correlation {
-	choice := int32(2)
-	toolIndex := int32(1)
 	return Correlation{
-		SessionID:            "session-1",
-		RunID:                "run-1",
-		InferenceID:          "inference-1",
-		TurnID:               "turn-1",
-		ProviderCallID:       "provider-call-1",
-		ProviderCallIndex:    1,
-		Provider:             "claude",
-		Model:                "claude-test",
-		ResponseID:           "msg_1",
-		ChoiceIndex:          &choice,
-		SegmentID:            "segment-1",
-		SegmentIndex:         1,
-		SegmentType:          "text",
-		StreamKind:           "text",
-		ToolCallID:           "tool-1",
-		ToolCallIndex:        &toolIndex,
-		CorrelationKey:       "claude:provider-call-1:block:0:text",
-		ParentCorrelationKey: "claude:provider-call-1:provider-call",
+		SessionID:      "session-1",
+		RunID:          "run-1",
+		TurnID:         "turn-1",
+		ProviderCallID: "provider-call-1",
+		SegmentID:      "segment-1",
+		ToolCallID:     "tool-1",
 	}
 }
 
@@ -81,7 +67,7 @@ func TestCanonicalEventsRoundTripCorrelation(t *testing.T) {
 				t.Fatalf("decoded event %T does not implement CorrelatedEvent", decoded)
 			}
 			got := correlated.Correlation()
-			if got.CorrelationKey != corr.CorrelationKey || got.ProviderCallID != corr.ProviderCallID || got.SegmentID != corr.SegmentID || got.ToolCallID != corr.ToolCallID {
+			if got.RunID != corr.RunID || got.ProviderCallID != corr.ProviderCallID || got.SegmentID != corr.SegmentID || got.ToolCallID != corr.ToolCallID {
 				t.Fatalf("correlation mismatch: got %+v want %+v", got, corr)
 			}
 		})
@@ -91,19 +77,19 @@ func TestCanonicalEventsRoundTripCorrelation(t *testing.T) {
 func TestValidateCanonicalEventRejectsMissingCorrelationFields(t *testing.T) {
 	metadata := EventMetadata{SessionID: "session-1", InferenceID: "inference-1", TurnID: "turn-1"}
 
-	if err := ValidateCanonicalEvent(NewTextDeltaEvent(metadata, Correlation{CorrelationKey: "text"}, "x", "x", 1)); err == nil {
+	if err := ValidateCanonicalEvent(NewTextDeltaEvent(metadata, Correlation{RunID: "run-1", ProviderCallID: "provider-1"}, "x", "x", 1)); err == nil {
 		t.Fatalf("expected text delta without segment_id to fail validation")
 	}
 
-	if err := ValidateCanonicalEvent(NewProviderCallFinishedEvent(metadata, Correlation{CorrelationKey: "provider"}, "end_turn", "completed", nil, nil, false)); err == nil {
+	if err := ValidateCanonicalEvent(NewProviderCallFinishedEvent(metadata, Correlation{RunID: "run-1"}, "end_turn", "completed", nil, nil, false)); err == nil {
 		t.Fatalf("expected provider finish without provider_call_id to fail validation")
 	}
 
-	if err := ValidateCanonicalEvent(NewToolCallRequestedEvent(metadata, Correlation{CorrelationKey: "tool"}, "", "sql_doc", "{}")); err == nil {
+	if err := ValidateCanonicalEvent(NewToolCallRequestedEvent(metadata, Correlation{RunID: "run-1"}, "", "sql_doc", "{}")); err == nil {
 		t.Fatalf("expected tool request without tool_call_id to fail validation")
 	}
 
-	if err := ValidateCanonicalEvent(NewTextDeltaEvent(metadata, Correlation{SegmentID: "segment-1"}, "x", "x", 1)); err == nil {
-		t.Fatalf("expected text delta without correlation_key to fail validation")
+	if err := ValidateCanonicalEvent(NewTextDeltaEvent(metadata, Correlation{RunID: "run-1", SegmentID: "segment-1"}, "x", "x", 1)); err == nil {
+		t.Fatalf("expected text delta without provider_call_id to fail validation")
 	}
 }

--- a/pkg/events/correlation.go
+++ b/pkg/events/correlation.go
@@ -1,43 +1,22 @@
 package events
 
-// Correlation carries stable identity for joining provider objects, Geppetto
-// events, Pinocchio backend events, frontend frames, timeline entities, and
-// debug SQLite rows. New canonical events should expose this struct directly
-// instead of requiring consumers to inspect EventMetadata.Extra.
+// Correlation carries the canonical identity needed to join provider objects,
+// Geppetto events, Pinocchio backend events, frontend frames, timeline entities,
+// and debug SQLite rows. It intentionally contains only explicit IDs.
+//
+// Provider-native fields (response IDs, item IDs, output indexes, choice indexes,
+// model names, provider names, etc.) belong in observability/debug records or in
+// provider-specific adapter state. Canonical routing must use these IDs only.
 type Correlation struct {
 	// Application/runtime scope.
-	SessionID   string `json:"session_id,omitempty" yaml:"session_id,omitempty" mapstructure:"session_id,omitempty"`
-	RunID       string `json:"run_id,omitempty" yaml:"run_id,omitempty" mapstructure:"run_id,omitempty"`
-	InferenceID string `json:"inference_id,omitempty" yaml:"inference_id,omitempty" mapstructure:"inference_id,omitempty"`
-	TurnID      string `json:"turn_id,omitempty" yaml:"turn_id,omitempty" mapstructure:"turn_id,omitempty"`
+	SessionID string `json:"session_id,omitempty" yaml:"session_id,omitempty" mapstructure:"session_id,omitempty"`
+	RunID     string `json:"run_id,omitempty" yaml:"run_id,omitempty" mapstructure:"run_id,omitempty"`
+	TurnID    string `json:"turn_id,omitempty" yaml:"turn_id,omitempty" mapstructure:"turn_id,omitempty"`
 
-	// Provider-call scope.
-	ProviderCallID    string `json:"provider_call_id,omitempty" yaml:"provider_call_id,omitempty" mapstructure:"provider_call_id,omitempty"`
-	ProviderCallIndex int32  `json:"provider_call_index,omitempty" yaml:"provider_call_index,omitempty" mapstructure:"provider_call_index,omitempty"`
-	Provider          string `json:"provider,omitempty" yaml:"provider,omitempty" mapstructure:"provider,omitempty"`
-	Model             string `json:"model,omitempty" yaml:"model,omitempty" mapstructure:"model,omitempty"`
-	ResponseID        string `json:"response_id,omitempty" yaml:"response_id,omitempty" mapstructure:"response_id,omitempty"`
-
-	// Provider item/block scope.
-	ItemID            string `json:"item_id,omitempty" yaml:"item_id,omitempty" mapstructure:"item_id,omitempty"`
-	OutputIndex       *int32 `json:"output_index,omitempty" yaml:"output_index,omitempty" mapstructure:"output_index,omitempty"`
-	SummaryIndex      *int32 `json:"summary_index,omitempty" yaml:"summary_index,omitempty" mapstructure:"summary_index,omitempty"`
-	ChoiceIndex       *int32 `json:"choice_index,omitempty" yaml:"choice_index,omitempty" mapstructure:"choice_index,omitempty"`
-	ContentBlockIndex *int32 `json:"content_block_index,omitempty" yaml:"content_block_index,omitempty" mapstructure:"content_block_index,omitempty"`
-
-	// Transcript segment scope.
-	SegmentID    string `json:"segment_id,omitempty" yaml:"segment_id,omitempty" mapstructure:"segment_id,omitempty"`
-	SegmentIndex int32  `json:"segment_index,omitempty" yaml:"segment_index,omitempty" mapstructure:"segment_index,omitempty"`
-	SegmentType  string `json:"segment_type,omitempty" yaml:"segment_type,omitempty" mapstructure:"segment_type,omitempty"`
-	StreamKind   string `json:"stream_kind,omitempty" yaml:"stream_kind,omitempty" mapstructure:"stream_kind,omitempty"`
-
-	// Tool scope.
-	ToolCallID    string `json:"tool_call_id,omitempty" yaml:"tool_call_id,omitempty" mapstructure:"tool_call_id,omitempty"`
-	ToolCallIndex *int32 `json:"tool_call_index,omitempty" yaml:"tool_call_index,omitempty" mapstructure:"tool_call_index,omitempty"`
-
-	// Normalized join keys.
-	CorrelationKey       string `json:"correlation_key,omitempty" yaml:"correlation_key,omitempty" mapstructure:"correlation_key,omitempty"`
-	ParentCorrelationKey string `json:"parent_correlation_key,omitempty" yaml:"parent_correlation_key,omitempty" mapstructure:"parent_correlation_key,omitempty"`
+	// Canonical lifecycle identities.
+	ProviderCallID string `json:"provider_call_id,omitempty" yaml:"provider_call_id,omitempty" mapstructure:"provider_call_id,omitempty"`
+	SegmentID      string `json:"segment_id,omitempty" yaml:"segment_id,omitempty" mapstructure:"segment_id,omitempty"`
+	ToolCallID     string `json:"tool_call_id,omitempty" yaml:"tool_call_id,omitempty" mapstructure:"tool_call_id,omitempty"`
 }
 
 // CorrelatedEvent is implemented by canonical events that carry typed

--- a/pkg/events/correlation_builders.go
+++ b/pkg/events/correlation_builders.go
@@ -153,29 +153,3 @@ func BuildClaudeSegmentCorrelation(provider, providerCallID string, contentBlock
 	}
 	return corr
 }
-
-func streamKindForSegmentType(segmentType string) string {
-	switch segmentType {
-	case SegmentTypeText:
-		return StreamKindContent
-	case SegmentTypeReasoning:
-		return StreamKindReasoning
-	case SegmentTypeTool:
-		return StreamKindToolCall
-	default:
-		return ""
-	}
-}
-
-func segmentTypeForStreamKind(streamKind string) string {
-	switch streamKind {
-	case StreamKindContent:
-		return SegmentTypeText
-	case StreamKindReasoning, "reasoning-summary":
-		return SegmentTypeReasoning
-	case StreamKindToolCall:
-		return SegmentTypeTool
-	default:
-		return ""
-	}
-}

--- a/pkg/events/correlation_builders.go
+++ b/pkg/events/correlation_builders.go
@@ -7,9 +7,6 @@ import (
 )
 
 const (
-	maxInt32Value = int64(1<<31 - 1)
-	minInt32Value = -1 << 31
-
 	SegmentTypeText      = "text"
 	SegmentTypeReasoning = "reasoning"
 	SegmentTypeTool      = "tool"
@@ -19,169 +16,71 @@ const (
 	StreamKindToolCall  = "tool_call"
 )
 
-// BuildProviderCallCorrelation creates a provider-call identity that is stable
-// before provider-native response IDs are known. The provider response ID is
-// preserved separately in ResponseID when available.
-func BuildProviderCallCorrelation(provider, inferenceID, runID string, providerCallIndex int, responseID string) Correlation {
-	provider = strings.TrimSpace(provider)
-	inferenceID = strings.TrimSpace(inferenceID)
-	runID = strings.TrimSpace(runID)
-	responseID = strings.TrimSpace(responseID)
+// BuildRunCorrelation creates the canonical run-level identity.
+func BuildRunCorrelation(sessionID, runID, turnID string) Correlation {
+	return Correlation{
+		SessionID: strings.TrimSpace(sessionID),
+		RunID:     strings.TrimSpace(runID),
+		TurnID:    strings.TrimSpace(turnID),
+	}
+}
 
-	scopeID := runID
-	if scopeID == "" {
-		scopeID = inferenceID
-	}
-	corr := Correlation{
-		Provider:          provider,
-		InferenceID:       inferenceID,
-		RunID:             runID,
-		ResponseID:        responseID,
-		ProviderCallIndex: checkedInt32(providerCallIndex),
-	}
-	if provider != "" && scopeID != "" {
-		corr.ProviderCallID = fmt.Sprintf("%s:%s:provider-call:%d", provider, scopeID, providerCallIndex)
-		corr.CorrelationKey = corr.ProviderCallID
+// BuildProviderCallCorrelation creates a provider-call identity that is stable
+// before provider-native response IDs are known. The index is used only to build
+// a deterministic ID; it is not exposed as canonical correlation state.
+func BuildProviderCallCorrelation(provider, runID, _ string, providerCallIndex int, _ string) Correlation {
+	provider = strings.TrimSpace(provider)
+	runID = strings.TrimSpace(runID)
+	corr := Correlation{RunID: runID}
+	if provider != "" && runID != "" {
+		corr.ProviderCallID = fmt.Sprintf("%s:%s:provider-call:%d", provider, runID, providerCallIndex)
 	}
 	return corr
 }
 
 // BuildSegmentCorrelation creates a segment identity nested under a provider
 // call. The provider object ID is optional; when present it is used to make the
-// correlation key provider-native without involving rendered chat message IDs.
-func BuildSegmentCorrelation(parent Correlation, providerObjectID string, segmentIndex int, segmentType string) Correlation {
+// segment ID provider-native without involving rendered chat message IDs.
+func BuildSegmentCorrelation(parent Correlation, providerObjectID string, segmentOrdinal int, segmentType string) Correlation {
 	providerObjectID = strings.TrimSpace(providerObjectID)
 	segmentType = strings.TrimSpace(segmentType)
 
 	corr := parent
-	idx := checkedInt32(segmentIndex)
-	corr.SegmentIndex = idx
-	corr.SegmentType = segmentType
-	corr.StreamKind = streamKindForSegmentType(segmentType)
-	corr.ParentCorrelationKey = parent.CorrelationKey
-	if providerObjectID != "" {
-		corr.ItemID = providerObjectID
-	}
 	if parent.ProviderCallID != "" && segmentType != "" {
 		objectPart := "segment"
 		if providerObjectID != "" {
 			objectPart = providerObjectID
 		}
-		corr.SegmentID = fmt.Sprintf("%s:%s:%d:%s", parent.ProviderCallID, objectPart, segmentIndex, segmentType)
-		corr.CorrelationKey = corr.SegmentID
+		corr.SegmentID = fmt.Sprintf("%s:%s:%d:%s", parent.ProviderCallID, objectPart, segmentOrdinal, segmentType)
 	}
 	return corr
 }
 
-// BuildChatCompletionsCorrelation creates the normalized identity used for
-// OpenAI-compatible streamed Chat Completions. Provider-native object IDs remain
-// in ResponseID/ToolCallID; CorrelationKey is the stable cross-layer join key.
+// BuildToolCorrelation creates a canonical tool identity under a provider call.
+func BuildToolCorrelation(parent Correlation, toolCallID string) Correlation {
+	corr := parent
+	corr.ToolCallID = strings.TrimSpace(toolCallID)
+	return corr
+}
+
+// BuildChatCompletionsCorrelation creates the normalized segment identity used
+// for OpenAI-compatible streamed Chat Completions.
 func BuildChatCompletionsCorrelation(provider, responseID string, choiceIndex *int, streamKind, toolCallID string, toolCallIndex *int) Correlation {
+	segmentID := ChatCompletionsSegmentID(provider, responseID, choiceIndex, streamKind, toolCallID, toolCallIndex)
+	corr := Correlation{SegmentID: segmentID}
+	if strings.TrimSpace(toolCallID) != "" {
+		corr.ToolCallID = strings.TrimSpace(toolCallID)
+	}
+	return corr
+}
+
+// ChatCompletionsSegmentID returns the opaque canonical segment ID for an
+// OpenAI-compatible Chat Completions stream.
+func ChatCompletionsSegmentID(provider, responseID string, choiceIndex *int, streamKind, toolCallID string, toolCallIndex *int) string {
 	provider = strings.TrimSpace(provider)
 	responseID = strings.TrimSpace(responseID)
 	streamKind = strings.TrimSpace(streamKind)
 	toolCallID = strings.TrimSpace(toolCallID)
-
-	corr := Correlation{
-		Provider:       provider,
-		ResponseID:     responseID,
-		StreamKind:     streamKind,
-		ToolCallID:     toolCallID,
-		SegmentType:    segmentTypeForStreamKind(streamKind),
-		CorrelationKey: chatCompletionsCorrelationKey(provider, responseID, choiceIndex, streamKind, toolCallID, toolCallIndex),
-	}
-	if choiceIndex != nil {
-		v := checkedInt32(*choiceIndex)
-		corr.ChoiceIndex = &v
-	}
-	if toolCallIndex != nil {
-		v := checkedInt32(*toolCallIndex)
-		corr.ToolCallIndex = &v
-	}
-	return corr
-}
-
-// BuildResponsesCorrelation creates the normalized identity for OpenAI
-// Responses API stream items and summaries while preserving provider-native
-// item IDs.
-func BuildResponsesCorrelation(provider, responseID, itemID string, outputIndex, summaryIndex *int) Correlation {
-	provider = strings.TrimSpace(provider)
-	responseID = strings.TrimSpace(responseID)
-	itemID = strings.TrimSpace(itemID)
-
-	corr := Correlation{
-		Provider:       provider,
-		ResponseID:     responseID,
-		ItemID:         itemID,
-		CorrelationKey: responsesCorrelationKey(provider, responseID, itemID, outputIndex, summaryIndex),
-	}
-	if outputIndex != nil {
-		v := checkedInt32(*outputIndex)
-		corr.OutputIndex = &v
-	}
-	if summaryIndex != nil {
-		v := checkedInt32(*summaryIndex)
-		corr.SummaryIndex = &v
-	}
-	return corr
-}
-
-// BuildClaudeProviderCallCorrelation creates the provider-call envelope identity
-// for Anthropic/Claude message streams.
-func BuildClaudeProviderCallCorrelation(provider, responseID string, providerCallIndex int) Correlation {
-	provider = strings.TrimSpace(provider)
-	responseID = strings.TrimSpace(responseID)
-	corr := Correlation{
-		Provider:          provider,
-		ResponseID:        responseID,
-		ProviderCallIndex: checkedInt32(providerCallIndex),
-	}
-	if responseID != "" {
-		corr.ProviderCallID = responseID
-	} else if provider != "" {
-		corr.ProviderCallID = fmt.Sprintf("%s-provider-call-%d", provider, providerCallIndex)
-	}
-	if provider != "" && corr.ProviderCallID != "" {
-		corr.CorrelationKey = fmt.Sprintf("%s:%s:provider-call", provider, corr.ProviderCallID)
-	}
-	return corr
-}
-
-// BuildClaudeSegmentCorrelation creates content-block identity beneath a Claude
-// provider-call envelope. ContentBlockIndex is provider-native and stable within
-// a single message stream.
-func BuildClaudeSegmentCorrelation(provider, providerCallID string, contentBlockIndex int, segmentType string) Correlation {
-	provider = strings.TrimSpace(provider)
-	providerCallID = strings.TrimSpace(providerCallID)
-	segmentType = strings.TrimSpace(segmentType)
-	idx := checkedInt32(contentBlockIndex)
-	corr := Correlation{
-		Provider:          provider,
-		ProviderCallID:    providerCallID,
-		ContentBlockIndex: &idx,
-		SegmentIndex:      idx,
-		SegmentType:       segmentType,
-		StreamKind:        streamKindForSegmentType(segmentType),
-	}
-	if provider != "" && providerCallID != "" && segmentType != "" {
-		corr.SegmentID = fmt.Sprintf("%s:block:%d:%s", providerCallID, contentBlockIndex, segmentType)
-		corr.CorrelationKey = fmt.Sprintf("%s:%s:block:%d:%s", provider, providerCallID, contentBlockIndex, segmentType)
-		corr.ParentCorrelationKey = fmt.Sprintf("%s:%s:provider-call", provider, providerCallID)
-	}
-	return corr
-}
-
-func checkedInt32(v int) int32 {
-	if int64(v) > maxInt32Value {
-		return int32(maxInt32Value)
-	}
-	if v < minInt32Value {
-		return int32(minInt32Value)
-	}
-	return int32(v)
-}
-
-func chatCompletionsCorrelationKey(provider, responseID string, choiceIndex *int, streamKind, toolCallID string, toolCallIndex *int) string {
 	if provider == "" || responseID == "" || streamKind == "" || streamKind == "unknown" {
 		return ""
 	}
@@ -200,7 +99,19 @@ func chatCompletionsCorrelationKey(provider, responseID string, choiceIndex *int
 	return fmt.Sprintf("%s-chat:%s:choice:%d:%s", provider, responseID, choice, streamKind)
 }
 
-func responsesCorrelationKey(provider, responseID, itemID string, outputIndex, summaryIndex *int) string {
+// BuildResponsesCorrelation creates the normalized segment identity for OpenAI
+// Responses API stream items and summaries while preserving provider-native
+// item IDs inside the opaque SegmentID.
+func BuildResponsesCorrelation(provider, responseID, itemID string, outputIndex, summaryIndex *int) Correlation {
+	return Correlation{SegmentID: ResponsesSegmentID(provider, responseID, itemID, outputIndex, summaryIndex)}
+}
+
+// ResponsesSegmentID returns the opaque canonical segment ID for an OpenAI
+// Responses item/output/summary.
+func ResponsesSegmentID(provider, responseID, itemID string, outputIndex, summaryIndex *int) string {
+	provider = strings.TrimSpace(provider)
+	responseID = strings.TrimSpace(responseID)
+	itemID = strings.TrimSpace(itemID)
 	if provider == "" || responseID == "" {
 		return ""
 	}
@@ -216,17 +127,31 @@ func responsesCorrelationKey(provider, responseID, itemID string, outputIndex, s
 	return provider + ":" + responseID
 }
 
-func segmentTypeForStreamKind(streamKind string) string {
-	switch streamKind {
-	case StreamKindContent:
-		return SegmentTypeText
-	case StreamKindReasoning:
-		return SegmentTypeReasoning
-	case StreamKindToolCall:
-		return SegmentTypeTool
-	default:
-		return ""
+// BuildClaudeProviderCallCorrelation creates the provider-call envelope identity
+// for Anthropic/Claude message streams.
+func BuildClaudeProviderCallCorrelation(provider, responseID string, providerCallIndex int) Correlation {
+	provider = strings.TrimSpace(provider)
+	responseID = strings.TrimSpace(responseID)
+	corr := Correlation{}
+	if responseID != "" {
+		corr.ProviderCallID = provider + ":" + responseID
+	} else if provider != "" {
+		corr.ProviderCallID = fmt.Sprintf("%s-provider-call-%d", provider, providerCallIndex)
 	}
+	return corr
+}
+
+// BuildClaudeSegmentCorrelation creates content-block identity beneath a Claude
+// provider-call envelope. ContentBlockIndex remains internal to ID construction.
+func BuildClaudeSegmentCorrelation(provider, providerCallID string, contentBlockIndex int, segmentType string) Correlation {
+	provider = strings.TrimSpace(provider)
+	providerCallID = strings.TrimSpace(providerCallID)
+	segmentType = strings.TrimSpace(segmentType)
+	corr := Correlation{ProviderCallID: providerCallID}
+	if provider != "" && providerCallID != "" && segmentType != "" {
+		corr.SegmentID = fmt.Sprintf("%s:%s:block:%d:%s", provider, providerCallID, contentBlockIndex, segmentType)
+	}
+	return corr
 }
 
 func streamKindForSegmentType(segmentType string) string {
@@ -237,6 +162,19 @@ func streamKindForSegmentType(segmentType string) string {
 		return StreamKindReasoning
 	case SegmentTypeTool:
 		return StreamKindToolCall
+	default:
+		return ""
+	}
+}
+
+func segmentTypeForStreamKind(streamKind string) string {
+	switch streamKind {
+	case StreamKindContent:
+		return SegmentTypeText
+	case StreamKindReasoning, "reasoning-summary":
+		return SegmentTypeReasoning
+	case StreamKindToolCall:
+		return SegmentTypeTool
 	default:
 		return ""
 	}

--- a/pkg/events/correlation_builders_test.go
+++ b/pkg/events/correlation_builders_test.go
@@ -4,34 +4,22 @@ import "testing"
 
 func TestBuildProviderCallCorrelation(t *testing.T) {
 	corr := BuildProviderCallCorrelation("claude", "inference-1", "", 3, "msg_late")
+	if corr.RunID != "inference-1" {
+		t.Fatalf("run id mismatch: %+v", corr)
+	}
 	if corr.ProviderCallID != "claude:inference-1:provider-call:3" {
 		t.Fatalf("provider call id mismatch: %+v", corr)
-	}
-	if corr.ResponseID != "msg_late" {
-		t.Fatalf("response id should remain provider-native metadata: %+v", corr)
-	}
-	if corr.CorrelationKey != corr.ProviderCallID {
-		t.Fatalf("provider call key should be independent from response id: %+v", corr)
 	}
 }
 
 func TestBuildSegmentCorrelation(t *testing.T) {
 	parent := BuildProviderCallCorrelation("openai", "inference-1", "run-1", 1, "resp_1")
 	segment := BuildSegmentCorrelation(parent, "item_1", 2, SegmentTypeText)
-	if segment.SegmentID == "" || segment.CorrelationKey == "" {
-		t.Fatalf("segment identity missing: %+v", segment)
+	if segment.RunID != parent.RunID || segment.ProviderCallID != parent.ProviderCallID {
+		t.Fatalf("parent identity not preserved: segment=%+v parent=%+v", segment, parent)
 	}
-	if segment.SegmentID != "openai:run-1:provider-call:1:item_1:2:text" {
+	if segment.SegmentID != "openai:inference-1:provider-call:1:item_1:2:text" {
 		t.Fatalf("segment id mismatch: got %q", segment.SegmentID)
-	}
-	if segment.CorrelationKey != segment.SegmentID {
-		t.Fatalf("segment key should match segment id: got %q want %q", segment.CorrelationKey, segment.SegmentID)
-	}
-	if segment.ParentCorrelationKey != parent.CorrelationKey {
-		t.Fatalf("parent key mismatch: got %q want %q", segment.ParentCorrelationKey, parent.CorrelationKey)
-	}
-	if segment.SegmentType != SegmentTypeText || segment.StreamKind != StreamKindContent {
-		t.Fatalf("segment type/stream kind mismatch: %+v", segment)
 	}
 }
 
@@ -42,37 +30,34 @@ func TestBuildChatCompletionsCorrelation(t *testing.T) {
 	tests := []struct {
 		name string
 		corr Correlation
-		key  string
+		id   string
 	}{
 		{
 			name: "content",
 			corr: BuildChatCompletionsCorrelation("openai", "chatcmpl_1", &choice, StreamKindContent, "", nil),
-			key:  "openai-chat:chatcmpl_1:choice:1:content",
+			id:   "openai-chat:chatcmpl_1:choice:1:content",
 		},
 		{
 			name: "reasoning",
 			corr: BuildChatCompletionsCorrelation("openai", "chatcmpl_1", &choice, StreamKindReasoning, "", nil),
-			key:  "openai-chat:chatcmpl_1:choice:1:reasoning",
+			id:   "openai-chat:chatcmpl_1:choice:1:reasoning",
 		},
 		{
 			name: "tool id",
 			corr: BuildChatCompletionsCorrelation("openai", "chatcmpl_1", &choice, StreamKindToolCall, "call_1", &toolIndex),
-			key:  "openai-chat:chatcmpl_1:choice:1:tool:call_1",
+			id:   "openai-chat:chatcmpl_1:choice:1:tool:call_1",
 		},
 		{
 			name: "tool index fallback",
 			corr: BuildChatCompletionsCorrelation("openai", "chatcmpl_1", &choice, StreamKindToolCall, "", &toolIndex),
-			key:  "openai-chat:chatcmpl_1:choice:1:tool-index:2",
+			id:   "openai-chat:chatcmpl_1:choice:1:tool-index:2",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.corr.CorrelationKey != tt.key {
-				t.Fatalf("key mismatch: got %q want %q", tt.corr.CorrelationKey, tt.key)
-			}
-			if tt.corr.ChoiceIndex == nil || *tt.corr.ChoiceIndex != 1 {
-				t.Fatalf("choice index not preserved: %+v", tt.corr.ChoiceIndex)
+			if tt.corr.SegmentID != tt.id {
+				t.Fatalf("segment id mismatch: got %q want %q", tt.corr.SegmentID, tt.id)
 			}
 		})
 	}
@@ -82,37 +67,31 @@ func TestBuildResponsesCorrelation(t *testing.T) {
 	output := 3
 	summary := 4
 
-	if got := BuildResponsesCorrelation("openai", "resp_1", "item_1", &output, &summary).CorrelationKey; got != "openai:resp_1:item:item_1" {
+	if got := BuildResponsesCorrelation("openai", "resp_1", "item_1", &output, &summary).SegmentID; got != "openai:resp_1:item:item_1" {
 		t.Fatalf("item key mismatch: %q", got)
 	}
-	if got := BuildResponsesCorrelation("openai", "resp_1", "", &output, &summary).CorrelationKey; got != "openai:resp_1:output:3:summary:4" {
+	if got := BuildResponsesCorrelation("openai", "resp_1", "", &output, &summary).SegmentID; got != "openai:resp_1:output:3:summary:4" {
 		t.Fatalf("summary key mismatch: %q", got)
 	}
-	if got := BuildResponsesCorrelation("openai", "resp_1", "", &output, nil).CorrelationKey; got != "openai:resp_1:output:3" {
+	if got := BuildResponsesCorrelation("openai", "resp_1", "", &output, nil).SegmentID; got != "openai:resp_1:output:3" {
 		t.Fatalf("output key mismatch: %q", got)
 	}
-	if got := BuildResponsesCorrelation("openai", "resp_1", "", nil, nil).CorrelationKey; got != "openai:resp_1" {
+	if got := BuildResponsesCorrelation("openai", "resp_1", "", nil, nil).SegmentID; got != "openai:resp_1" {
 		t.Fatalf("response key mismatch: %q", got)
 	}
 }
 
 func TestBuildClaudeCorrelation(t *testing.T) {
 	providerCall := BuildClaudeProviderCallCorrelation("claude", "msg_1", 7)
-	if providerCall.ProviderCallID != "msg_1" {
+	if providerCall.ProviderCallID != "claude:msg_1" {
 		t.Fatalf("provider call id mismatch: %+v", providerCall)
-	}
-	if providerCall.CorrelationKey != "claude:msg_1:provider-call" {
-		t.Fatalf("provider key mismatch: %q", providerCall.CorrelationKey)
 	}
 
 	segment := BuildClaudeSegmentCorrelation("claude", providerCall.ProviderCallID, 2, SegmentTypeText)
-	if segment.SegmentID != "msg_1:block:2:text" {
+	if segment.ProviderCallID != providerCall.ProviderCallID {
+		t.Fatalf("provider call id not preserved: %+v", segment)
+	}
+	if segment.SegmentID != "claude:claude:msg_1:block:2:text" {
 		t.Fatalf("segment id mismatch: %q", segment.SegmentID)
-	}
-	if segment.CorrelationKey != "claude:msg_1:block:2:text" {
-		t.Fatalf("segment key mismatch: %q", segment.CorrelationKey)
-	}
-	if segment.ParentCorrelationKey != providerCall.CorrelationKey {
-		t.Fatalf("parent key mismatch: got %q want %q", segment.ParentCorrelationKey, providerCall.CorrelationKey)
 	}
 }

--- a/pkg/events/correlation_validation.go
+++ b/pkg/events/correlation_validation.go
@@ -2,9 +2,10 @@ package events
 
 import "fmt"
 
-// ValidateCanonicalEvent verifies the non-negotiable identity fields for the new
-// hard-cutover event vocabulary. Provider adapters and downstream bridges can use
-// this as a cheap guard before publishing/transporting canonical events.
+// ValidateCanonicalEvent verifies the non-negotiable identity fields for the
+// hard-cutover event vocabulary. Correlation is intentionally small: run,
+// provider-call, segment, and tool identities are explicit IDs. There are no
+// fallback join keys.
 func ValidateCanonicalEvent(event Event) error {
 	correlated, ok := event.(CorrelatedEvent)
 	if !ok {
@@ -12,30 +13,39 @@ func ValidateCanonicalEvent(event Event) error {
 	}
 
 	corr := correlated.Correlation()
-	if corr.CorrelationKey == "" {
-		return fmt.Errorf("event %s missing correlation_key", event.Type())
-	}
 
-	//nolint:exhaustive // Validation groups canonical scopes and lets run/future events use the common correlation_key guard.
+	//nolint:exhaustive // Validation groups canonical scopes and future events must be added deliberately.
 	switch event.Type() {
+	case EventTypeRunStarted, EventTypeRunFinished, EventTypeRunStopped, EventTypeRunFailed:
+		if corr.RunID == "" {
+			return fmt.Errorf("event %s missing run_id", event.Type())
+		}
 	case EventTypeProviderCallStarted, EventTypeProviderCallMetadataUpdated, EventTypeProviderCallFinished:
+		if corr.RunID == "" {
+			return fmt.Errorf("event %s missing run_id", event.Type())
+		}
 		if corr.ProviderCallID == "" {
 			return fmt.Errorf("event %s missing provider_call_id", event.Type())
 		}
 	case EventTypeTextSegmentStarted, EventTypeTextDelta, EventTypeTextSegmentFinished,
 		EventTypeReasoningSegmentStarted, EventTypeReasoningDelta, EventTypeReasoningSegmentFinished:
+		if corr.RunID == "" {
+			return fmt.Errorf("event %s missing run_id", event.Type())
+		}
+		if corr.ProviderCallID == "" {
+			return fmt.Errorf("event %s missing provider_call_id", event.Type())
+		}
 		if corr.SegmentID == "" {
 			return fmt.Errorf("event %s missing segment_id", event.Type())
 		}
 	case EventTypeToolCallStarted, EventTypeToolCallArgumentsDelta, EventTypeToolCallRequested,
 		EventTypeToolExecutionStarted, EventTypeToolResultReady, EventTypeToolCallFinished:
+		if corr.RunID == "" {
+			return fmt.Errorf("event %s missing run_id", event.Type())
+		}
 		if corr.ToolCallID == "" {
 			return fmt.Errorf("event %s missing tool_call_id", event.Type())
 		}
-	default:
-		// Run lifecycle and future canonical event types only require the common
-		// typed correlation_key unless they are added to one of the stricter
-		// scopes above.
 	}
 
 	return nil

--- a/pkg/events/structuredsink/filtering_sink.go
+++ b/pkg/events/structuredsink/filtering_sink.go
@@ -194,8 +194,8 @@ func streamStateKey(meta events.EventMetadata, corr events.Correlation) string {
 	if corr.SegmentID != "" {
 		return corr.SegmentID
 	}
-	if corr.CorrelationKey != "" {
-		return corr.CorrelationKey
+	if corr.ProviderCallID != "" {
+		return corr.ProviderCallID
 	}
 	return meta.ID.String()
 }

--- a/pkg/inference/session/context.go
+++ b/pkg/inference/session/context.go
@@ -5,9 +5,10 @@ import "context"
 type sessionMetaContextKey string
 
 const (
-	sessionIDContextKey   sessionMetaContextKey = "session_id"
-	inferenceIDContextKey sessionMetaContextKey = "inference_id"
-	runTagsContextKey     sessionMetaContextKey = "run_tags"
+	sessionIDContextKey         sessionMetaContextKey = "session_id"
+	inferenceIDContextKey       sessionMetaContextKey = "inference_id"
+	providerCallIndexContextKey sessionMetaContextKey = "provider_call_index"
+	runTagsContextKey           sessionMetaContextKey = "run_tags"
 )
 
 // WithSessionMeta stores session and inference identifiers in context so
@@ -43,6 +44,28 @@ func InferenceIDFromContext(ctx context.Context) string {
 	}
 	inferenceID, _ := ctx.Value(inferenceIDContextKey).(string)
 	return inferenceID
+}
+
+// WithProviderCallIndex stores the zero-based provider-call index for the
+// current inference step within a larger run/tool loop.
+func WithProviderCallIndex(ctx context.Context, index int) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if index < 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, providerCallIndexContextKey, index)
+}
+
+// ProviderCallIndexFromContext returns the zero-based provider-call index for
+// the current inference step, when a higher-level runner/tool loop supplied it.
+func ProviderCallIndexFromContext(ctx context.Context) (int, bool) {
+	if ctx == nil {
+		return 0, false
+	}
+	index, ok := ctx.Value(providerCallIndexContextKey).(int)
+	return index, ok
 }
 
 // WithRunTags stores per-run tags in context for downstream callbacks.

--- a/pkg/inference/session/context_test.go
+++ b/pkg/inference/session/context_test.go
@@ -34,6 +34,23 @@ func TestSessionMetaAccessorsMissing(t *testing.T) {
 	}
 }
 
+func TestWithProviderCallIndexRoundTrip(t *testing.T) {
+	ctx := WithProviderCallIndex(context.Background(), 2)
+	got, ok := ProviderCallIndexFromContext(ctx)
+	if !ok {
+		t.Fatalf("ProviderCallIndexFromContext() ok = false, want true")
+	}
+	if got != 2 {
+		t.Fatalf("ProviderCallIndexFromContext() = %d, want 2", got)
+	}
+}
+
+func TestProviderCallIndexAccessorsMissing(t *testing.T) {
+	if got, ok := ProviderCallIndexFromContext(context.Background()); ok || got != 0 {
+		t.Fatalf("ProviderCallIndexFromContext() = (%d, %v), want (0, false)", got, ok)
+	}
+}
+
 func TestWithRunTagsRoundTrip(t *testing.T) {
 	ctx := WithRunTags(context.Background(), map[string]any{"request_id": "r-1", "attempt": 2})
 	tags := RunTagsFromContext(ctx)

--- a/pkg/inference/toolloop/loop.go
+++ b/pkg/inference/toolloop/loop.go
@@ -291,7 +291,7 @@ func (l *Loop) executeTools(ctx context.Context, toolCalls []toolblocks.ToolCall
 	execCalls := make([]tools.ToolCall, 0, len(toolCalls))
 	for _, call := range toolCalls {
 		argBytes, _ := json.Marshal(call.Arguments)
-		execCalls = append(execCalls, tools.ToolCall{ID: call.ID, Name: call.Name, Arguments: json.RawMessage(argBytes)})
+		execCalls = append(execCalls, tools.ToolCall{ID: call.ID, Name: call.Name, Arguments: json.RawMessage(argBytes), Correlation: call.Correlation})
 	}
 
 	execResults, err := executor.ExecuteToolCalls(ctx, execCalls, registry)

--- a/pkg/inference/toolloop/loop.go
+++ b/pkg/inference/toolloop/loop.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-go-golems/geppetto/pkg/events"
 	"github.com/go-go-golems/geppetto/pkg/inference/engine"
+	gepsession "github.com/go-go-golems/geppetto/pkg/inference/session"
 	"github.com/go-go-golems/geppetto/pkg/inference/tools"
 	"github.com/go-go-golems/geppetto/pkg/turns"
 	"github.com/go-go-golems/geppetto/pkg/turns/toolblocks"
@@ -128,7 +129,8 @@ func (l *Loop) RunLoop(ctx context.Context, initialTurn *turns.Turn) (*turns.Tur
 		log.Debug().Int("iteration", i+1).Msg("toolloop: engine inference step")
 
 		l.snapshot(ctx, t, "pre_inference")
-		updated, err := l.eng.RunInference(ctx, t)
+		iterationCtx := gepsession.WithProviderCallIndex(ctx, i)
+		updated, err := l.eng.RunInference(iterationCtx, t)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/inference/toolloop/loop_test.go
+++ b/pkg/inference/toolloop/loop_test.go
@@ -211,6 +211,65 @@ func TestLoop_ExecutesToolsAndEmitsPauseEventsWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestLoopExecuteToolsPreservesToolCallCorrelationForDefaultExecutor(t *testing.T) {
+	t.Parallel()
+
+	reg := tools.NewInMemoryToolRegistry()
+	type echoIn struct {
+		Text string `json:"text"`
+	}
+	echoTool, err := tools.NewToolFromFunc("echo", "Echo back the provided text", func(in echoIn) (map[string]any, error) {
+		return map[string]any{"echo": in.Text}, nil
+	})
+	if err != nil {
+		t.Fatalf("NewToolFromFunc: %v", err)
+	}
+	if err := reg.RegisterTool("echo", *echoTool); err != nil {
+		t.Fatalf("RegisterTool: %v", err)
+	}
+
+	sink := &capturingSink{}
+	ctx := events.WithEventSinks(context.Background(), sink)
+	ctx = tools.WithRegistry(ctx, reg)
+	corr := events.Correlation{
+		SessionID:      "session-1",
+		RunID:          "run-1",
+		TurnID:         "turn-1",
+		ProviderCallID: "provider-call-1",
+		SegmentID:      "segment-1",
+		ToolCallID:     "call-1",
+	}
+	loop := New(WithToolConfig(tools.DefaultToolConfig()))
+
+	results := loop.executeTools(ctx, []toolblocks.ToolCall{{
+		ID:          "call-1",
+		Name:        "echo",
+		Arguments:   map[string]any{"text": "hello"},
+		Correlation: corr,
+	}})
+	if len(results) != 1 || results[0].Error != nil {
+		t.Fatalf("unexpected tool results: %#v", results)
+	}
+
+	sink.mu.Lock()
+	defer sink.mu.Unlock()
+	if len(sink.events) != 3 {
+		t.Fatalf("expected 3 execution lifecycle events, got %d: %#v", len(sink.events), sink.events)
+	}
+	for i, event := range sink.events {
+		correlated, ok := event.(events.CorrelatedEvent)
+		if !ok {
+			t.Fatalf("event %d is not correlated: %T", i, event)
+		}
+		if got := correlated.Correlation(); got != corr {
+			t.Fatalf("event %d correlation = %#v, want %#v", i, got, corr)
+		}
+		if err := events.ValidateCanonicalEvent(event); err != nil {
+			t.Fatalf("event %d should validate as canonical: %v", i, err)
+		}
+	}
+}
+
 func TestLoop_executeToolsRequiresContextRegistry(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/inference/toolloop/loop_test.go
+++ b/pkg/inference/toolloop/loop_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-go-golems/geppetto/pkg/events"
 	"github.com/go-go-golems/geppetto/pkg/inference/engine"
+	gepsession "github.com/go-go-golems/geppetto/pkg/inference/session"
 	"github.com/go-go-golems/geppetto/pkg/inference/tools"
 	"github.com/go-go-golems/geppetto/pkg/turns"
 	"github.com/go-go-golems/geppetto/pkg/turns/toolblocks"
@@ -16,6 +17,8 @@ import (
 
 type toolCallingFakeEngine struct {
 	calls               atomic.Int64
+	mu                  sync.Mutex
+	providerCallIndexes []int
 	sawToolConfig       bool
 	seenToolConfig      engine.ToolConfig
 	sawToolDefinitions  bool
@@ -24,6 +27,11 @@ type toolCallingFakeEngine struct {
 
 func (e *toolCallingFakeEngine) RunInference(ctx context.Context, t *turns.Turn) (*turns.Turn, error) {
 	callNum := e.calls.Add(1)
+	if idx, ok := gepsession.ProviderCallIndexFromContext(ctx); ok {
+		e.mu.Lock()
+		e.providerCallIndexes = append(e.providerCallIndexes, idx)
+		e.mu.Unlock()
+	}
 
 	if callNum == 1 && t != nil {
 		if cfg, ok, err := engine.KeyToolConfig.Get(t.Data); err == nil && ok {
@@ -124,6 +132,12 @@ func TestLoop_ExecutesToolsAndEmitsPauseEventsWhenEnabled(t *testing.T) {
 	}
 	if eng.calls.Load() < 2 {
 		t.Fatalf("expected engine to be called at least twice, got %d", eng.calls.Load())
+	}
+	eng.mu.Lock()
+	providerCallIndexes := append([]int(nil), eng.providerCallIndexes...)
+	eng.mu.Unlock()
+	if len(providerCallIndexes) < 2 || providerCallIndexes[0] != 0 || providerCallIndexes[1] != 1 {
+		t.Fatalf("provider call indexes = %v, want first two [0 1]", providerCallIndexes)
 	}
 	if !eng.sawToolConfig {
 		t.Fatalf("expected engine to see tool_config on the first inference turn")

--- a/pkg/inference/tools/base_executor.go
+++ b/pkg/inference/tools/base_executor.go
@@ -158,7 +158,12 @@ func (b *BaseToolExecutor) PublishResult(ctx context.Context, call ToolCall, res
 }
 
 func toolExecutionCorrelation(ctx context.Context, call ToolCall) events.Correlation {
-	if corr, ok := CurrentToolCorrelationFromContext(ctx); ok {
+	corr, ok := CurrentToolCorrelationFromContext(ctx)
+	if hasToolCallCorrelation(call.Correlation) {
+		corr = mergeToolCorrelation(corr, call.Correlation)
+		ok = true
+	}
+	if ok {
 		if corr.ToolCallID == "" {
 			corr.ToolCallID = call.ID
 		}
@@ -166,6 +171,32 @@ func toolExecutionCorrelation(ctx context.Context, call ToolCall) events.Correla
 	}
 
 	return events.Correlation{ToolCallID: call.ID}
+}
+
+func hasToolCallCorrelation(corr events.Correlation) bool {
+	return corr.SessionID != "" || corr.RunID != "" || corr.TurnID != "" || corr.ProviderCallID != "" || corr.SegmentID != "" || corr.ToolCallID != ""
+}
+
+func mergeToolCorrelation(base, overlay events.Correlation) events.Correlation {
+	if overlay.SessionID != "" {
+		base.SessionID = overlay.SessionID
+	}
+	if overlay.RunID != "" {
+		base.RunID = overlay.RunID
+	}
+	if overlay.TurnID != "" {
+		base.TurnID = overlay.TurnID
+	}
+	if overlay.ProviderCallID != "" {
+		base.ProviderCallID = overlay.ProviderCallID
+	}
+	if overlay.SegmentID != "" {
+		base.SegmentID = overlay.SegmentID
+	}
+	if overlay.ToolCallID != "" {
+		base.ToolCallID = overlay.ToolCallID
+	}
+	return base
 }
 
 func (b *BaseToolExecutor) ShouldRetry(_ context.Context, attempt int, _ *ToolResult, _ error) (bool, time.Duration) {
@@ -198,6 +229,9 @@ func (b *BaseToolExecutor) ExecuteToolCall(ctx context.Context, call ToolCall, r
 		return &ToolResult{ID: call.ID, Error: err.Error(), Duration: time.Since(start)}, nil
 	}
 	ctx = WithCurrentToolCall(ctx, call)
+	if hasToolCallCorrelation(call.Correlation) {
+		ctx = WithCurrentToolCorrelation(ctx, toolExecutionCorrelation(ctx, call))
+	}
 
 	// Lookup + allow checks
 	def, err := registry.GetTool(call.Name)

--- a/pkg/inference/tools/base_executor.go
+++ b/pkg/inference/tools/base_executor.go
@@ -162,33 +162,10 @@ func toolExecutionCorrelation(ctx context.Context, call ToolCall) events.Correla
 		if corr.ToolCallID == "" {
 			corr.ToolCallID = call.ID
 		}
-		if corr.ToolCallIndex == nil {
-			idx := int32(0)
-			corr.ToolCallIndex = &idx
-		}
-		if corr.SegmentType == "" {
-			corr.SegmentType = events.SegmentTypeTool
-		}
-		if corr.StreamKind == "" {
-			corr.StreamKind = events.StreamKindToolCall
-		}
-		if corr.CorrelationKey == "" && corr.ToolCallID != "" {
-			corr.CorrelationKey = "tool-execution:" + corr.ToolCallID
-		}
 		return corr
 	}
 
-	corr := events.Correlation{
-		ToolCallID:   call.ID,
-		SegmentType:  events.SegmentTypeTool,
-		StreamKind:   events.StreamKindToolCall,
-		SegmentIndex: 0,
-	}
-	if call.ID != "" {
-		corr.CorrelationKey = "tool-execution:" + call.ID
-		corr.SegmentID = corr.CorrelationKey
-	}
-	return corr
+	return events.Correlation{ToolCallID: call.ID}
 }
 
 func (b *BaseToolExecutor) ShouldRetry(_ context.Context, attempt int, _ *ToolResult, _ error) (bool, time.Duration) {

--- a/pkg/inference/tools/base_executor_events_test.go
+++ b/pkg/inference/tools/base_executor_events_test.go
@@ -31,6 +31,7 @@ func TestBaseToolExecutorPublishesCanonicalToolLifecycleEvents(t *testing.T) {
 
 	sink := &captureEventSink{}
 	ctx := events.WithEventSinks(context.Background(), sink)
+	ctx = WithCurrentToolCorrelation(ctx, events.Correlation{RunID: "run-1", ProviderCallID: "provider-call-1", ToolCallID: "call-1"})
 	executor := NewBaseToolExecutor(DefaultToolConfig())
 
 	result, err := executor.ExecuteToolCall(ctx, ToolCall{ID: "call-1", Name: "hello", Arguments: json.RawMessage(`{}`)}, registry)
@@ -66,21 +67,17 @@ func TestBaseToolExecutorPublishesCanonicalToolLifecycleEvents(t *testing.T) {
 
 func TestToolExecutionCorrelationCanComeFromContext(t *testing.T) {
 	base := events.Correlation{
-		Provider:       "gemini",
+		RunID:          "run-1",
 		ProviderCallID: "provider-call-1",
 		ToolCallID:     "call-1",
-		CorrelationKey: "provider:tool:call-1",
 	}
 	ctx := WithCurrentToolCorrelation(context.Background(), base)
 
 	corr := toolExecutionCorrelation(ctx, ToolCall{ID: "call-1", Name: "hello"})
-	if corr.Provider != "gemini" || corr.ProviderCallID != "provider-call-1" {
+	if corr.RunID != "run-1" || corr.ProviderCallID != "provider-call-1" {
 		t.Fatalf("provider correlation was not preserved: %#v", corr)
 	}
-	if corr.ToolCallID != "call-1" || corr.CorrelationKey != "provider:tool:call-1" {
+	if corr.ToolCallID != "call-1" {
 		t.Fatalf("tool correlation was not preserved: %#v", corr)
-	}
-	if corr.SegmentType != events.SegmentTypeTool || corr.StreamKind != events.StreamKindToolCall {
-		t.Fatalf("tool execution correlation was not normalized: %#v", corr)
 	}
 }

--- a/pkg/inference/tools/base_executor_events_test.go
+++ b/pkg/inference/tools/base_executor_events_test.go
@@ -65,19 +65,110 @@ func TestBaseToolExecutorPublishesCanonicalToolLifecycleEvents(t *testing.T) {
 	}
 }
 
-func TestToolExecutionCorrelationCanComeFromContext(t *testing.T) {
-	base := events.Correlation{
+func TestBaseToolExecutorPublishesCanonicalEventsFromToolCallCorrelation(t *testing.T) {
+	t.Parallel()
+
+	registry := NewInMemoryToolRegistry()
+	def, err := NewToolFromFunc("hello", "returns hello", func() (map[string]string, error) {
+		return map[string]string{"message": "hello"}, nil
+	})
+	if err != nil {
+		t.Fatalf("NewToolFromFunc: %v", err)
+	}
+	if err := registry.RegisterTool("hello", *def); err != nil {
+		t.Fatalf("RegisterTool: %v", err)
+	}
+
+	sink := &captureEventSink{}
+	ctx := events.WithEventSinks(context.Background(), sink)
+	executor := NewBaseToolExecutor(DefaultToolConfig())
+	corr := events.Correlation{
+		SessionID:      "session-1",
 		RunID:          "run-1",
+		TurnID:         "turn-1",
 		ProviderCallID: "provider-call-1",
+		SegmentID:      "segment-1",
 		ToolCallID:     "call-1",
 	}
-	ctx := WithCurrentToolCorrelation(context.Background(), base)
 
-	corr := toolExecutionCorrelation(ctx, ToolCall{ID: "call-1", Name: "hello"})
-	if corr.RunID != "run-1" || corr.ProviderCallID != "provider-call-1" {
-		t.Fatalf("provider correlation was not preserved: %#v", corr)
+	result, err := executor.ExecuteToolCall(ctx, ToolCall{ID: "call-1", Name: "hello", Arguments: json.RawMessage(`{}`), Correlation: corr}, registry)
+	if err != nil {
+		t.Fatalf("ExecuteToolCall: %v", err)
 	}
-	if corr.ToolCallID != "call-1" {
-		t.Fatalf("tool correlation was not preserved: %#v", corr)
+	if result == nil || result.Error != "" {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if len(sink.events) != 3 {
+		t.Fatalf("expected 3 lifecycle events, got %d: %#v", len(sink.events), sink.events)
+	}
+	for i, event := range sink.events {
+		correlated, ok := event.(events.CorrelatedEvent)
+		if !ok {
+			t.Fatalf("event %d is not correlated: %T", i, event)
+		}
+		if got := correlated.Correlation(); got != corr {
+			t.Fatalf("event %d correlation = %#v, want %#v", i, got, corr)
+		}
+		if err := events.ValidateCanonicalEvent(event); err != nil {
+			t.Fatalf("event %d should validate as canonical: %v", i, err)
+		}
+	}
+}
+
+func TestToolExecutionCorrelationSources(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		call ToolCall
+		want events.Correlation
+	}{
+		{
+			name: "context correlation",
+			ctx: WithCurrentToolCorrelation(context.Background(), events.Correlation{
+				RunID:          "run-1",
+				ProviderCallID: "provider-call-1",
+				ToolCallID:     "call-1",
+			}),
+			call: ToolCall{ID: "call-1", Name: "hello"},
+			want: events.Correlation{RunID: "run-1", ProviderCallID: "provider-call-1", ToolCallID: "call-1"},
+		},
+		{
+			name: "tool call correlation",
+			ctx:  context.Background(),
+			call: ToolCall{ID: "call-1", Name: "hello", Correlation: events.Correlation{
+				SessionID:      "session-1",
+				RunID:          "run-1",
+				TurnID:         "turn-1",
+				ProviderCallID: "provider-call-1",
+				SegmentID:      "segment-1",
+				ToolCallID:     "call-1",
+			}},
+			want: events.Correlation{SessionID: "session-1", RunID: "run-1", TurnID: "turn-1", ProviderCallID: "provider-call-1", SegmentID: "segment-1", ToolCallID: "call-1"},
+		},
+		{
+			name: "tool call overrides batch context",
+			ctx: WithCurrentToolCorrelation(context.Background(), events.Correlation{
+				RunID:          "run-1",
+				ProviderCallID: "provider-call-1",
+				ToolCallID:     "wrong-call",
+			}),
+			call: ToolCall{ID: "call-2", Name: "hello", Correlation: events.Correlation{
+				RunID:          "run-1",
+				ProviderCallID: "provider-call-2",
+				ToolCallID:     "call-2",
+			}},
+			want: events.Correlation{RunID: "run-1", ProviderCallID: "provider-call-2", ToolCallID: "call-2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			corr := toolExecutionCorrelation(tt.ctx, tt.call)
+			if corr != tt.want {
+				t.Fatalf("correlation = %#v, want %#v", corr, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/inference/tools/definition.go
+++ b/pkg/inference/tools/definition.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-go-golems/geppetto/pkg/events"
 	"github.com/invopop/jsonschema"
 	"github.com/rs/zerolog/log"
 )
@@ -119,9 +120,10 @@ type ToolExample struct {
 
 // ToolCall represents a request to execute a tool
 type ToolCall struct {
-	ID        string          `json:"id"`
-	Name      string          `json:"name"`
-	Arguments json.RawMessage `json:"arguments"`
+	ID          string             `json:"id"`
+	Name        string             `json:"name"`
+	Arguments   json.RawMessage    `json:"arguments"`
+	Correlation events.Correlation `json:"correlation,omitempty"`
 }
 
 // ToolResult represents the result of a tool execution

--- a/pkg/observability/canonical_records.go
+++ b/pkg/observability/canonical_records.go
@@ -118,77 +118,22 @@ func DerivedRecordsFromEvent(base Record, event events.Event) []Record {
 }
 
 func applyCorrelation(rec *Record, corr events.Correlation) {
-	if corr.Provider != "" {
-		rec.Provider = corr.Provider
-	}
-	if corr.Model != "" {
-		rec.Model = corr.Model
-	}
 	if corr.SessionID != "" {
 		rec.SessionID = corr.SessionID
 	}
 	if corr.RunID != "" {
 		rec.RunID = corr.RunID
 	}
-	if corr.InferenceID != "" {
-		rec.InferenceID = corr.InferenceID
-	}
 	if corr.TurnID != "" {
 		rec.TurnID = corr.TurnID
-	}
-	if corr.ResponseID != "" {
-		rec.ResponseID = corr.ResponseID
-	}
-	if corr.ItemID != "" {
-		rec.ItemID = corr.ItemID
 	}
 	if corr.ProviderCallID != "" {
 		rec.ProviderCallID = corr.ProviderCallID
 	}
-	if corr.ProviderCallIndex != 0 {
-		v := int(corr.ProviderCallIndex)
-		rec.ProviderCallIndex = &v
-	}
-	if corr.OutputIndex != nil {
-		v := int(*corr.OutputIndex)
-		rec.OutputIndex = &v
-	}
-	if corr.SummaryIndex != nil {
-		v := int(*corr.SummaryIndex)
-		rec.SummaryIndex = &v
-	}
-	if corr.ChoiceIndex != nil {
-		v := int(*corr.ChoiceIndex)
-		rec.ChoiceIndex = &v
-	}
-	if corr.ContentBlockIndex != nil {
-		v := int(*corr.ContentBlockIndex)
-		rec.ContentBlockIndex = &v
-	}
-	if corr.StreamKind != "" {
-		rec.StreamKind = corr.StreamKind
-	}
-	if corr.CorrelationKey != "" {
-		rec.CorrelationKey = corr.CorrelationKey
-	}
-	if corr.ParentCorrelationKey != "" {
-		rec.ParentCorrelationKey = corr.ParentCorrelationKey
-	}
 	if corr.ToolCallID != "" {
 		rec.ToolCallID = corr.ToolCallID
 	}
-	if corr.ToolCallIndex != nil {
-		v := int(*corr.ToolCallIndex)
-		rec.ToolCallIndex = &v
-	}
 	if corr.SegmentID != "" {
 		rec.SegmentID = corr.SegmentID
-	}
-	if corr.SegmentIndex != 0 {
-		v := int(corr.SegmentIndex)
-		rec.SegmentIndex = &v
-	}
-	if corr.SegmentType != "" {
-		rec.SegmentType = corr.SegmentType
 	}
 }

--- a/pkg/observability/canonical_records.go
+++ b/pkg/observability/canonical_records.go
@@ -44,33 +44,59 @@ func EnrichRecordFromEvent(rec *Record, event events.Event) {
 		rec.Usage = e.Usage
 		rec.DurationMs = e.DurationMs
 		rec.HasToolCalls = e.HasToolCalls
+	case *events.EventTextSegmentStarted:
+		rec.SegmentType = events.SegmentTypeText
+		rec.StreamKind = events.StreamKindContent
 	case *events.EventTextDelta:
 		rec.TextLen = len(e.Text)
+		rec.SegmentType = events.SegmentTypeText
+		rec.StreamKind = events.StreamKindContent
 	case *events.EventTextSegmentFinished:
 		rec.TextLen = len(e.Text)
 		rec.SegmentStatus = e.FinishReason
+		rec.SegmentType = events.SegmentTypeText
+		rec.StreamKind = events.StreamKindContent
+	case *events.EventReasoningSegmentStarted:
+		rec.SegmentType = events.SegmentTypeReasoning
+		rec.StreamKind = events.StreamKindReasoning
 	case *events.EventReasoningDelta:
 		rec.TextLen = len(e.Text)
+		rec.SegmentType = events.SegmentTypeReasoning
+		rec.StreamKind = events.StreamKindReasoning
 	case *events.EventReasoningSegmentFinished:
 		rec.TextLen = len(e.Text)
 		rec.SegmentStatus = e.FinishReason
+		rec.SegmentType = events.SegmentTypeReasoning
+		rec.StreamKind = events.StreamKindReasoning
 	case *events.EventToolCallStarted:
+		rec.SegmentType = events.SegmentTypeTool
+		rec.StreamKind = events.StreamKindToolCall
 		rec.ToolCallID = e.ToolCallID
 	case *events.EventToolCallArgumentsDelta:
 		rec.ToolCallID = e.ToolCallID
 		rec.TextLen = len(e.Arguments)
+		rec.SegmentType = events.SegmentTypeTool
+		rec.StreamKind = events.StreamKindToolCall
 	case *events.EventToolCallRequested:
 		rec.ToolCallID = e.ToolCallID
 		rec.TextLen = len(e.Input)
+		rec.SegmentType = events.SegmentTypeTool
+		rec.StreamKind = events.StreamKindToolCall
 	case *events.EventToolExecutionStarted:
 		rec.ToolCallID = e.ToolCallID
 		rec.TextLen = len(e.Input)
+		rec.SegmentType = events.SegmentTypeTool
+		rec.StreamKind = events.StreamKindToolCall
 	case *events.EventToolResultReady:
 		rec.ToolCallID = e.ToolCallID
 		rec.TextLen = len(e.Result)
+		rec.SegmentType = events.SegmentTypeTool
+		rec.StreamKind = events.StreamKindToolCall
 	case *events.EventToolCallFinished:
 		rec.ToolCallID = e.ToolCallID
 		rec.SegmentStatus = e.Status
+		rec.SegmentType = events.SegmentTypeTool
+		rec.StreamKind = events.StreamKindToolCall
 	}
 }
 

--- a/pkg/observability/canonical_records_test.go
+++ b/pkg/observability/canonical_records_test.go
@@ -20,7 +20,7 @@ func TestDerivedRecordsFromProviderCallFinished(t *testing.T) {
 	if rec.Stage != StageProviderCallResultFinalized || rec.Kind != RecordKindProviderCallResult {
 		t.Fatalf("unexpected provider-call result stage/kind: %#v", rec)
 	}
-	if rec.ProviderCallID != corr.ProviderCallID || rec.CorrelationKey != corr.CorrelationKey {
+	if rec.ProviderCallID != corr.ProviderCallID || rec.RunID != corr.RunID {
 		t.Fatalf("correlation not copied: %#v", rec)
 	}
 	if rec.StopReason != "tool_calls" || rec.FinishClass != "tool_calls_pending" || !rec.HasToolCalls {
@@ -33,15 +33,9 @@ func TestDerivedRecordsFromProviderCallFinished(t *testing.T) {
 
 func TestDerivedRecordsFromSegmentEvents(t *testing.T) {
 	corr := events.Correlation{
-		Provider:             "openai_responses",
-		ProviderCallID:       "provider-call-1",
-		ProviderCallIndex:    1,
-		SegmentID:            "segment-1",
-		SegmentIndex:         3,
-		SegmentType:          events.SegmentTypeText,
-		StreamKind:           events.StreamKindContent,
-		CorrelationKey:       "segment-key",
-		ParentCorrelationKey: "provider-key",
+		RunID:          "run-1",
+		ProviderCallID: "provider-call-1",
+		SegmentID:      "segment-1",
 	}
 	event := events.NewTextSegmentFinishedEvent(events.EventMetadata{TurnID: "turn-1"}, corr, "hello", "stop")
 
@@ -53,7 +47,7 @@ func TestDerivedRecordsFromSegmentEvents(t *testing.T) {
 	if rec.Stage != StageSegmentFinished || rec.Kind != RecordKindSegment {
 		t.Fatalf("unexpected segment stage/kind: %#v", rec)
 	}
-	if rec.SegmentID != "segment-1" || rec.SegmentType != events.SegmentTypeText || rec.StreamKind != events.StreamKindContent {
+	if rec.SegmentID != "segment-1" || rec.ProviderCallID != "provider-call-1" {
 		t.Fatalf("segment correlation not copied: %#v", rec)
 	}
 	if rec.TextLen != len("hello") || rec.SegmentStatus != "stop" {

--- a/pkg/steps/ai/claude/content-block-merger.go
+++ b/pkg/steps/ai/claude/content-block-merger.go
@@ -83,18 +83,26 @@ func (cbm *ContentBlockMerger) Error() *api.Error {
 }
 
 func (cbm *ContentBlockMerger) providerCallCorrelation() events.Correlation {
-	if cbm.providerCallCorr.CorrelationKey != "" {
+	if cbm.providerCallCorr.ProviderCallID != "" {
 		return cbm.providerCallCorr
 	}
-	return events.BuildProviderCallCorrelation("claude", cbm.metadata.InferenceID, "", cbm.providerCallIndex, "")
+	corr := events.BuildProviderCallCorrelation("claude", cbm.metadata.InferenceID, "", cbm.providerCallIndex, "")
+	corr.SessionID = cbm.metadata.SessionID
+	corr.TurnID = cbm.metadata.TurnID
+	return corr
 }
 
 func (cbm *ContentBlockMerger) contentBlockCorrelation(index int, segmentType string) events.Correlation {
-	providerCallID := cbm.providerCallCorrelation().ProviderCallID
+	parent := cbm.providerCallCorrelation()
+	providerCallID := parent.ProviderCallID
 	if providerCallID == "" && cbm.response != nil {
 		providerCallID = cbm.response.ID
 	}
-	return events.BuildClaudeSegmentCorrelation("claude", providerCallID, index, segmentType)
+	corr := events.BuildClaudeSegmentCorrelation("claude", providerCallID, index, segmentType)
+	corr.SessionID = parent.SessionID
+	corr.RunID = parent.RunID
+	corr.TurnID = parent.TurnID
+	return corr
 }
 
 func inputString(input any) string {
@@ -209,8 +217,9 @@ func (cbm *ContentBlockMerger) Add(event api.StreamingEvent) ([]events.Event, er
 		cbm.updateUsage(event)
 
 		cbm.providerCallCorr = events.BuildClaudeProviderCallCorrelation("claude", event.Message.ID, cbm.providerCallIndex)
-		cbm.providerCallCorr.InferenceID = cbm.metadata.InferenceID
-		cbm.providerCallCorr.Model = event.Message.Model
+		cbm.providerCallCorr.SessionID = cbm.metadata.SessionID
+		cbm.providerCallCorr.RunID = cbm.metadata.InferenceID
+		cbm.providerCallCorr.TurnID = cbm.metadata.TurnID
 		return []events.Event{events.NewProviderCallStartedEvent(cbm.metadata, cbm.providerCallCorr)}, nil
 
 	case api.MessageDeltaType:

--- a/pkg/steps/ai/claude/content-block-merger_test.go
+++ b/pkg/steps/ai/claude/content-block-merger_test.go
@@ -351,6 +351,54 @@ func TestContentBlockMerger(t *testing.T) {
 	}
 }
 
+func TestContentBlockMergerProviderCallCorrelationUsesProviderCallIndex(t *testing.T) {
+	for _, tt := range []struct {
+		name              string
+		providerCallIndex int
+		wantProviderID    string
+		wantKey           string
+	}{
+		{name: "first provider call", providerCallIndex: 0, wantProviderID: "msg_123", wantKey: "claude:msg_123:provider-call"},
+		{name: "third provider call", providerCallIndex: 2, wantProviderID: "msg_123", wantKey: "claude:msg_123:provider-call"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := events.EventMetadata{InferenceID: "inference-1", TurnID: "turn-1"}
+			merger := NewContentBlockMerger(metadata)
+			merger.providerCallIndex = tt.providerCallIndex
+
+			got, err := merger.Add(api.StreamingEvent{
+				Type: api.MessageStartType,
+				Message: &api.MessageResponse{
+					ID:    "msg_123",
+					Model: "claude-test",
+					Role:  "assistant",
+				},
+			})
+			require.NoError(t, err)
+			require.Len(t, got, 1)
+
+			correlated, ok := got[0].(events.CorrelatedEvent)
+			require.True(t, ok, "event should carry correlation")
+			corr := correlated.Correlation()
+			if corr.ProviderCallIndex != int32(tt.providerCallIndex) {
+				t.Fatalf("ProviderCallIndex = %d, want %d", corr.ProviderCallIndex, tt.providerCallIndex)
+			}
+			if corr.ProviderCallID != tt.wantProviderID {
+				t.Fatalf("ProviderCallID = %q, want %q", corr.ProviderCallID, tt.wantProviderID)
+			}
+			if corr.CorrelationKey != tt.wantKey {
+				t.Fatalf("CorrelationKey = %q, want %q", corr.CorrelationKey, tt.wantKey)
+			}
+			if corr.InferenceID != metadata.InferenceID {
+				t.Fatalf("InferenceID = %q, want %q", corr.InferenceID, metadata.InferenceID)
+			}
+			if corr.Model != "claude-test" {
+				t.Fatalf("Model = %q, want claude-test", corr.Model)
+			}
+		})
+	}
+}
+
 func TestContentBlockMergerReviewDerivedScenarios(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/steps/ai/claude/content-block-merger_test.go
+++ b/pkg/steps/ai/claude/content-block-merger_test.go
@@ -351,18 +351,17 @@ func TestContentBlockMerger(t *testing.T) {
 	}
 }
 
-func TestContentBlockMergerProviderCallCorrelationUsesProviderCallIndex(t *testing.T) {
+func TestContentBlockMergerProviderCallCorrelationUsesExplicitIDs(t *testing.T) {
 	for _, tt := range []struct {
 		name              string
 		providerCallIndex int
 		wantProviderID    string
-		wantKey           string
 	}{
-		{name: "first provider call", providerCallIndex: 0, wantProviderID: "msg_123", wantKey: "claude:msg_123:provider-call"},
-		{name: "third provider call", providerCallIndex: 2, wantProviderID: "msg_123", wantKey: "claude:msg_123:provider-call"},
+		{name: "first provider call", providerCallIndex: 0, wantProviderID: "claude:msg_123"},
+		{name: "third provider call", providerCallIndex: 2, wantProviderID: "claude:msg_123"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			metadata := events.EventMetadata{InferenceID: "inference-1", TurnID: "turn-1"}
+			metadata := events.EventMetadata{SessionID: "session-1", InferenceID: "inference-1", TurnID: "turn-1"}
 			merger := NewContentBlockMerger(metadata)
 			merger.providerCallIndex = tt.providerCallIndex
 
@@ -380,20 +379,11 @@ func TestContentBlockMergerProviderCallCorrelationUsesProviderCallIndex(t *testi
 			correlated, ok := got[0].(events.CorrelatedEvent)
 			require.True(t, ok, "event should carry correlation")
 			corr := correlated.Correlation()
-			if corr.ProviderCallIndex != int32(tt.providerCallIndex) {
-				t.Fatalf("ProviderCallIndex = %d, want %d", corr.ProviderCallIndex, tt.providerCallIndex)
-			}
 			if corr.ProviderCallID != tt.wantProviderID {
 				t.Fatalf("ProviderCallID = %q, want %q", corr.ProviderCallID, tt.wantProviderID)
 			}
-			if corr.CorrelationKey != tt.wantKey {
-				t.Fatalf("CorrelationKey = %q, want %q", corr.CorrelationKey, tt.wantKey)
-			}
-			if corr.InferenceID != metadata.InferenceID {
-				t.Fatalf("InferenceID = %q, want %q", corr.InferenceID, metadata.InferenceID)
-			}
-			if corr.Model != "claude-test" {
-				t.Fatalf("Model = %q, want claude-test", corr.Model)
+			if corr.SessionID != metadata.SessionID || corr.RunID != metadata.InferenceID || corr.TurnID != metadata.TurnID {
+				t.Fatalf("scope identity mismatch: %+v", corr)
 			}
 		})
 	}

--- a/pkg/steps/ai/claude/engine_claude.go
+++ b/pkg/steps/ai/claude/engine_claude.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-go-golems/geppetto/pkg/events"
 	"github.com/go-go-golems/geppetto/pkg/inference/engine"
+	gepsession "github.com/go-go-golems/geppetto/pkg/inference/session"
 	"github.com/go-go-golems/geppetto/pkg/inference/tools"
 	geppettoobs "github.com/go-go-golems/geppetto/pkg/observability"
 	"github.com/go-go-golems/geppetto/pkg/steps"
@@ -160,6 +161,9 @@ func (e *ClaudeEngine) RunInference(
 	}
 
 	completionMerger := NewContentBlockMerger(metadata)
+	if idx, ok := gepsession.ProviderCallIndexFromContext(ctx); ok {
+		completionMerger.providerCallIndex = idx
+	}
 
 	eventCount := 0
 	for {

--- a/pkg/steps/ai/claude/engine_claude.go
+++ b/pkg/steps/ai/claude/engine_claude.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/runtimeattrib"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
 	"github.com/go-go-golems/geppetto/pkg/turns"
+	"github.com/go-go-golems/geppetto/pkg/turns/toolblocks"
 	"github.com/go-go-golems/glazed/pkg/helpers/cast"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -233,7 +234,7 @@ streamingComplete:
 
 	// Create blocks from content blocks: text -> llm_text, tool_use -> tool_call
 	hasToolCalls := false
-	for _, c := range response.Content {
+	for i, c := range response.Content {
 		switch v := c.(type) {
 		case api.TextContent:
 			if s := v.Text; s != "" {
@@ -243,7 +244,9 @@ streamingComplete:
 			hasToolCalls = true
 			var args any
 			_ = json.Unmarshal(v.Input, &args)
-			turns.AppendBlock(t, turns.NewToolCallBlock(v.ID, v.Name, args))
+			corr := completionMerger.contentBlockCorrelation(i, events.SegmentTypeTool)
+			corr.ToolCallID = v.ID
+			turns.AppendBlock(t, toolblocks.NewToolCallBlockWithCorrelation(v.ID, v.Name, args, corr))
 		}
 	}
 

--- a/pkg/steps/ai/claude/observability_test.go
+++ b/pkg/steps/ai/claude/observability_test.go
@@ -228,8 +228,8 @@ func TestClaudeObservabilityCapturesPublishStartedAndProviderRecords(t *testing.
 	if started == nil {
 		t.Fatalf("missing provider-call-finished publish-started record in %#v", records)
 	}
-	if started.CorrelationKey == "" {
-		t.Fatalf("provider-call-finished record missing correlation key: %#v", started)
+	if started.ProviderCallID == "" {
+		t.Fatalf("provider-call-finished record missing provider call id: %#v", started)
 	}
 	if len(started.EventJSON) != 0 || len(started.MetadataJSON) != 0 {
 		t.Fatalf("publish-started should be compact: %#v", started)

--- a/pkg/steps/ai/gemini/engine_gemini.go
+++ b/pkg/steps/ai/gemini/engine_gemini.go
@@ -381,11 +381,10 @@ func (e *GeminiEngine) RunInference(ctx context.Context, t *turns.Turn) (*turns.
 	return t, nil
 }
 
-func geminiProviderCallCorrelation(metadata events.EventMetadata, inferenceScopeID, modelName string, providerCallIndex int) events.Correlation {
+func geminiProviderCallCorrelation(metadata events.EventMetadata, inferenceScopeID, _ string, providerCallIndex int) events.Correlation {
 	corr := events.BuildProviderCallCorrelation("gemini", inferenceScopeID, "", providerCallIndex, "")
 	corr.SessionID = metadata.SessionID
 	corr.TurnID = metadata.TurnID
-	corr.Model = modelName
 	return corr
 }
 
@@ -393,30 +392,13 @@ func geminiSegmentCorrelation(providerCallCorr events.Correlation, providerObjec
 	corr := events.BuildSegmentCorrelation(providerCallCorr, providerObjectID, segmentIndex, segmentType)
 	corr.SessionID = providerCallCorr.SessionID
 	corr.TurnID = providerCallCorr.TurnID
-	corr.Model = providerCallCorr.Model
 	return corr
 }
 
 func geminiToolCorrelation(providerCallCorr events.Correlation, toolCallID string, toolCallIndex int) events.Correlation {
 	corr := geminiSegmentCorrelation(providerCallCorr, toolCallID, toolCallIndex, events.SegmentTypeTool)
-	idx := checkedInt32(toolCallIndex)
 	corr.ToolCallID = toolCallID
-	corr.ToolCallIndex = &idx
 	return corr
-}
-
-func checkedInt32(v int) int32 {
-	const (
-		maxInt32Value = int64(1<<31 - 1)
-		minInt32Value = -1 << 31
-	)
-	if int64(v) > maxInt32Value {
-		return int32(maxInt32Value)
-	}
-	if v < minInt32Value {
-		return int32(minInt32Value)
-	}
-	return int32(v)
 }
 
 func extractGeminiFinishReason(c *genai.Candidate) (string, bool) {

--- a/pkg/steps/ai/gemini/engine_gemini.go
+++ b/pkg/steps/ai/gemini/engine_gemini.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-go-golems/geppetto/pkg/events"
 	"github.com/go-go-golems/geppetto/pkg/inference/engine"
+	gepsession "github.com/go-go-golems/geppetto/pkg/inference/session"
 	"github.com/go-go-golems/geppetto/pkg/inference/tools"
 	geppettoobs "github.com/go-go-golems/geppetto/pkg/observability"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/runtimeattrib"
@@ -326,7 +327,11 @@ func (e *GeminiEngine) RunInference(ctx context.Context, t *turns.Turn) (*turns.
 	if inferenceScopeID == "" {
 		inferenceScopeID = metadata.ID.String()
 	}
-	providerCallCorr := geminiProviderCallCorrelation(metadata, inferenceScopeID, modelName)
+	providerCallIndex := 0
+	if idx, ok := gepsession.ProviderCallIndexFromContext(ctx); ok {
+		providerCallIndex = idx
+	}
+	providerCallCorr := geminiProviderCallCorrelation(metadata, inferenceScopeID, modelName, providerCallIndex)
 	e.publishEvent(ctx, events.NewProviderCallStartedEvent(metadata, providerCallCorr))
 
 	// Streaming mode always on for engines in this architecture
@@ -376,8 +381,8 @@ func (e *GeminiEngine) RunInference(ctx context.Context, t *turns.Turn) (*turns.
 	return t, nil
 }
 
-func geminiProviderCallCorrelation(metadata events.EventMetadata, inferenceScopeID, modelName string) events.Correlation {
-	corr := events.BuildProviderCallCorrelation("gemini", inferenceScopeID, "", 0, "")
+func geminiProviderCallCorrelation(metadata events.EventMetadata, inferenceScopeID, modelName string, providerCallIndex int) events.Correlation {
+	corr := events.BuildProviderCallCorrelation("gemini", inferenceScopeID, "", providerCallIndex, "")
 	corr.SessionID = metadata.SessionID
 	corr.TurnID = metadata.TurnID
 	corr.Model = modelName

--- a/pkg/steps/ai/gemini/engine_gemini_test.go
+++ b/pkg/steps/ai/gemini/engine_gemini_test.go
@@ -104,7 +104,7 @@ func TestGeminiCanonicalCorrelationHelpersValidate(t *testing.T) {
 		TurnID:      "turn-1",
 	}
 
-	providerCorr := geminiProviderCallCorrelation(metadata, metadata.InferenceID, "gemini-test")
+	providerCorr := geminiProviderCallCorrelation(metadata, metadata.InferenceID, "gemini-test", 0)
 	if err := events.ValidateCanonicalEvent(events.NewProviderCallStartedEvent(metadata, providerCorr)); err != nil {
 		t.Fatalf("provider-call correlation should validate: %v", err)
 	}
@@ -120,9 +120,41 @@ func TestGeminiCanonicalCorrelationHelpersValidate(t *testing.T) {
 	}
 }
 
+func TestGeminiProviderCallCorrelationUsesProviderCallIndex(t *testing.T) {
+	metadata := events.EventMetadata{SessionID: "session-1", InferenceID: "inference-1", TurnID: "turn-1"}
+
+	for _, tt := range []struct {
+		name              string
+		providerCallIndex int
+		wantProviderID    string
+	}{
+		{name: "first provider call", providerCallIndex: 0, wantProviderID: "gemini:inference-1:provider-call:0"},
+		{name: "third provider call", providerCallIndex: 2, wantProviderID: "gemini:inference-1:provider-call:2"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			corr := geminiProviderCallCorrelation(metadata, metadata.InferenceID, "gemini-test", tt.providerCallIndex)
+			if corr.ProviderCallIndex != int32(tt.providerCallIndex) {
+				t.Fatalf("ProviderCallIndex = %d, want %d", corr.ProviderCallIndex, tt.providerCallIndex)
+			}
+			if corr.ProviderCallID != tt.wantProviderID {
+				t.Fatalf("ProviderCallID = %q, want %q", corr.ProviderCallID, tt.wantProviderID)
+			}
+			if corr.CorrelationKey != tt.wantProviderID {
+				t.Fatalf("CorrelationKey = %q, want %q", corr.CorrelationKey, tt.wantProviderID)
+			}
+			if corr.Model != "gemini-test" {
+				t.Fatalf("Model = %q, want gemini-test", corr.Model)
+			}
+			if corr.TurnID != metadata.TurnID {
+				t.Fatalf("TurnID = %q, want %q", corr.TurnID, metadata.TurnID)
+			}
+		})
+	}
+}
+
 func TestReduceGeminiStreamResponseReviewDerivedScenarios(t *testing.T) {
 	metadata := events.EventMetadata{SessionID: "session-1", InferenceID: "inference-1", TurnID: "turn-1"}
-	providerCorr := geminiProviderCallCorrelation(metadata, metadata.InferenceID, "gemini-test")
+	providerCorr := geminiProviderCallCorrelation(metadata, metadata.InferenceID, "gemini-test", 0)
 
 	tests := []struct {
 		name      string
@@ -222,7 +254,7 @@ func TestReduceGeminiStreamResponseReviewDerivedScenarios(t *testing.T) {
 
 func TestCompleteGeminiStreamTerminalErrorClosesActiveText(t *testing.T) {
 	metadata := events.EventMetadata{SessionID: "session-1", InferenceID: "inference-1", TurnID: "turn-1"}
-	providerCorr := geminiProviderCallCorrelation(metadata, metadata.InferenceID, "gemini-test")
+	providerCorr := geminiProviderCallCorrelation(metadata, metadata.InferenceID, "gemini-test", 0)
 	state := newGeminiStreamState(providerCorr)
 
 	chunkEvents := reduceGeminiStreamResponse(metadata, state, geminiTextResponse("partial"))

--- a/pkg/steps/ai/gemini/engine_gemini_test.go
+++ b/pkg/steps/ai/gemini/engine_gemini_test.go
@@ -120,7 +120,7 @@ func TestGeminiCanonicalCorrelationHelpersValidate(t *testing.T) {
 	}
 }
 
-func TestGeminiProviderCallCorrelationUsesProviderCallIndex(t *testing.T) {
+func TestGeminiProviderCallCorrelationUsesExplicitIDs(t *testing.T) {
 	metadata := events.EventMetadata{SessionID: "session-1", InferenceID: "inference-1", TurnID: "turn-1"}
 
 	for _, tt := range []struct {
@@ -133,20 +133,11 @@ func TestGeminiProviderCallCorrelationUsesProviderCallIndex(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			corr := geminiProviderCallCorrelation(metadata, metadata.InferenceID, "gemini-test", tt.providerCallIndex)
-			if corr.ProviderCallIndex != int32(tt.providerCallIndex) {
-				t.Fatalf("ProviderCallIndex = %d, want %d", corr.ProviderCallIndex, tt.providerCallIndex)
-			}
 			if corr.ProviderCallID != tt.wantProviderID {
 				t.Fatalf("ProviderCallID = %q, want %q", corr.ProviderCallID, tt.wantProviderID)
 			}
-			if corr.CorrelationKey != tt.wantProviderID {
-				t.Fatalf("CorrelationKey = %q, want %q", corr.CorrelationKey, tt.wantProviderID)
-			}
-			if corr.Model != "gemini-test" {
-				t.Fatalf("Model = %q, want gemini-test", corr.Model)
-			}
-			if corr.TurnID != metadata.TurnID {
-				t.Fatalf("TurnID = %q, want %q", corr.TurnID, metadata.TurnID)
+			if corr.SessionID != metadata.SessionID || corr.RunID != metadata.InferenceID || corr.TurnID != metadata.TurnID {
+				t.Fatalf("scope identity mismatch: %+v", corr)
 			}
 		})
 	}

--- a/pkg/steps/ai/gemini/observability.go
+++ b/pkg/steps/ai/gemini/observability.go
@@ -65,23 +65,20 @@ func (e *GeminiEngine) publishProviderRecord(ctx context.Context, metadata event
 		return
 	}
 	rec := geppettoobs.Record{
-		Timestamp:            time.Now().UTC(),
-		Stage:                geppettoobs.StageProviderRoutedEvent,
-		Kind:                 geppettoobs.RecordKindProviderEvent,
-		Provider:             "gemini",
-		Model:                corr.Model,
-		SessionID:            firstNonEmptyString(corr.SessionID, metadata.SessionID),
-		RunID:                corr.RunID,
-		InferenceID:          firstNonEmptyString(corr.InferenceID, metadata.InferenceID),
-		TurnID:               firstNonEmptyString(corr.TurnID, metadata.TurnID),
-		MessageID:            metadata.ID.String(),
-		EventType:            eventType,
-		ProviderCallID:       corr.ProviderCallID,
-		ProviderCallIndex:    intPtrFromInt32NonZero(corr.ProviderCallIndex),
-		ResponseID:           corr.ResponseID,
-		StreamKind:           corr.StreamKind,
-		CorrelationKey:       corr.CorrelationKey,
-		ParentCorrelationKey: corr.ParentCorrelationKey,
+		Timestamp:      time.Now().UTC(),
+		Stage:          geppettoobs.StageProviderRoutedEvent,
+		Kind:           geppettoobs.RecordKindProviderEvent,
+		Provider:       "gemini",
+		Model:          metadata.Model,
+		SessionID:      firstNonEmptyString(corr.SessionID, metadata.SessionID),
+		RunID:          corr.RunID,
+		InferenceID:    metadata.InferenceID,
+		TurnID:         firstNonEmptyString(corr.TurnID, metadata.TurnID),
+		MessageID:      metadata.ID.String(),
+		EventType:      eventType,
+		ProviderCallID: corr.ProviderCallID,
+		SegmentID:      corr.SegmentID,
+		ToolCallID:     corr.ToolCallID,
 	}
 	if body, err := json.Marshal(object); err == nil {
 		rec.ObjectJSON = body
@@ -96,12 +93,4 @@ func firstNonEmptyString(values ...string) string {
 		}
 	}
 	return ""
-}
-
-func intPtrFromInt32NonZero(v int32) *int {
-	if v == 0 {
-		return nil
-	}
-	out := int(v)
-	return &out
 }

--- a/pkg/steps/ai/gemini/stream_helpers.go
+++ b/pkg/steps/ai/gemini/stream_helpers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-go-golems/geppetto/pkg/events"
 	"github.com/go-go-golems/geppetto/pkg/inference/engine"
 	"github.com/go-go-golems/geppetto/pkg/turns"
+	"github.com/go-go-golems/geppetto/pkg/turns/toolblocks"
 	genai "github.com/google/generative-ai-go/genai"
 	"google.golang.org/api/iterator"
 )
@@ -104,7 +105,7 @@ func appendGeminiFinalTurnBlocks(t *turns.Turn, state *geminiStreamState) {
 	if state.message != "" {
 		turns.AppendBlock(t, turns.NewAssistantTextBlock(state.message))
 	}
-	for _, c := range state.pendingCalls {
-		turns.AppendBlock(t, turns.NewToolCallBlock(c.id, c.name, c.args))
+	for i, c := range state.pendingCalls {
+		turns.AppendBlock(t, toolblocks.NewToolCallBlockWithCorrelation(c.id, c.name, c.args, geminiToolCorrelation(state.providerCallCorr, c.id, i)))
 	}
 }

--- a/pkg/steps/ai/openai/chat_stream_reducer.go
+++ b/pkg/steps/ai/openai/chat_stream_reducer.go
@@ -361,6 +361,9 @@ func (state openAIChatStreamState) chatCorrelation(
 	corr.ParentCorrelationKey = state.ProviderCallCorr.CorrelationKey
 	corr.Model = state.Model
 	corr.TurnID = state.TurnID
+	if corr.SegmentType == events.SegmentTypeText || corr.SegmentType == events.SegmentTypeReasoning {
+		corr.SegmentIndex = state.ProviderCallCorr.ProviderCallIndex + 1
+	}
 	if corr.SegmentType != "" && corr.SegmentID == "" && corr.CorrelationKey != "" {
 		corr.SegmentID = corr.CorrelationKey
 	}

--- a/pkg/steps/ai/openai/chat_stream_reducer.go
+++ b/pkg/steps/ai/openai/chat_stream_reducer.go
@@ -51,10 +51,11 @@ type openAIReasoningNormalizeObservation struct {
 type openAIChatStreamState struct {
 	Metadata events.EventMetadata
 
-	Provider         string
-	Model            string
-	TurnID           string
-	ProviderCallCorr events.Correlation
+	Provider          string
+	Model             string
+	TurnID            string
+	ProviderCallIndex int32
+	ProviderCallCorr  events.Correlation
 
 	CurrentResponseID  string
 	CurrentChoiceIndex *int
@@ -92,12 +93,14 @@ func newOpenAIChatStreamState(
 	provider string,
 	model string,
 	providerCallCorr events.Correlation,
+	providerCallIndex int,
 ) openAIChatStreamState {
 	return openAIChatStreamState{
 		Metadata:           metadata,
 		Provider:           provider,
 		Model:              model,
 		TurnID:             metadata.TurnID,
+		ProviderCallIndex:  int32(providerCallIndex), // #nosec G115 -- tool-loop indexes are small, local ordinals.
 		ProviderCallCorr:   providerCallCorr,
 		ToolCallMerger:     NewToolCallMerger(),
 		StartedToolStreams: map[string]bool{},
@@ -356,17 +359,10 @@ func (state openAIChatStreamState) chatCorrelation(
 	toolCallIndex *int,
 ) events.Correlation {
 	corr := events.BuildChatCompletionsCorrelation(state.Provider, state.CurrentResponseID, choiceIndex, streamKind, toolCallID, toolCallIndex)
-	corr.ProviderCallID = state.ProviderCallCorr.ProviderCallID
-	corr.ProviderCallIndex = state.ProviderCallCorr.ProviderCallIndex
-	corr.ParentCorrelationKey = state.ProviderCallCorr.CorrelationKey
-	corr.Model = state.Model
+	corr.SessionID = state.ProviderCallCorr.SessionID
+	corr.RunID = state.ProviderCallCorr.RunID
 	corr.TurnID = state.TurnID
-	if corr.SegmentType == events.SegmentTypeText || corr.SegmentType == events.SegmentTypeReasoning {
-		corr.SegmentIndex = state.ProviderCallCorr.ProviderCallIndex + 1
-	}
-	if corr.SegmentType != "" && corr.SegmentID == "" && corr.CorrelationKey != "" {
-		corr.SegmentID = corr.CorrelationKey
-	}
+	corr.ProviderCallID = state.ProviderCallCorr.ProviderCallID
 	return corr
 }
 
@@ -393,8 +389,11 @@ func appendOpenAIChatEvent(effects []openAIChatStreamEffect, event events.Event)
 }
 
 func openAIChatToolStreamKey(corr events.Correlation, tc ChatToolCall) string {
-	if corr.CorrelationKey != "" {
-		return corr.CorrelationKey
+	if corr.ToolCallID != "" {
+		return corr.ToolCallID
+	}
+	if corr.SegmentID != "" {
+		return corr.SegmentID
 	}
 	if strings.TrimSpace(tc.ID) != "" {
 		return tc.ID

--- a/pkg/steps/ai/openai/chat_stream_reducer_test.go
+++ b/pkg/steps/ai/openai/chat_stream_reducer_test.go
@@ -216,6 +216,34 @@ func TestReduceOpenAIChatStreamReviewDerivedScenarios(t *testing.T) {
 	}
 }
 
+func TestOpenAIChatCorrelationUsesProviderCallIndexForTextAndReasoningSegments(t *testing.T) {
+	state := newTestOpenAIChatStreamState()
+	state.ProviderCallCorr = events.BuildProviderCallCorrelation("openai", "inference-1", "", 2, "")
+	state.CurrentResponseID = "chatcmpl-test"
+
+	for _, tt := range []struct {
+		name       string
+		streamKind string
+		wantType   string
+	}{
+		{name: "text", streamKind: events.StreamKindContent, wantType: events.SegmentTypeText},
+		{name: "reasoning", streamKind: events.StreamKindReasoning, wantType: events.SegmentTypeReasoning},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			corr := state.chatCorrelation(ptrInt(0), tt.streamKind, "", nil)
+			if corr.SegmentIndex != 3 {
+				t.Fatalf("SegmentIndex = %d, want providerCallIndex+1 = 3", corr.SegmentIndex)
+			}
+			if corr.SegmentType != tt.wantType {
+				t.Fatalf("SegmentType = %q, want %q", corr.SegmentType, tt.wantType)
+			}
+			if corr.SegmentID == "" || corr.CorrelationKey == "" {
+				t.Fatalf("segment identity missing: %+v", corr)
+			}
+		})
+	}
+}
+
 func TestReduceOpenAIChatStreamToolArgumentsAccumulate(t *testing.T) {
 	state := newTestOpenAIChatStreamState()
 	var got []events.Event
@@ -256,6 +284,8 @@ func newTestOpenAIChatStreamState() openAIChatStreamState {
 	providerCallCorr := events.BuildProviderCallCorrelation("openai", metadata.InferenceID, "", 0, "")
 	return newOpenAIChatStreamState(metadata, "openai", "gpt-test", providerCallCorr)
 }
+
+func ptrInt(v int) *int { return &v }
 
 func chunkInput(chunk chatStreamEvent) openAIChatStreamInput {
 	return openAIChatStreamInput{Kind: openAIChatStreamInputChunk, Chunk: chunk}

--- a/pkg/steps/ai/openai/chat_stream_reducer_test.go
+++ b/pkg/steps/ai/openai/chat_stream_reducer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/go-go-golems/geppetto/pkg/events"
@@ -216,7 +217,7 @@ func TestReduceOpenAIChatStreamReviewDerivedScenarios(t *testing.T) {
 	}
 }
 
-func TestOpenAIChatCorrelationUsesProviderCallIndexForTextAndReasoningSegments(t *testing.T) {
+func TestOpenAIChatCorrelationUsesExplicitSegmentIDs(t *testing.T) {
 	state := newTestOpenAIChatStreamState()
 	state.ProviderCallCorr = events.BuildProviderCallCorrelation("openai", "inference-1", "", 2, "")
 	state.CurrentResponseID = "chatcmpl-test"
@@ -224,34 +225,30 @@ func TestOpenAIChatCorrelationUsesProviderCallIndexForTextAndReasoningSegments(t
 	for _, tt := range []struct {
 		name       string
 		streamKind string
-		wantType   string
+		wantPart   string
 	}{
-		{name: "text", streamKind: events.StreamKindContent, wantType: events.SegmentTypeText},
-		{name: "reasoning", streamKind: events.StreamKindReasoning, wantType: events.SegmentTypeReasoning},
+		{name: "text", streamKind: events.StreamKindContent, wantPart: events.StreamKindContent},
+		{name: "reasoning", streamKind: events.StreamKindReasoning, wantPart: events.StreamKindReasoning},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			corr := state.chatCorrelation(ptrInt(0), tt.streamKind, "", nil)
-			if corr.SegmentIndex != 3 {
-				t.Fatalf("SegmentIndex = %d, want providerCallIndex+1 = 3", corr.SegmentIndex)
+			if corr.RunID != "inference-1" || corr.ProviderCallID == "" || corr.SegmentID == "" {
+				t.Fatalf("explicit correlation identity missing: %+v", corr)
 			}
-			if corr.SegmentType != tt.wantType {
-				t.Fatalf("SegmentType = %q, want %q", corr.SegmentType, tt.wantType)
-			}
-			if corr.SegmentID == "" || corr.CorrelationKey == "" {
-				t.Fatalf("segment identity missing: %+v", corr)
+			if !strings.Contains(corr.SegmentID, tt.wantPart) {
+				t.Fatalf("SegmentID = %q, want opaque ID containing %q", corr.SegmentID, tt.wantPart)
 			}
 		})
 	}
 }
 
-func TestOpenAIChatSameCallReasoningAndTextShareSegmentIndexButKeepDistinctIdentity(t *testing.T) {
+func TestOpenAIChatSameCallReasoningAndTextKeepDistinctSegmentIDs(t *testing.T) {
 	for _, tt := range []struct {
 		name              string
 		providerCallIndex int
-		wantSegmentIndex  int32
 	}{
-		{name: "first provider call", providerCallIndex: 0, wantSegmentIndex: 1},
-		{name: "third provider call", providerCallIndex: 2, wantSegmentIndex: 3},
+		{name: "first provider call", providerCallIndex: 0},
+		{name: "third provider call", providerCallIndex: 2},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			state := newTestOpenAIChatStreamState()
@@ -279,29 +276,28 @@ func TestOpenAIChatSameCallReasoningAndTextShareSegmentIndexButKeepDistinctIdent
 			})
 			assertOpenAIChatCanonicalEventsValidate(t, got)
 
-			byType := map[string][]events.Correlation{}
+			byKind := map[string][]events.Correlation{}
 			for _, ev := range got {
 				correlated, ok := ev.(events.CorrelatedEvent)
 				if !ok {
 					continue
 				}
 				corr := correlated.Correlation()
-				switch corr.SegmentType {
-				case events.SegmentTypeReasoning, events.SegmentTypeText:
-					byType[corr.SegmentType] = append(byType[corr.SegmentType], corr)
+				switch {
+				case strings.Contains(corr.SegmentID, events.StreamKindReasoning):
+					byKind[events.SegmentTypeReasoning] = append(byKind[events.SegmentTypeReasoning], corr)
+				case strings.Contains(corr.SegmentID, events.StreamKindContent):
+					byKind[events.SegmentTypeText] = append(byKind[events.SegmentTypeText], corr)
 				}
 			}
 
-			reasoning := byType[events.SegmentTypeReasoning]
-			text := byType[events.SegmentTypeText]
+			reasoning := byKind[events.SegmentTypeReasoning]
+			text := byKind[events.SegmentTypeText]
 			if len(reasoning) != 3 || len(text) != 3 {
 				t.Fatalf("correlation counts: reasoning=%d text=%d, want 3 each", len(reasoning), len(text))
 			}
-			assertOpenAIChatSegmentCorrelationGroup(t, reasoning, tt.wantSegmentIndex, events.SegmentTypeReasoning, events.StreamKindReasoning)
-			assertOpenAIChatSegmentCorrelationGroup(t, text, tt.wantSegmentIndex, events.SegmentTypeText, events.StreamKindContent)
-			if reasoning[0].CorrelationKey == text[0].CorrelationKey {
-				t.Fatalf("reasoning and text correlation keys both %q; want distinct identity", reasoning[0].CorrelationKey)
-			}
+			assertOpenAIChatSegmentCorrelationGroup(t, reasoning, events.SegmentTypeReasoning)
+			assertOpenAIChatSegmentCorrelationGroup(t, text, events.SegmentTypeText)
 			if reasoning[0].SegmentID == text[0].SegmentID {
 				t.Fatalf("reasoning and text segment IDs both %q; want distinct identity", reasoning[0].SegmentID)
 			}
@@ -347,7 +343,7 @@ func newTestOpenAIChatStreamState() openAIChatStreamState {
 		TurnID:      "turn-1",
 	}
 	providerCallCorr := events.BuildProviderCallCorrelation("openai", metadata.InferenceID, "", 0, "")
-	return newOpenAIChatStreamState(metadata, "openai", "gpt-test", providerCallCorr)
+	return newOpenAIChatStreamState(metadata, "openai", "gpt-test", providerCallCorr, 0)
 }
 
 func ptrInt(v int) *int { return &v }
@@ -427,30 +423,18 @@ func assertOpenAIChatEventTypes(t *testing.T, got []events.Event, want []events.
 	}
 }
 
-func assertOpenAIChatSegmentCorrelationGroup(t *testing.T, got []events.Correlation, wantSegmentIndex int32, wantSegmentType, wantStreamKind string) {
+func assertOpenAIChatSegmentCorrelationGroup(t *testing.T, got []events.Correlation, wantSegmentType string) {
 	t.Helper()
 	if len(got) == 0 {
 		t.Fatalf("missing %s correlations", wantSegmentType)
 	}
 	first := got[0]
-	if first.CorrelationKey == "" || first.SegmentID == "" {
+	if first.RunID == "" || first.ProviderCallID == "" || first.SegmentID == "" {
 		t.Fatalf("first %s correlation missing identity: %+v", wantSegmentType, first)
 	}
 	for i, corr := range got {
-		if corr.ProviderCallIndex != wantSegmentIndex-1 {
-			t.Fatalf("%s[%d].ProviderCallIndex = %d, want %d", wantSegmentType, i, corr.ProviderCallIndex, wantSegmentIndex-1)
-		}
-		if corr.SegmentIndex != wantSegmentIndex {
-			t.Fatalf("%s[%d].SegmentIndex = %d, want %d", wantSegmentType, i, corr.SegmentIndex, wantSegmentIndex)
-		}
-		if corr.SegmentType != wantSegmentType {
-			t.Fatalf("%s[%d].SegmentType = %q, want %q", wantSegmentType, i, corr.SegmentType, wantSegmentType)
-		}
-		if corr.StreamKind != wantStreamKind {
-			t.Fatalf("%s[%d].StreamKind = %q, want %q", wantSegmentType, i, corr.StreamKind, wantStreamKind)
-		}
-		if corr.CorrelationKey != first.CorrelationKey {
-			t.Fatalf("%s[%d].CorrelationKey = %q, want stable key %q", wantSegmentType, i, corr.CorrelationKey, first.CorrelationKey)
+		if corr.RunID != first.RunID || corr.ProviderCallID != first.ProviderCallID {
+			t.Fatalf("%s[%d] parent identity drift: %+v want run/provider %q/%q", wantSegmentType, i, corr, first.RunID, first.ProviderCallID)
 		}
 		if corr.SegmentID != first.SegmentID {
 			t.Fatalf("%s[%d].SegmentID = %q, want stable segment ID %q", wantSegmentType, i, corr.SegmentID, first.SegmentID)

--- a/pkg/steps/ai/openai/chat_stream_reducer_test.go
+++ b/pkg/steps/ai/openai/chat_stream_reducer_test.go
@@ -244,6 +244,71 @@ func TestOpenAIChatCorrelationUsesProviderCallIndexForTextAndReasoningSegments(t
 	}
 }
 
+func TestOpenAIChatSameCallReasoningAndTextShareSegmentIndexButKeepDistinctIdentity(t *testing.T) {
+	for _, tt := range []struct {
+		name              string
+		providerCallIndex int
+		wantSegmentIndex  int32
+	}{
+		{name: "first provider call", providerCallIndex: 0, wantSegmentIndex: 1},
+		{name: "third provider call", providerCallIndex: 2, wantSegmentIndex: 3},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			state := newTestOpenAIChatStreamState()
+			state.ProviderCallCorr = events.BuildProviderCallCorrelation("openai", "inference-1", "", tt.providerCallIndex, "")
+			var got []events.Event
+
+			for _, input := range []openAIChatStreamInput{
+				chunkInput(reasoningDelta("thinking")),
+				chunkInput(textDelta("answer")),
+				terminalInput(openAIChatTerminalEOF, nil),
+			} {
+				var effects []openAIChatStreamEffect
+				state, effects = reduceOpenAIChatStream(state, input)
+				got = append(got, eventsFromOpenAIChatEffects(effects)...)
+			}
+
+			assertOpenAIChatEventTypes(t, got, []events.EventType{
+				events.EventTypeReasoningSegmentStarted,
+				events.EventTypeReasoningDelta,
+				events.EventTypeTextSegmentStarted,
+				events.EventTypeTextDelta,
+				events.EventTypeReasoningSegmentFinished,
+				events.EventTypeTextSegmentFinished,
+				events.EventTypeProviderCallFinished,
+			})
+			assertOpenAIChatCanonicalEventsValidate(t, got)
+
+			byType := map[string][]events.Correlation{}
+			for _, ev := range got {
+				correlated, ok := ev.(events.CorrelatedEvent)
+				if !ok {
+					continue
+				}
+				corr := correlated.Correlation()
+				switch corr.SegmentType {
+				case events.SegmentTypeReasoning, events.SegmentTypeText:
+					byType[corr.SegmentType] = append(byType[corr.SegmentType], corr)
+				}
+			}
+
+			reasoning := byType[events.SegmentTypeReasoning]
+			text := byType[events.SegmentTypeText]
+			if len(reasoning) != 3 || len(text) != 3 {
+				t.Fatalf("correlation counts: reasoning=%d text=%d, want 3 each", len(reasoning), len(text))
+			}
+			assertOpenAIChatSegmentCorrelationGroup(t, reasoning, tt.wantSegmentIndex, events.SegmentTypeReasoning, events.StreamKindReasoning)
+			assertOpenAIChatSegmentCorrelationGroup(t, text, tt.wantSegmentIndex, events.SegmentTypeText, events.StreamKindContent)
+			if reasoning[0].CorrelationKey == text[0].CorrelationKey {
+				t.Fatalf("reasoning and text correlation keys both %q; want distinct identity", reasoning[0].CorrelationKey)
+			}
+			if reasoning[0].SegmentID == text[0].SegmentID {
+				t.Fatalf("reasoning and text segment IDs both %q; want distinct identity", reasoning[0].SegmentID)
+			}
+		})
+	}
+}
+
 func TestReduceOpenAIChatStreamToolArgumentsAccumulate(t *testing.T) {
 	state := newTestOpenAIChatStreamState()
 	var got []events.Event
@@ -359,6 +424,37 @@ func assertOpenAIChatEventTypes(t *testing.T, got []events.Event, want []events.
 	}
 	if !reflect.DeepEqual(gotTypes, want) {
 		t.Fatalf("event types = %#v, want %#v", gotTypes, want)
+	}
+}
+
+func assertOpenAIChatSegmentCorrelationGroup(t *testing.T, got []events.Correlation, wantSegmentIndex int32, wantSegmentType, wantStreamKind string) {
+	t.Helper()
+	if len(got) == 0 {
+		t.Fatalf("missing %s correlations", wantSegmentType)
+	}
+	first := got[0]
+	if first.CorrelationKey == "" || first.SegmentID == "" {
+		t.Fatalf("first %s correlation missing identity: %+v", wantSegmentType, first)
+	}
+	for i, corr := range got {
+		if corr.ProviderCallIndex != wantSegmentIndex-1 {
+			t.Fatalf("%s[%d].ProviderCallIndex = %d, want %d", wantSegmentType, i, corr.ProviderCallIndex, wantSegmentIndex-1)
+		}
+		if corr.SegmentIndex != wantSegmentIndex {
+			t.Fatalf("%s[%d].SegmentIndex = %d, want %d", wantSegmentType, i, corr.SegmentIndex, wantSegmentIndex)
+		}
+		if corr.SegmentType != wantSegmentType {
+			t.Fatalf("%s[%d].SegmentType = %q, want %q", wantSegmentType, i, corr.SegmentType, wantSegmentType)
+		}
+		if corr.StreamKind != wantStreamKind {
+			t.Fatalf("%s[%d].StreamKind = %q, want %q", wantSegmentType, i, corr.StreamKind, wantStreamKind)
+		}
+		if corr.CorrelationKey != first.CorrelationKey {
+			t.Fatalf("%s[%d].CorrelationKey = %q, want stable key %q", wantSegmentType, i, corr.CorrelationKey, first.CorrelationKey)
+		}
+		if corr.SegmentID != first.SegmentID {
+			t.Fatalf("%s[%d].SegmentID = %q, want stable segment ID %q", wantSegmentType, i, corr.SegmentID, first.SegmentID)
+		}
 	}
 }
 

--- a/pkg/steps/ai/openai/engine_openai.go
+++ b/pkg/steps/ai/openai/engine_openai.go
@@ -12,6 +12,7 @@ import (
 	gepsession "github.com/go-go-golems/geppetto/pkg/inference/session"
 	"github.com/go-go-golems/geppetto/pkg/inference/tools"
 	"github.com/go-go-golems/geppetto/pkg/turns"
+	"github.com/go-go-golems/geppetto/pkg/turns/toolblocks"
 
 	"github.com/go-go-golems/geppetto/pkg/events"
 	"github.com/google/uuid"
@@ -363,7 +364,8 @@ func appendOpenAIChatTurnBlocks(t *turns.Turn, state openAIChatStreamState, incl
 	for _, tc := range mergedToolCalls {
 		var args any
 		_ = json.Unmarshal([]byte(tc.Function.Arguments), &args)
-		turns.AppendBlock(t, turns.NewToolCallBlock(tc.ID, tc.Function.Name, args))
+		corr := state.chatCorrelation(state.CurrentChoiceIndex, events.StreamKindToolCall, tc.ID, tc.Index)
+		turns.AppendBlock(t, toolblocks.NewToolCallBlockWithCorrelation(tc.ID, tc.Function.Name, args, corr))
 	}
 	return len(mergedToolCalls)
 }

--- a/pkg/steps/ai/openai/engine_openai.go
+++ b/pkg/steps/ai/openai/engine_openai.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-go-golems/geppetto/pkg/inference/engine"
+	gepsession "github.com/go-go-golems/geppetto/pkg/inference/session"
 	"github.com/go-go-golems/geppetto/pkg/inference/tools"
 	"github.com/go-go-golems/geppetto/pkg/turns"
 
@@ -220,7 +221,11 @@ func (e *OpenAIEngine) RunInference(
 	if inferenceScopeID == "" {
 		inferenceScopeID = metadata.ID.String()
 	}
-	providerCallCorr := events.BuildProviderCallCorrelation(e.inferenceProvider(), inferenceScopeID, "", 0, "")
+	providerCallIndex := 0
+	if idx, ok := gepsession.ProviderCallIndexFromContext(ctx); ok {
+		providerCallIndex = idx
+	}
+	providerCallCorr := events.BuildProviderCallCorrelation(e.inferenceProvider(), inferenceScopeID, "", providerCallIndex, "")
 	providerCallCorr.Model = req.Model
 	providerCallCorr.TurnID = metadata.TurnID
 	e.publishEvent(ctx, events.NewProviderCallStartedEvent(metadata, providerCallCorr))

--- a/pkg/steps/ai/openai/engine_openai.go
+++ b/pkg/steps/ai/openai/engine_openai.go
@@ -226,7 +226,7 @@ func (e *OpenAIEngine) RunInference(
 		providerCallIndex = idx
 	}
 	providerCallCorr := events.BuildProviderCallCorrelation(e.inferenceProvider(), inferenceScopeID, "", providerCallIndex, "")
-	providerCallCorr.Model = req.Model
+	providerCallCorr.SessionID = metadata.SessionID
 	providerCallCorr.TurnID = metadata.TurnID
 	e.publishEvent(ctx, events.NewProviderCallStartedEvent(metadata, providerCallCorr))
 
@@ -248,7 +248,7 @@ func (e *OpenAIEngine) RunInference(
 		}
 	}()
 
-	state := newOpenAIChatStreamState(metadata, e.inferenceProvider(), req.Model, providerCallCorr)
+	state := newOpenAIChatStreamState(metadata, e.inferenceProvider(), req.Model, providerCallCorr, providerCallIndex)
 	state, terminal, runErr := e.consumeOpenAIChatStream(ctx, stream, state, metadata, req.Model)
 	state, metadata = e.completeOpenAIChatStream(ctx, t, state, metadata, req.Model, startTime, terminal)
 
@@ -396,8 +396,7 @@ func stopReasonString(stopReason *string) string {
 	return *stopReason
 }
 
-func providerCallCorrWithResponse(corr events.Correlation, responseID string) events.Correlation {
-	corr.ResponseID = responseID
+func providerCallCorrWithResponse(corr events.Correlation, _ string) events.Correlation {
 	return corr
 }
 

--- a/pkg/steps/ai/openai/observability.go
+++ b/pkg/steps/ai/openai/observability.go
@@ -201,7 +201,7 @@ func firstChatToolCall(calls []ChatToolCall) *ChatToolCall {
 }
 
 func chatCorrelationKey(provider, responseID string, choiceIndex *int, streamKind, toolCallID string, toolCallIndex *int) string {
-	return events.BuildChatCompletionsCorrelation(provider, responseID, choiceIndex, streamKind, toolCallID, toolCallIndex).CorrelationKey
+	return events.BuildChatCompletionsCorrelation(provider, responseID, choiceIndex, streamKind, toolCallID, toolCallIndex).SegmentID
 }
 
 func applyChatProviderDataToRecord(rec *geppettoobs.Record, data map[string]interface{}) {

--- a/pkg/steps/ai/openai/observability_test.go
+++ b/pkg/steps/ai/openai/observability_test.go
@@ -201,8 +201,8 @@ func TestOpenAIObservabilityAddsChatCorrelationFields(t *testing.T) {
 	if reasoningPublish == nil {
 		t.Fatalf("missing reasoning delta publish record")
 	}
-	if reasoningPublish.CorrelationKey != reasoningRec.CorrelationKey || reasoningPublish.StreamKind != "reasoning" {
-		t.Fatalf("reasoning publish did not preserve correlation data: %#v", reasoningPublish)
+	if reasoningPublish.SegmentID != reasoningRec.CorrelationKey {
+		t.Fatalf("reasoning publish did not preserve segment identity: %#v", reasoningPublish)
 	}
 }
 
@@ -247,7 +247,7 @@ func TestOpenAIObservabilityAddsToolCorrelationFields(t *testing.T) {
 	if toolPublish == nil {
 		t.Fatalf("missing tool requested publish record")
 	}
-	if toolPublish.CorrelationKey != toolProvider.CorrelationKey || toolPublish.ToolCallID != "call_1" {
+	if toolPublish.SegmentID != toolProvider.CorrelationKey || toolPublish.ToolCallID != "call_1" {
 		t.Fatalf("tool publish did not preserve correlation data: %#v", toolPublish)
 	}
 }

--- a/pkg/steps/ai/openai_responses/correlation_test.go
+++ b/pkg/steps/ai/openai_responses/correlation_test.go
@@ -47,12 +47,13 @@ func TestResponsesSegmentCorrelationInheritsProviderCallIndex(t *testing.T) {
 	outputIndex := 0
 
 	for _, tt := range []struct {
-		name        string
-		segmentType string
-		streamKind  string
+		name             string
+		segmentType      string
+		streamKind       string
+		wantSegmentIndex int32
 	}{
-		{name: "text", segmentType: events.SegmentTypeText, streamKind: events.StreamKindContent},
-		{name: "reasoning", segmentType: events.SegmentTypeReasoning, streamKind: events.StreamKindReasoning},
+		{name: "text", segmentType: events.SegmentTypeText, streamKind: events.StreamKindContent, wantSegmentIndex: 3},
+		{name: "reasoning", segmentType: events.SegmentTypeReasoning, streamKind: events.StreamKindReasoning, wantSegmentIndex: 3},
 		{name: "tool", segmentType: events.SegmentTypeTool, streamKind: events.StreamKindToolCall},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -65,6 +66,9 @@ func TestResponsesSegmentCorrelationInheritsProviderCallIndex(t *testing.T) {
 			}
 			if corr.ParentCorrelationKey != providerCorr.CorrelationKey {
 				t.Fatalf("ParentCorrelationKey = %q, want %q", corr.ParentCorrelationKey, providerCorr.CorrelationKey)
+			}
+			if corr.SegmentIndex != tt.wantSegmentIndex {
+				t.Fatalf("SegmentIndex = %d, want %d", corr.SegmentIndex, tt.wantSegmentIndex)
 			}
 			if corr.SegmentType != tt.segmentType {
 				t.Fatalf("SegmentType = %q, want %q", corr.SegmentType, tt.segmentType)

--- a/pkg/steps/ai/openai_responses/correlation_test.go
+++ b/pkg/steps/ai/openai_responses/correlation_test.go
@@ -1,0 +1,80 @@
+package openai_responses
+
+import (
+	"testing"
+
+	"github.com/go-go-golems/geppetto/pkg/events"
+)
+
+func TestResponsesProviderCallCorrelationUsesProviderCallIndex(t *testing.T) {
+	metadata := events.EventMetadata{InferenceID: "inference-1", TurnID: "turn-1"}
+	reqBody := responsesRequest{Model: "gpt-test"}
+
+	for _, tt := range []struct {
+		name              string
+		providerCallIndex int
+		wantProviderID    string
+	}{
+		{name: "first provider call", providerCallIndex: 0, wantProviderID: "openai_responses:inference-1:provider-call:0"},
+		{name: "third provider call", providerCallIndex: 2, wantProviderID: "openai_responses:inference-1:provider-call:2"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			corr := newResponsesProviderCallCorrelation(metadata, reqBody, tt.providerCallIndex)
+			if corr.ProviderCallIndex != int32(tt.providerCallIndex) {
+				t.Fatalf("ProviderCallIndex = %d, want %d", corr.ProviderCallIndex, tt.providerCallIndex)
+			}
+			if corr.ProviderCallID != tt.wantProviderID {
+				t.Fatalf("ProviderCallID = %q, want %q", corr.ProviderCallID, tt.wantProviderID)
+			}
+			if corr.CorrelationKey != tt.wantProviderID {
+				t.Fatalf("CorrelationKey = %q, want %q", corr.CorrelationKey, tt.wantProviderID)
+			}
+			if corr.Model != reqBody.Model {
+				t.Fatalf("Model = %q, want %q", corr.Model, reqBody.Model)
+			}
+			if corr.TurnID != metadata.TurnID {
+				t.Fatalf("TurnID = %q, want %q", corr.TurnID, metadata.TurnID)
+			}
+		})
+	}
+}
+
+func TestResponsesSegmentCorrelationInheritsProviderCallIndex(t *testing.T) {
+	metadata := events.EventMetadata{InferenceID: "inference-1", TurnID: "turn-1"}
+	providerCorr := newResponsesProviderCallCorrelation(metadata, responsesRequest{Model: "gpt-test"}, 2)
+	state := newResponsesStreamState(responsesRequest{Model: "gpt-test"}, providerCorr, nil)
+	state.currentResponseID = "resp-1"
+	outputIndex := 0
+
+	for _, tt := range []struct {
+		name        string
+		segmentType string
+		streamKind  string
+	}{
+		{name: "text", segmentType: events.SegmentTypeText, streamKind: events.StreamKindContent},
+		{name: "reasoning", segmentType: events.SegmentTypeReasoning, streamKind: events.StreamKindReasoning},
+		{name: "tool", segmentType: events.SegmentTypeTool, streamKind: events.StreamKindToolCall},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			corr := state.segmentCorrelation("item-1", &outputIndex, nil, tt.segmentType)
+			if corr.ProviderCallIndex != 2 {
+				t.Fatalf("ProviderCallIndex = %d, want 2", corr.ProviderCallIndex)
+			}
+			if corr.ProviderCallID != providerCorr.ProviderCallID {
+				t.Fatalf("ProviderCallID = %q, want %q", corr.ProviderCallID, providerCorr.ProviderCallID)
+			}
+			if corr.ParentCorrelationKey != providerCorr.CorrelationKey {
+				t.Fatalf("ParentCorrelationKey = %q, want %q", corr.ParentCorrelationKey, providerCorr.CorrelationKey)
+			}
+			if corr.SegmentType != tt.segmentType {
+				t.Fatalf("SegmentType = %q, want %q", corr.SegmentType, tt.segmentType)
+			}
+			if corr.StreamKind != tt.streamKind {
+				t.Fatalf("StreamKind = %q, want %q", corr.StreamKind, tt.streamKind)
+			}
+			if corr.SegmentID == "" || corr.CorrelationKey == "" {
+				t.Fatalf("segment identity missing: %+v", corr)
+			}
+		})
+	}
+}

--- a/pkg/steps/ai/openai_responses/correlation_test.go
+++ b/pkg/steps/ai/openai_responses/correlation_test.go
@@ -39,7 +39,7 @@ func TestResponsesProviderCallCorrelationUsesProviderCallIndex(t *testing.T) {
 	}
 }
 
-func TestResponsesSegmentCorrelationInheritsProviderCallIndex(t *testing.T) {
+func TestResponsesSegmentCorrelationKeepsProviderCallIndexAndTypedSegmentIdentity(t *testing.T) {
 	metadata := events.EventMetadata{InferenceID: "inference-1", TurnID: "turn-1"}
 	providerCorr := newResponsesProviderCallCorrelation(metadata, responsesRequest{Model: "gpt-test"}, 2)
 	state := newResponsesStreamState(responsesRequest{Model: "gpt-test"}, providerCorr, nil)
@@ -47,13 +47,12 @@ func TestResponsesSegmentCorrelationInheritsProviderCallIndex(t *testing.T) {
 	outputIndex := 0
 
 	for _, tt := range []struct {
-		name             string
-		segmentType      string
-		streamKind       string
-		wantSegmentIndex int32
+		name        string
+		segmentType string
+		streamKind  string
 	}{
-		{name: "text", segmentType: events.SegmentTypeText, streamKind: events.StreamKindContent, wantSegmentIndex: 3},
-		{name: "reasoning", segmentType: events.SegmentTypeReasoning, streamKind: events.StreamKindReasoning, wantSegmentIndex: 3},
+		{name: "text", segmentType: events.SegmentTypeText, streamKind: events.StreamKindContent},
+		{name: "reasoning", segmentType: events.SegmentTypeReasoning, streamKind: events.StreamKindReasoning},
 		{name: "tool", segmentType: events.SegmentTypeTool, streamKind: events.StreamKindToolCall},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -67,8 +66,8 @@ func TestResponsesSegmentCorrelationInheritsProviderCallIndex(t *testing.T) {
 			if corr.ParentCorrelationKey != providerCorr.CorrelationKey {
 				t.Fatalf("ParentCorrelationKey = %q, want %q", corr.ParentCorrelationKey, providerCorr.CorrelationKey)
 			}
-			if corr.SegmentIndex != tt.wantSegmentIndex {
-				t.Fatalf("SegmentIndex = %d, want %d", corr.SegmentIndex, tt.wantSegmentIndex)
+			if corr.SegmentIndex != 0 {
+				t.Fatalf("SegmentIndex = %d, want 0; Responses uses provider item/output identity because one provider call may contain multiple same-type segments", corr.SegmentIndex)
 			}
 			if corr.SegmentType != tt.segmentType {
 				t.Fatalf("SegmentType = %q, want %q", corr.SegmentType, tt.segmentType)
@@ -80,5 +79,38 @@ func TestResponsesSegmentCorrelationInheritsProviderCallIndex(t *testing.T) {
 				t.Fatalf("segment identity missing: %+v", corr)
 			}
 		})
+	}
+}
+
+func TestResponsesMultipleReasoningSegmentsInSameProviderCallDoNotShareIdentity(t *testing.T) {
+	metadata := events.EventMetadata{InferenceID: "inference-1", TurnID: "turn-1"}
+	providerCorr := newResponsesProviderCallCorrelation(metadata, responsesRequest{Model: "gpt-test"}, 2)
+	state := newResponsesStreamState(responsesRequest{Model: "gpt-test"}, providerCorr, nil)
+	state.currentResponseID = "resp-1"
+	firstOutputIndex := 0
+	secondOutputIndex := 2
+
+	first := state.segmentCorrelation("rs_1", &firstOutputIndex, nil, events.SegmentTypeReasoning)
+	second := state.segmentCorrelation("rs_2", &secondOutputIndex, nil, events.SegmentTypeReasoning)
+
+	for name, corr := range map[string]events.Correlation{"first": first, "second": second} {
+		if corr.ProviderCallIndex != 2 {
+			t.Fatalf("%s ProviderCallIndex = %d, want 2", name, corr.ProviderCallIndex)
+		}
+		if corr.SegmentIndex != 0 {
+			t.Fatalf("%s SegmentIndex = %d, want 0; distinct Responses items should route by SegmentID/CorrelationKey", name, corr.SegmentIndex)
+		}
+		if corr.SegmentType != events.SegmentTypeReasoning || corr.StreamKind != events.StreamKindReasoning {
+			t.Fatalf("%s segment type/kind = %q/%q, want reasoning/reasoning", name, corr.SegmentType, corr.StreamKind)
+		}
+		if corr.SegmentID == "" || corr.CorrelationKey == "" {
+			t.Fatalf("%s correlation missing identity: %+v", name, corr)
+		}
+	}
+	if first.SegmentID == second.SegmentID {
+		t.Fatalf("SegmentID collision: %q", first.SegmentID)
+	}
+	if first.CorrelationKey == second.CorrelationKey {
+		t.Fatalf("CorrelationKey collision: %q", first.CorrelationKey)
 	}
 }

--- a/pkg/steps/ai/openai_responses/correlation_test.go
+++ b/pkg/steps/ai/openai_responses/correlation_test.go
@@ -1,13 +1,14 @@
 package openai_responses
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/go-go-golems/geppetto/pkg/events"
 )
 
-func TestResponsesProviderCallCorrelationUsesProviderCallIndex(t *testing.T) {
-	metadata := events.EventMetadata{InferenceID: "inference-1", TurnID: "turn-1"}
+func TestResponsesProviderCallCorrelationUsesExplicitProviderCallID(t *testing.T) {
+	metadata := events.EventMetadata{SessionID: "session-1", InferenceID: "inference-1", TurnID: "turn-1"}
 	reqBody := responsesRequest{Model: "gpt-test"}
 
 	for _, tt := range []struct {
@@ -20,27 +21,18 @@ func TestResponsesProviderCallCorrelationUsesProviderCallIndex(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			corr := newResponsesProviderCallCorrelation(metadata, reqBody, tt.providerCallIndex)
-			if corr.ProviderCallIndex != int32(tt.providerCallIndex) {
-				t.Fatalf("ProviderCallIndex = %d, want %d", corr.ProviderCallIndex, tt.providerCallIndex)
-			}
 			if corr.ProviderCallID != tt.wantProviderID {
 				t.Fatalf("ProviderCallID = %q, want %q", corr.ProviderCallID, tt.wantProviderID)
 			}
-			if corr.CorrelationKey != tt.wantProviderID {
-				t.Fatalf("CorrelationKey = %q, want %q", corr.CorrelationKey, tt.wantProviderID)
-			}
-			if corr.Model != reqBody.Model {
-				t.Fatalf("Model = %q, want %q", corr.Model, reqBody.Model)
-			}
-			if corr.TurnID != metadata.TurnID {
-				t.Fatalf("TurnID = %q, want %q", corr.TurnID, metadata.TurnID)
+			if corr.SessionID != metadata.SessionID || corr.RunID != metadata.InferenceID || corr.TurnID != metadata.TurnID {
+				t.Fatalf("scope identity mismatch: %+v", corr)
 			}
 		})
 	}
 }
 
-func TestResponsesSegmentCorrelationKeepsProviderCallIndexAndTypedSegmentIdentity(t *testing.T) {
-	metadata := events.EventMetadata{InferenceID: "inference-1", TurnID: "turn-1"}
+func TestResponsesSegmentCorrelationKeepsExplicitSegmentIdentity(t *testing.T) {
+	metadata := events.EventMetadata{SessionID: "session-1", InferenceID: "inference-1", TurnID: "turn-1"}
 	providerCorr := newResponsesProviderCallCorrelation(metadata, responsesRequest{Model: "gpt-test"}, 2)
 	state := newResponsesStreamState(responsesRequest{Model: "gpt-test"}, providerCorr, nil)
 	state.currentResponseID = "resp-1"
@@ -49,41 +41,25 @@ func TestResponsesSegmentCorrelationKeepsProviderCallIndexAndTypedSegmentIdentit
 	for _, tt := range []struct {
 		name        string
 		segmentType string
-		streamKind  string
 	}{
-		{name: "text", segmentType: events.SegmentTypeText, streamKind: events.StreamKindContent},
-		{name: "reasoning", segmentType: events.SegmentTypeReasoning, streamKind: events.StreamKindReasoning},
-		{name: "tool", segmentType: events.SegmentTypeTool, streamKind: events.StreamKindToolCall},
+		{name: "text", segmentType: events.SegmentTypeText},
+		{name: "reasoning", segmentType: events.SegmentTypeReasoning},
+		{name: "tool", segmentType: events.SegmentTypeTool},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			corr := state.segmentCorrelation("item-1", &outputIndex, nil, tt.segmentType)
-			if corr.ProviderCallIndex != 2 {
-				t.Fatalf("ProviderCallIndex = %d, want 2", corr.ProviderCallIndex)
+			if corr.RunID != providerCorr.RunID || corr.ProviderCallID != providerCorr.ProviderCallID {
+				t.Fatalf("parent identity mismatch: %+v want %+v", corr, providerCorr)
 			}
-			if corr.ProviderCallID != providerCorr.ProviderCallID {
-				t.Fatalf("ProviderCallID = %q, want %q", corr.ProviderCallID, providerCorr.ProviderCallID)
-			}
-			if corr.ParentCorrelationKey != providerCorr.CorrelationKey {
-				t.Fatalf("ParentCorrelationKey = %q, want %q", corr.ParentCorrelationKey, providerCorr.CorrelationKey)
-			}
-			if corr.SegmentIndex != 0 {
-				t.Fatalf("SegmentIndex = %d, want 0; Responses uses provider item/output identity because one provider call may contain multiple same-type segments", corr.SegmentIndex)
-			}
-			if corr.SegmentType != tt.segmentType {
-				t.Fatalf("SegmentType = %q, want %q", corr.SegmentType, tt.segmentType)
-			}
-			if corr.StreamKind != tt.streamKind {
-				t.Fatalf("StreamKind = %q, want %q", corr.StreamKind, tt.streamKind)
-			}
-			if corr.SegmentID == "" || corr.CorrelationKey == "" {
-				t.Fatalf("segment identity missing: %+v", corr)
+			if corr.SegmentID == "" || !strings.Contains(corr.SegmentID, "item:item-1") {
+				t.Fatalf("segment identity missing provider item: %+v", corr)
 			}
 		})
 	}
 }
 
 func TestResponsesMultipleReasoningSegmentsInSameProviderCallDoNotShareIdentity(t *testing.T) {
-	metadata := events.EventMetadata{InferenceID: "inference-1", TurnID: "turn-1"}
+	metadata := events.EventMetadata{SessionID: "session-1", InferenceID: "inference-1", TurnID: "turn-1"}
 	providerCorr := newResponsesProviderCallCorrelation(metadata, responsesRequest{Model: "gpt-test"}, 2)
 	state := newResponsesStreamState(responsesRequest{Model: "gpt-test"}, providerCorr, nil)
 	state.currentResponseID = "resp-1"
@@ -94,23 +70,14 @@ func TestResponsesMultipleReasoningSegmentsInSameProviderCallDoNotShareIdentity(
 	second := state.segmentCorrelation("rs_2", &secondOutputIndex, nil, events.SegmentTypeReasoning)
 
 	for name, corr := range map[string]events.Correlation{"first": first, "second": second} {
-		if corr.ProviderCallIndex != 2 {
-			t.Fatalf("%s ProviderCallIndex = %d, want 2", name, corr.ProviderCallIndex)
+		if corr.RunID != providerCorr.RunID || corr.ProviderCallID != providerCorr.ProviderCallID {
+			t.Fatalf("%s parent identity mismatch: %+v", name, corr)
 		}
-		if corr.SegmentIndex != 0 {
-			t.Fatalf("%s SegmentIndex = %d, want 0; distinct Responses items should route by SegmentID/CorrelationKey", name, corr.SegmentIndex)
-		}
-		if corr.SegmentType != events.SegmentTypeReasoning || corr.StreamKind != events.StreamKindReasoning {
-			t.Fatalf("%s segment type/kind = %q/%q, want reasoning/reasoning", name, corr.SegmentType, corr.StreamKind)
-		}
-		if corr.SegmentID == "" || corr.CorrelationKey == "" {
-			t.Fatalf("%s correlation missing identity: %+v", name, corr)
+		if corr.SegmentID == "" {
+			t.Fatalf("%s correlation missing SegmentID: %+v", name, corr)
 		}
 	}
 	if first.SegmentID == second.SegmentID {
 		t.Fatalf("SegmentID collision: %q", first.SegmentID)
-	}
-	if first.CorrelationKey == second.CorrelationKey {
-		t.Fatalf("CorrelationKey collision: %q", first.CorrelationKey)
 	}
 }

--- a/pkg/steps/ai/openai_responses/observability.go
+++ b/pkg/steps/ai/openai_responses/observability.go
@@ -113,7 +113,8 @@ func providerRecordBase(metadata events.EventMetadata, model string, currentResp
 	if idx, ok := intFromProviderNumber(m["summary_index"]); ok {
 		rec.SummaryIndex = &idx
 	}
-	rec.CorrelationKey = responsesCorrelationKey(rec.Provider, rec.ResponseID, rec.ItemID, rec.OutputIndex, rec.SummaryIndex)
+	rec.SegmentID = responsesSegmentID(rec.Provider, rec.ResponseID, rec.ItemID, rec.OutputIndex, rec.SummaryIndex)
+	rec.CorrelationKey = rec.SegmentID
 	return rec
 }
 
@@ -156,8 +157,8 @@ func providerData(provider, responseID, itemID string, outputIndex, summaryIndex
 	if summaryIndex != nil {
 		data["summary_index"] = *summaryIndex
 	}
-	if key := responsesCorrelationKey(provider, responseID, itemID, outputIndex, summaryIndex); key != "" {
-		data["correlation_key"] = key
+	if segmentID := responsesSegmentID(provider, responseID, itemID, outputIndex, summaryIndex); segmentID != "" {
+		data["segment_id"] = segmentID
 	}
 	if len(data) == 0 {
 		return nil
@@ -165,8 +166,8 @@ func providerData(provider, responseID, itemID string, outputIndex, summaryIndex
 	return data
 }
 
-func responsesCorrelationKey(provider, responseID, itemID string, outputIndex, summaryIndex *int) string {
-	return events.BuildResponsesCorrelation(provider, responseID, itemID, outputIndex, summaryIndex).CorrelationKey
+func responsesSegmentID(provider, responseID, itemID string, outputIndex, summaryIndex *int) string {
+	return events.BuildResponsesCorrelation(provider, responseID, itemID, outputIndex, summaryIndex).SegmentID
 }
 
 func applyProviderDataToRecord(rec *geppettoobs.Record, data map[string]interface{}) {

--- a/pkg/steps/ai/openai_responses/stream_state.go
+++ b/pkg/steps/ai/openai_responses/stream_state.go
@@ -80,23 +80,15 @@ func newResponsesStreamState(reqBody responsesRequest, providerCallCorr events.C
 }
 
 func (s *responsesStreamState) providerCallCorrelation() events.Correlation {
-	corr := s.providerCallCorr
-	corr.ResponseID = s.currentResponseID
-	return corr
+	return s.providerCallCorr
 }
 
-func (s *responsesStreamState) segmentCorrelation(itemID string, outputIndex, summaryIndex *int, segmentType string) events.Correlation {
+func (s *responsesStreamState) segmentCorrelation(itemID string, outputIndex, summaryIndex *int, _ string) events.Correlation {
 	corr := events.BuildResponsesCorrelation("openai_responses", s.currentResponseID, itemID, outputIndex, summaryIndex)
-	corr.ProviderCallID = s.providerCallCorr.ProviderCallID
-	corr.ProviderCallIndex = s.providerCallCorr.ProviderCallIndex
-	corr.ParentCorrelationKey = s.providerCallCorr.CorrelationKey
-	corr.Model = s.reqBody.Model
+	corr.SessionID = s.providerCallCorr.SessionID
+	corr.RunID = s.providerCallCorr.RunID
 	corr.TurnID = s.providerCallCorr.TurnID
-	corr.SegmentType = segmentType
-	corr.StreamKind = streamKindForResponsesSegment(segmentType)
-	if corr.SegmentID == "" && corr.CorrelationKey != "" {
-		corr.SegmentID = corr.CorrelationKey
-	}
+	corr.ProviderCallID = s.providerCallCorr.ProviderCallID
 	return corr
 }
 

--- a/pkg/steps/ai/openai_responses/stream_state.go
+++ b/pkg/steps/ai/openai_responses/stream_state.go
@@ -94,6 +94,9 @@ func (s *responsesStreamState) segmentCorrelation(itemID string, outputIndex, su
 	corr.TurnID = s.providerCallCorr.TurnID
 	corr.SegmentType = segmentType
 	corr.StreamKind = streamKindForResponsesSegment(segmentType)
+	if segmentType == events.SegmentTypeText || segmentType == events.SegmentTypeReasoning {
+		corr.SegmentIndex = s.providerCallCorr.ProviderCallIndex + 1
+	}
 	if corr.SegmentID == "" && corr.CorrelationKey != "" {
 		corr.SegmentID = corr.CorrelationKey
 	}

--- a/pkg/steps/ai/openai_responses/stream_state.go
+++ b/pkg/steps/ai/openai_responses/stream_state.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-go-golems/geppetto/pkg/events"
 	"github.com/go-go-golems/geppetto/pkg/inference/engine"
 	"github.com/go-go-golems/geppetto/pkg/turns"
+	"github.com/go-go-golems/geppetto/pkg/turns/toolblocks"
 	"github.com/rs/zerolog/log"
 )
 
@@ -172,7 +173,7 @@ func appendResponsesFinalTurnBlocks(t *turns.Turn, state *responsesStreamState, 
 		if err := json.Unmarshal([]byte(pc.args.String()), &args); err != nil {
 			args = map[string]any{}
 		}
-		b := turns.NewToolCallBlock(pc.callID, pc.name, args)
+		b := toolblocks.NewToolCallBlockWithCorrelation(pc.callID, pc.name, args, state.toolCorrelation(pc.itemID, pc.callID, pc.outputIndex))
 		if b.Payload == nil {
 			b.Payload = map[string]any{}
 		}

--- a/pkg/steps/ai/openai_responses/stream_state.go
+++ b/pkg/steps/ai/openai_responses/stream_state.go
@@ -94,9 +94,6 @@ func (s *responsesStreamState) segmentCorrelation(itemID string, outputIndex, su
 	corr.TurnID = s.providerCallCorr.TurnID
 	corr.SegmentType = segmentType
 	corr.StreamKind = streamKindForResponsesSegment(segmentType)
-	if segmentType == events.SegmentTypeText || segmentType == events.SegmentTypeReasoning {
-		corr.SegmentIndex = s.providerCallCorr.ProviderCallIndex + 1
-	}
 	if corr.SegmentID == "" && corr.CorrelationKey != "" {
 		corr.SegmentID = corr.CorrelationKey
 	}

--- a/pkg/steps/ai/openai_responses/streaming.go
+++ b/pkg/steps/ai/openai_responses/streaming.go
@@ -237,16 +237,3 @@ func consumeResponsesSSE(
 		}
 	}
 }
-
-func streamKindForResponsesSegment(segmentType string) string {
-	switch segmentType {
-	case events.SegmentTypeText:
-		return events.StreamKindContent
-	case events.SegmentTypeReasoning:
-		return events.StreamKindReasoning
-	case events.SegmentTypeTool:
-		return events.StreamKindToolCall
-	default:
-		return ""
-	}
-}

--- a/pkg/steps/ai/openai_responses/streaming.go
+++ b/pkg/steps/ai/openai_responses/streaming.go
@@ -107,13 +107,13 @@ func responsesChunkFromValue(v any) string {
 	}
 }
 
-func newResponsesProviderCallCorrelation(metadata events.EventMetadata, reqBody responsesRequest, providerCallIndex int) events.Correlation {
+func newResponsesProviderCallCorrelation(metadata events.EventMetadata, _ responsesRequest, providerCallIndex int) events.Correlation {
 	inferenceScopeID := metadata.InferenceID
 	if inferenceScopeID == "" {
 		inferenceScopeID = metadata.ID.String()
 	}
 	corr := events.BuildProviderCallCorrelation("openai_responses", inferenceScopeID, "", providerCallIndex, "")
-	corr.Model = reqBody.Model
+	corr.SessionID = metadata.SessionID
 	corr.TurnID = metadata.TurnID
 	return corr
 }

--- a/pkg/steps/ai/openai_responses/streaming.go
+++ b/pkg/steps/ai/openai_responses/streaming.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-go-golems/geppetto/pkg/events"
 	"github.com/go-go-golems/geppetto/pkg/inference/engine"
+	gepsession "github.com/go-go-golems/geppetto/pkg/inference/session"
 	"github.com/go-go-golems/geppetto/pkg/turns"
 	"github.com/rs/zerolog/log"
 )
@@ -25,7 +26,11 @@ func (e *Engine) runStreamingInference(ctx context.Context, t *turns.Turn, httpC
 	reader := bufio.NewReader(resp.Body)
 	var eventName string
 	var dataBuf strings.Builder
-	providerCallCorr := newResponsesProviderCallCorrelation(metadata, reqBody)
+	providerCallIndex := 0
+	if idx, ok := gepsession.ProviderCallIndexFromContext(ctx); ok {
+		providerCallIndex = idx
+	}
+	providerCallCorr := newResponsesProviderCallCorrelation(metadata, reqBody, providerCallIndex)
 	e.publishEvent(ctx, events.NewProviderCallStartedEvent(metadata, providerCallCorr))
 	streamState := newResponsesStreamState(reqBody, providerCallCorr, tap)
 	log.Trace().Msg("Responses: starting SSE read loop")
@@ -102,12 +107,12 @@ func responsesChunkFromValue(v any) string {
 	}
 }
 
-func newResponsesProviderCallCorrelation(metadata events.EventMetadata, reqBody responsesRequest) events.Correlation {
+func newResponsesProviderCallCorrelation(metadata events.EventMetadata, reqBody responsesRequest, providerCallIndex int) events.Correlation {
 	inferenceScopeID := metadata.InferenceID
 	if inferenceScopeID == "" {
 		inferenceScopeID = metadata.ID.String()
 	}
-	corr := events.BuildProviderCallCorrelation("openai_responses", inferenceScopeID, "", 0, "")
+	corr := events.BuildProviderCallCorrelation("openai_responses", inferenceScopeID, "", providerCallIndex, "")
 	corr.Model = reqBody.Model
 	corr.TurnID = metadata.TurnID
 	return corr

--- a/pkg/turns/toolblocks/correlation.go
+++ b/pkg/turns/toolblocks/correlation.go
@@ -1,0 +1,112 @@
+package toolblocks
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/go-go-golems/geppetto/pkg/events"
+	"github.com/go-go-golems/geppetto/pkg/turns"
+)
+
+const PayloadKeyCorrelation = "correlation"
+
+// NewToolCallBlockWithCorrelation returns a tool_call block that preserves the
+// canonical provider/request correlation needed by host-side execution events.
+func NewToolCallBlockWithCorrelation(id string, name string, args any, corr events.Correlation) turns.Block {
+	b := turns.NewToolCallBlock(id, name, args)
+	AttachToolCallCorrelation(&b, corr)
+	return b
+}
+
+// AttachToolCallCorrelation stores canonical correlation on a tool_call block.
+// The stored value is debug/persistence friendly JSON data; consumers must still
+// treat IDs as opaque strings.
+func AttachToolCallCorrelation(b *turns.Block, corr events.Correlation) {
+	if b == nil {
+		return
+	}
+	if corr.ToolCallID == "" {
+		if id, _ := b.Payload[turns.PayloadKeyID].(string); id != "" {
+			corr.ToolCallID = id
+		}
+	}
+	if isEmptyCorrelation(corr) {
+		return
+	}
+	if b.Payload == nil {
+		b.Payload = map[string]any{}
+	}
+	b.Payload[PayloadKeyCorrelation] = corr
+}
+
+func toolCallCorrelationFromBlock(b turns.Block) (events.Correlation, bool) {
+	return decodeCorrelation(b.Payload[PayloadKeyCorrelation])
+}
+
+func decodeCorrelation(raw any) (events.Correlation, bool) {
+	switch v := raw.(type) {
+	case nil:
+		return events.Correlation{}, false
+	case events.Correlation:
+		return v, !isEmptyCorrelation(v)
+	case map[string]any:
+		corr := events.Correlation{
+			SessionID:      stringFromMap(v, "session_id", "sessionId"),
+			RunID:          stringFromMap(v, "run_id", "runId"),
+			TurnID:         stringFromMap(v, "turn_id", "turnId"),
+			ProviderCallID: stringFromMap(v, "provider_call_id", "providerCallId"),
+			SegmentID:      stringFromMap(v, "segment_id", "segmentId"),
+			ToolCallID:     stringFromMap(v, "tool_call_id", "toolCallId"),
+		}
+		return corr, !isEmptyCorrelation(corr)
+	case map[string]string:
+		corr := events.Correlation{
+			SessionID:      firstString(v, "session_id", "sessionId"),
+			RunID:          firstString(v, "run_id", "runId"),
+			TurnID:         firstString(v, "turn_id", "turnId"),
+			ProviderCallID: firstString(v, "provider_call_id", "providerCallId"),
+			SegmentID:      firstString(v, "segment_id", "segmentId"),
+			ToolCallID:     firstString(v, "tool_call_id", "toolCallId"),
+		}
+		return corr, !isEmptyCorrelation(corr)
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return events.Correlation{}, false
+		}
+		var corr events.Correlation
+		if err := json.Unmarshal(b, &corr); err != nil {
+			return events.Correlation{}, false
+		}
+		return corr, !isEmptyCorrelation(corr)
+	}
+}
+
+func isEmptyCorrelation(corr events.Correlation) bool {
+	return strings.TrimSpace(corr.SessionID) == "" &&
+		strings.TrimSpace(corr.RunID) == "" &&
+		strings.TrimSpace(corr.TurnID) == "" &&
+		strings.TrimSpace(corr.ProviderCallID) == "" &&
+		strings.TrimSpace(corr.SegmentID) == "" &&
+		strings.TrimSpace(corr.ToolCallID) == ""
+}
+
+func stringFromMap(m map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if v, ok := m[key]; ok {
+			if s, ok := v.(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+func firstString(m map[string]string, keys ...string) string {
+	for _, key := range keys {
+		if v := m[key]; v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/pkg/turns/toolblocks/toolblocks.go
+++ b/pkg/turns/toolblocks/toolblocks.go
@@ -2,14 +2,17 @@ package toolblocks
 
 import (
 	"encoding/json"
+
+	"github.com/go-go-golems/geppetto/pkg/events"
 	"github.com/go-go-golems/geppetto/pkg/turns"
 )
 
 // ToolCall represents a pending tool invocation described by a Turn block.
 type ToolCall struct {
-	ID        string
-	Name      string
-	Arguments map[string]any
+	ID          string
+	Name        string
+	Arguments   map[string]any
+	Correlation events.Correlation
 }
 
 // ToolResult represents the outcome of executing a tool call.
@@ -60,7 +63,8 @@ func ExtractPendingToolCalls(t *turns.Turn) []ToolCall {
 		if args == nil {
 			args = map[string]any{}
 		}
-		calls = append(calls, ToolCall{ID: id, Name: name, Arguments: args})
+		corr, _ := toolCallCorrelationFromBlock(b)
+		calls = append(calls, ToolCall{ID: id, Name: name, Arguments: args, Correlation: corr})
 	}
 	return calls
 }


### PR DESCRIPTION
This change addresses an issue where text or reasoning segments from multiple
LLM calls within a single turn (e.g., in a tool-use loop) could have
conflicting segment indices, causing them to overwrite each other in the UI.

### The Problem
In a tool-use scenario, the model might be called multiple times. Each call can
produce its own text or reasoning output. Previously, the segment indexing did
not account for multiple calls within the same turn, leading to non-unique
indices.

### The Solution
A new concept, `ProviderCallIndex`, is introduced to track the sequence of LLM
calls within a single inference loop.

- A `ProviderCallIndex` is now passed via the context by the `toolloop`.
- All AI engines (OpenAI, Gemini, Claude) have been updated to read this index
  and include it in their correlation data for observability events.
- The OpenAI stream reducer now uses this `ProviderCallIndex` to compute a
  unique `SegmentIndex` for text and reasoning segments. This ensures that
  segments from subsequent LLM calls receive a higher index, preventing
  conflicts.

This change is supported by extensive new tests to verify the correct indexing
behavior across different providers and scenarios.