### PR TITLE
Add CLI flags for profile introspection

### DIFF
--- a/pkg/cli/bootstrap/profile_introspection.go
+++ b/pkg/cli/bootstrap/profile_introspection.go
@@ -100,10 +100,22 @@ func BuildProfileRegistryReport(ctx context.Context, cfg AppBootstrapConfig, par
 	if chain == nil {
 		return &ProfileRegistryReport{}, cleanup, nil
 	}
+
+	// Determine the default profile slug from the default registry
+	// when the user has not explicitly selected a profile via --profile.
+	var defaultProfileSlug gepprofiles.EngineProfileSlug
+	if !chain.DefaultRegistrySlug.IsZero() && chain.DefaultProfileResolve.EngineProfileSlug.IsZero() {
+		reg, regErr := chain.Registry.GetRegistry(ctx, chain.DefaultRegistrySlug)
+		if regErr == nil && reg != nil && !reg.DefaultEngineProfileSlug.IsZero() {
+			defaultProfileSlug = reg.DefaultEngineProfileSlug
+		}
+	}
+
 	report, err := BuildProfileRegistryReportFromRegistry(ctx, ProfileRegistryReportInput{
 		SourceEntries:       runtime.ProfileSettings.ProfileRegistries,
 		Registry:            chain.Registry,
 		DefaultRegistrySlug: chain.DefaultRegistrySlug,
+		DefaultProfileSlug:  defaultProfileSlug,
 		ResolveInput:        chain.DefaultProfileResolve,
 	}, opts)
 	if err != nil {
@@ -349,7 +361,16 @@ func sourceReports(entries []string) []ProfileRegistrySourceReport {
 	}
 	ret := make([]ProfileRegistrySourceReport, 0, len(specs))
 	for _, spec := range specs {
-		ret = append(ret, ProfileRegistrySourceReport{Raw: spec.Raw, Kind: string(spec.Kind), Path: spec.Path, DSN: spec.DSN})
+		// Redact DSN to prevent leaking credentials from sqlite-dsn: sources.
+		var dsn, raw string
+		if spec.Kind == gepprofiles.RegistrySourceKindSQLiteDSN {
+			dsn = "***REDACTED***"
+			raw = "sqlite-dsn:***REDACTED***"
+		} else {
+			dsn = spec.DSN
+			raw = spec.Raw
+		}
+		ret = append(ret, ProfileRegistrySourceReport{Raw: raw, Kind: string(spec.Kind), Path: spec.Path, DSN: dsn})
 	}
 	return ret
 }

--- a/pkg/cli/bootstrap/profile_introspection.go
+++ b/pkg/cli/bootstrap/profile_introspection.go
@@ -1,0 +1,438 @@
+package bootstrap
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	gepprofiles "github.com/go-go-golems/geppetto/pkg/engineprofiles"
+	geppettosections "github.com/go-go-golems/geppetto/pkg/sections"
+	"github.com/go-go-golems/glazed/pkg/cmds/values"
+	"gopkg.in/yaml.v3"
+)
+
+type ProfileIntrospectionSettings = geppettosections.ProfileIntrospectionSettings
+
+type ProfileRegistryReportOptions struct {
+	IncludeResolution     bool
+	IncludeMergedSettings bool
+	RedactSecrets         bool
+}
+
+type ProfileRegistryReportInput struct {
+	SourceEntries       []string
+	Registry            gepprofiles.Registry
+	DefaultRegistrySlug gepprofiles.RegistrySlug
+	DefaultProfileSlug  gepprofiles.EngineProfileSlug
+	ResolveInput        gepprofiles.ResolveInput
+}
+
+type ProfileRegistryReport struct {
+	Sources          []ProfileRegistrySourceReport  `json:"sources,omitempty" yaml:"sources,omitempty"`
+	DefaultRegistry  string                         `json:"default_registry,omitempty" yaml:"default_registry,omitempty"`
+	DefaultProfile   string                         `json:"default_profile,omitempty" yaml:"default_profile,omitempty"`
+	SelectedRegistry string                         `json:"selected_registry,omitempty" yaml:"selected_registry,omitempty"`
+	SelectedProfile  string                         `json:"selected_profile,omitempty" yaml:"selected_profile,omitempty"`
+	Registries       []ProfileRegistrySummaryReport `json:"registries,omitempty" yaml:"registries,omitempty"`
+	Profiles         []ProfileSummaryReport         `json:"profiles,omitempty" yaml:"profiles,omitempty"`
+	Resolution       *ProfileResolutionReport       `json:"resolution,omitempty" yaml:"resolution,omitempty"`
+}
+
+type ProfileRegistrySourceReport struct {
+	Raw  string `json:"raw" yaml:"raw"`
+	Kind string `json:"kind" yaml:"kind"`
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
+	DSN  string `json:"dsn,omitempty" yaml:"dsn,omitempty"`
+}
+
+type ProfileRegistrySummaryReport struct {
+	Slug           string `json:"slug" yaml:"slug"`
+	DisplayName    string `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	Description    string `json:"description,omitempty" yaml:"description,omitempty"`
+	DefaultProfile string `json:"default_profile,omitempty" yaml:"default_profile,omitempty"`
+	ProfileCount   int    `json:"profile_count" yaml:"profile_count"`
+	IsDefault      bool   `json:"is_default,omitempty" yaml:"is_default,omitempty"`
+}
+
+type ProfileSummaryReport struct {
+	Registry    string `json:"registry" yaml:"registry"`
+	Slug        string `json:"slug" yaml:"slug"`
+	DisplayName string `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Model       string `json:"model,omitempty" yaml:"model,omitempty"`
+	APIType     string `json:"api_type,omitempty" yaml:"api_type,omitempty"`
+	Version     uint64 `json:"version,omitempty" yaml:"version,omitempty"`
+	Source      string `json:"source,omitempty" yaml:"source,omitempty"`
+	IsDefault   bool   `json:"is_default,omitempty" yaml:"is_default,omitempty"`
+	IsSelected  bool   `json:"is_selected,omitempty" yaml:"is_selected,omitempty"`
+}
+
+type ProfileResolutionReport struct {
+	Registry          string                                  `json:"registry" yaml:"registry"`
+	Profile           string                                  `json:"profile" yaml:"profile"`
+	Lineage           []gepprofiles.ResolvedProfileStackEntry `json:"lineage,omitempty" yaml:"lineage,omitempty"`
+	Metadata          map[string]any                          `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	InferenceSettings map[string]any                          `json:"inference_settings,omitempty" yaml:"inference_settings,omitempty"`
+}
+
+func ResolveProfileIntrospectionSettings(parsed *values.Values) ProfileIntrospectionSettings {
+	ret := ProfileIntrospectionSettings{}
+	if parsed != nil {
+		_ = parsed.DecodeSectionInto(geppettosections.ProfileIntrospectionSectionSlug, &ret)
+	}
+	ret.ProfileOutput = strings.TrimSpace(ret.ProfileOutput)
+	if ret.ProfileOutput == "" {
+		ret.ProfileOutput = "text"
+	}
+	return ret
+}
+
+func BuildProfileRegistryReport(ctx context.Context, cfg AppBootstrapConfig, parsed *values.Values, opts ProfileRegistryReportOptions) (*ProfileRegistryReport, func(), error) {
+	runtime, err := ResolveCLIProfileRuntime(ctx, cfg, parsed)
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanup := runtime.Close
+	chain := runtime.ProfileRegistryChain
+	if chain == nil {
+		return &ProfileRegistryReport{}, cleanup, nil
+	}
+	report, err := BuildProfileRegistryReportFromRegistry(ctx, ProfileRegistryReportInput{
+		SourceEntries:       runtime.ProfileSettings.ProfileRegistries,
+		Registry:            chain.Registry,
+		DefaultRegistrySlug: chain.DefaultRegistrySlug,
+		ResolveInput:        chain.DefaultProfileResolve,
+	}, opts)
+	if err != nil {
+		if cleanup != nil {
+			cleanup()
+		}
+		return nil, nil, err
+	}
+	return report, cleanup, nil
+}
+
+func BuildProfileRegistryReportFromRegistry(ctx context.Context, in ProfileRegistryReportInput, opts ProfileRegistryReportOptions) (*ProfileRegistryReport, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if in.Registry == nil {
+		return &ProfileRegistryReport{Sources: sourceReports(in.SourceEntries)}, nil
+	}
+	if !opts.RedactSecrets {
+		opts.RedactSecrets = true
+	}
+
+	report := &ProfileRegistryReport{
+		Sources:         sourceReports(in.SourceEntries),
+		DefaultRegistry: in.DefaultRegistrySlug.String(),
+	}
+	if !in.DefaultProfileSlug.IsZero() {
+		report.DefaultProfile = in.DefaultProfileSlug.String()
+	}
+	if !in.ResolveInput.RegistrySlug.IsZero() {
+		report.SelectedRegistry = in.ResolveInput.RegistrySlug.String()
+	}
+	if !in.ResolveInput.EngineProfileSlug.IsZero() {
+		report.SelectedProfile = in.ResolveInput.EngineProfileSlug.String()
+	}
+
+	registries, err := in.Registry.ListRegistries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(registries, func(i, j int) bool { return registries[i].Slug < registries[j].Slug })
+	for _, summary := range registries {
+		reg, err := in.Registry.GetRegistry(ctx, summary.Slug)
+		if err != nil {
+			return nil, err
+		}
+		defaultProfile := summary.DefaultEngineProfileSlug
+		if defaultProfile.IsZero() && reg != nil {
+			defaultProfile = reg.DefaultEngineProfileSlug
+		}
+		description := ""
+		if reg != nil {
+			description = strings.TrimSpace(reg.Description)
+		}
+		report.Registries = append(report.Registries, ProfileRegistrySummaryReport{
+			Slug:           summary.Slug.String(),
+			DisplayName:    strings.TrimSpace(summary.DisplayName),
+			Description:    description,
+			DefaultProfile: defaultProfile.String(),
+			ProfileCount:   summary.EngineProfileCount,
+			IsDefault:      summary.Slug == in.DefaultRegistrySlug,
+		})
+
+		profiles, err := in.Registry.ListEngineProfiles(ctx, summary.Slug)
+		if err != nil {
+			return nil, err
+		}
+		sort.Slice(profiles, func(i, j int) bool {
+			if profiles[i] == nil {
+				return false
+			}
+			if profiles[j] == nil {
+				return true
+			}
+			return profiles[i].Slug < profiles[j].Slug
+		})
+		for _, profile := range profiles {
+			if profile == nil {
+				continue
+			}
+			model, apiType := profileModelAndAPIType(profile)
+			report.Profiles = append(report.Profiles, ProfileSummaryReport{
+				Registry:    summary.Slug.String(),
+				Slug:        profile.Slug.String(),
+				DisplayName: strings.TrimSpace(profile.DisplayName),
+				Description: strings.TrimSpace(profile.Description),
+				Model:       model,
+				APIType:     apiType,
+				Version:     profile.Metadata.Version,
+				Source:      strings.TrimSpace(profile.Metadata.Source),
+				IsDefault:   profile.Slug == defaultProfile,
+				IsSelected:  isSelectedProfile(summary.Slug, profile.Slug, in.ResolveInput),
+			})
+		}
+	}
+
+	if opts.IncludeResolution {
+		resolveInput := in.ResolveInput
+		if resolveInput.RegistrySlug.IsZero() {
+			resolveInput.RegistrySlug = in.DefaultRegistrySlug
+		}
+		if resolveInput.EngineProfileSlug.IsZero() && !in.DefaultProfileSlug.IsZero() {
+			resolveInput.EngineProfileSlug = in.DefaultProfileSlug
+		}
+		resolved, err := in.Registry.ResolveEngineProfile(ctx, resolveInput)
+		if err != nil {
+			return nil, err
+		}
+		report.SelectedRegistry = resolved.RegistrySlug.String()
+		report.SelectedProfile = resolved.EngineProfileSlug.String()
+		report.Resolution = &ProfileResolutionReport{
+			Registry: resolved.RegistrySlug.String(),
+			Profile:  resolved.EngineProfileSlug.String(),
+			Lineage:  append([]gepprofiles.ResolvedProfileStackEntry(nil), resolved.StackLineage...),
+			Metadata: RedactProfileSecrets(resolved.Metadata).(map[string]any),
+		}
+		if opts.IncludeMergedSettings && resolved.InferenceSettings != nil {
+			settingsMap, err := inferenceSettingsMap(resolved.InferenceSettings)
+			if err != nil {
+				return nil, err
+			}
+			report.Resolution.InferenceSettings = RedactProfileSecrets(settingsMap).(map[string]any)
+		}
+	}
+
+	return report, nil
+}
+
+func RenderProfileRegistryReport(w io.Writer, report *ProfileRegistryReport, format string) error {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "", "text", "table":
+		return RenderProfileRegistryReportText(w, report)
+	case "json":
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	case "yaml", "yml":
+		b, err := yaml.Marshal(report)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(b)
+		return err
+	default:
+		return fmt.Errorf("unsupported profile output format %q", format)
+	}
+}
+
+func RenderProfileRegistryReportText(w io.Writer, report *ProfileRegistryReport) error {
+	if report == nil {
+		_, err := fmt.Fprintln(w, "No profile report available.")
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "Profile sources"); err != nil {
+		return err
+	}
+	if len(report.Sources) == 0 {
+		if _, err := fmt.Fprintln(w, "  none"); err != nil {
+			return err
+		}
+	}
+	for i, source := range report.Sources {
+		loc := firstNonEmpty(source.Path, source.DSN, source.Raw)
+		if _, err := fmt.Fprintf(w, "  %d. %s %s\n", i+1, source.Kind, loc); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintf(w, "\nDefault selection\n  registry: %s\n  profile:  %s\n", firstNonEmpty(report.DefaultRegistry, "none"), firstNonEmpty(report.DefaultProfile, "none")); err != nil {
+		return err
+	}
+	if report.SelectedRegistry != "" || report.SelectedProfile != "" {
+		if _, err := fmt.Fprintf(w, "\nSelected profile\n  registry: %s\n  profile:  %s\n", firstNonEmpty(report.SelectedRegistry, report.DefaultRegistry, "none"), firstNonEmpty(report.SelectedProfile, report.DefaultProfile, "none")); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintln(w, "\nRegistries"); err != nil {
+		return err
+	}
+	if len(report.Registries) == 0 {
+		if _, err := fmt.Fprintln(w, "  none"); err != nil {
+			return err
+		}
+	}
+	for _, reg := range report.Registries {
+		marker := " "
+		if reg.IsDefault {
+			marker = "*"
+		}
+		if _, err := fmt.Fprintf(w, "  %s %s profiles=%d default_profile=%s\n", marker, reg.Slug, reg.ProfileCount, firstNonEmpty(reg.DefaultProfile, "none")); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintln(w, "\nProfiles"); err != nil {
+		return err
+	}
+	if len(report.Profiles) == 0 {
+		if _, err := fmt.Fprintln(w, "  none"); err != nil {
+			return err
+		}
+	}
+	for _, profile := range report.Profiles {
+		marker := " "
+		if profile.IsDefault {
+			marker = "*"
+		}
+		selected := " "
+		if profile.IsSelected || (report.SelectedProfile != "" && profile.Slug == report.SelectedProfile && (report.SelectedRegistry == "" || profile.Registry == report.SelectedRegistry)) {
+			selected = ">"
+		}
+		desc := firstNonEmpty(profile.Description, profile.DisplayName)
+		if _, err := fmt.Fprintf(w, "  %s%s %-14s %-24s model=%-16s api=%-18s %s\n", selected, marker, profile.Registry, profile.Slug, firstNonEmpty(profile.Model, "-"), firstNonEmpty(profile.APIType, "-"), desc); err != nil {
+			return err
+		}
+	}
+	if report.Resolution != nil {
+		if _, err := fmt.Fprintf(w, "\nResolved profile\n  registry: %s\n  profile:  %s\n", report.Resolution.Registry, report.Resolution.Profile); err != nil {
+			return err
+		}
+		if len(report.Resolution.Lineage) > 0 {
+			if _, err := fmt.Fprintln(w, "\nStack lineage"); err != nil {
+				return err
+			}
+			for i, entry := range report.Resolution.Lineage {
+				if _, err := fmt.Fprintf(w, "  %d. %s/%s version=%d source=%s\n", i+1, entry.RegistrySlug, entry.EngineProfileSlug, entry.Version, firstNonEmpty(entry.Source, "-")); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func sourceReports(entries []string) []ProfileRegistrySourceReport {
+	specs, err := gepprofiles.ParseRegistrySourceSpecs(entries)
+	if err != nil {
+		ret := make([]ProfileRegistrySourceReport, 0, len(entries))
+		for _, entry := range entries {
+			if strings.TrimSpace(entry) != "" {
+				ret = append(ret, ProfileRegistrySourceReport{Raw: strings.TrimSpace(entry), Kind: "invalid"})
+			}
+		}
+		return ret
+	}
+	ret := make([]ProfileRegistrySourceReport, 0, len(specs))
+	for _, spec := range specs {
+		ret = append(ret, ProfileRegistrySourceReport{Raw: spec.Raw, Kind: string(spec.Kind), Path: spec.Path, DSN: spec.DSN})
+	}
+	return ret
+}
+
+func profileModelAndAPIType(profile *gepprofiles.EngineProfile) (string, string) {
+	if profile == nil || profile.InferenceSettings == nil || profile.InferenceSettings.Chat == nil {
+		return "", ""
+	}
+	model := ""
+	if profile.InferenceSettings.Chat.Engine != nil {
+		model = strings.TrimSpace(*profile.InferenceSettings.Chat.Engine)
+	}
+	apiType := ""
+	if profile.InferenceSettings.Chat.ApiType != nil {
+		apiType = strings.TrimSpace(string(*profile.InferenceSettings.Chat.ApiType))
+	}
+	return model, apiType
+}
+
+func isSelectedProfile(registry gepprofiles.RegistrySlug, profile gepprofiles.EngineProfileSlug, in gepprofiles.ResolveInput) bool {
+	if in.EngineProfileSlug.IsZero() || profile != in.EngineProfileSlug {
+		return false
+	}
+	return in.RegistrySlug.IsZero() || registry == in.RegistrySlug
+}
+
+func inferenceSettingsMap(in any) (map[string]any, error) {
+	b, err := yaml.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]any{}
+	if err := yaml.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func RedactProfileSecrets(v any) any {
+	switch typed := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for k, child := range typed {
+			if isSensitiveProfileKey(k) {
+				out[k] = "***REDACTED***"
+				continue
+			}
+			out[k] = RedactProfileSecrets(child)
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, child := range typed {
+			out = append(out, RedactProfileSecrets(child))
+		}
+		return out
+	case []map[string]any:
+		out := make([]map[string]any, 0, len(typed))
+		for _, child := range typed {
+			redacted, _ := RedactProfileSecrets(child).(map[string]any)
+			out = append(out, redacted)
+		}
+		return out
+	default:
+		return typed
+	}
+}
+
+func isSensitiveProfileKey(key string) bool {
+	k := strings.ToLower(strings.TrimSpace(key))
+	for _, needle := range []string{"api_key", "api-key", "apikey", "token", "secret", "password", "credential", "authorization", "auth_header", "key"} {
+		if strings.Contains(k, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/pkg/cli/bootstrap/profile_introspection_test.go
+++ b/pkg/cli/bootstrap/profile_introspection_test.go
@@ -70,6 +70,80 @@ func TestRenderProfileRegistryReportText(t *testing.T) {
 	}
 }
 
+func TestDefaultProfileSlugPopulatedFromRegistry(t *testing.T) {
+	// When no explicit --profile is given, the report should still show
+	// the default profile from the default registry.
+	// BuildProfileRegistryReportFromRegistry sets it from the registry metadata
+	// when the caller provides DefaultProfileSlug.
+	ctx := context.Background()
+	registry := testProfileReportRegistry(t)
+	report, err := BuildProfileRegistryReportFromRegistry(ctx, ProfileRegistryReportInput{
+		SourceEntries:       []string{"profiles.yaml"},
+		Registry:            registry,
+		DefaultRegistrySlug: gepprofiles.MustRegistrySlug("default"),
+		DefaultProfileSlug:  gepprofiles.MustEngineProfileSlug("default"),
+		// No ResolveInput.EngineProfileSlug set — simulates no --profile flag.
+	}, ProfileRegistryReportOptions{})
+	if err != nil {
+		t.Fatalf("BuildProfileRegistryReportFromRegistry: %v", err)
+	}
+	// The default registry's default profile is "default" (from the YAML fixture).
+	if report.DefaultProfile != "default" {
+		t.Fatalf("expected default_profile=default, got %q", report.DefaultProfile)
+	}
+}
+
+func TestDefaultProfileSlugExplicitOverridesRegistryDefault(t *testing.T) {
+	// When --profile is explicitly set, DefaultProfileSlug should remain empty
+	// (only the selected/resolve path should reflect the choice).
+	ctx := context.Background()
+	registry := testProfileReportRegistry(t)
+	report, err := BuildProfileRegistryReportFromRegistry(ctx, ProfileRegistryReportInput{
+		SourceEntries:       []string{"profiles.yaml"},
+		Registry:            registry,
+		DefaultRegistrySlug: gepprofiles.MustRegistrySlug("default"),
+		DefaultProfileSlug:  gepprofiles.MustEngineProfileSlug("fast"),
+	}, ProfileRegistryReportOptions{})
+	if err != nil {
+		t.Fatalf("BuildProfileRegistryReportFromRegistry: %v", err)
+	}
+	if report.DefaultProfile != "fast" {
+		t.Fatalf("expected default_profile=fast, got %q", report.DefaultProfile)
+	}
+}
+
+func TestSourceReportRedactsDSN(t *testing.T) {
+	reports := sourceReports([]string{"sqlite-dsn:file:test.db?_auth&_auth_user=admin&_auth_pass=s3cret"})
+	if len(reports) != 1 {
+		t.Fatalf("expected 1 source report, got %d", len(reports))
+	}
+	if reports[0].DSN != "***REDACTED***" {
+		t.Fatalf("expected redacted DSN, got %q", reports[0].DSN)
+	}
+	if reports[0].Raw != "sqlite-dsn:***REDACTED***" {
+		t.Fatalf("expected redacted Raw, got %q", reports[0].Raw)
+	}
+	if reports[0].Kind != "sqlite-dsn" {
+		t.Fatalf("expected kind sqlite-dsn, got %q", reports[0].Kind)
+	}
+}
+
+func TestSourceReportPreservesNonDSN(t *testing.T) {
+	reports := sourceReports([]string{"profiles.yaml"})
+	if len(reports) != 1 {
+		t.Fatalf("expected 1 source report, got %d", len(reports))
+	}
+	if reports[0].Kind != "yaml" {
+		t.Fatalf("expected yaml kind, got %q", reports[0].Kind)
+	}
+	if reports[0].Path != "profiles.yaml" {
+		t.Fatalf("expected path profiles.yaml, got %q", reports[0].Path)
+	}
+	if reports[0].DSN != "" {
+		t.Fatalf("expected empty DSN for yaml source, got %q", reports[0].DSN)
+	}
+}
+
 func testProfileReportRegistry(t *testing.T) gepprofiles.Registry {
 	t.Helper()
 	dir := t.TempDir()

--- a/pkg/cli/bootstrap/profile_introspection_test.go
+++ b/pkg/cli/bootstrap/profile_introspection_test.go
@@ -1,0 +1,111 @@
+package bootstrap
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gepprofiles "github.com/go-go-golems/geppetto/pkg/engineprofiles"
+	aitypes "github.com/go-go-golems/geppetto/pkg/steps/ai/types"
+)
+
+func TestBuildProfileRegistryReportFromRegistryListsDefaultsAndResolution(t *testing.T) {
+	ctx := context.Background()
+	registry := testProfileReportRegistry(t)
+	report, err := BuildProfileRegistryReportFromRegistry(ctx, ProfileRegistryReportInput{
+		SourceEntries:       []string{"profiles.yaml"},
+		Registry:            registry,
+		DefaultRegistrySlug: gepprofiles.MustRegistrySlug("default"),
+		ResolveInput: gepprofiles.ResolveInput{
+			RegistrySlug:      gepprofiles.MustRegistrySlug("default"),
+			EngineProfileSlug: gepprofiles.MustEngineProfileSlug("fast"),
+		},
+	}, ProfileRegistryReportOptions{IncludeResolution: true, IncludeMergedSettings: true, RedactSecrets: true})
+	if err != nil {
+		t.Fatalf("BuildProfileRegistryReportFromRegistry: %v", err)
+	}
+	if report.DefaultRegistry != "default" {
+		t.Fatalf("default registry mismatch: %#v", report)
+	}
+	if report.SelectedProfile != "fast" {
+		t.Fatalf("selected profile mismatch: %#v", report)
+	}
+	if len(report.Profiles) != 2 {
+		t.Fatalf("expected 2 profiles, got %d", len(report.Profiles))
+	}
+	if report.Profiles[1].Model != "gpt-4.1-mini" {
+		t.Fatalf("profile summary missing model: %#v", report.Profiles)
+	}
+	if report.Resolution == nil || len(report.Resolution.Lineage) != 2 {
+		t.Fatalf("expected stack lineage, got %#v", report.Resolution)
+	}
+	if got := report.Resolution.InferenceSettings["api"].(map[string]any)["api_keys"]; got != "***REDACTED***" {
+		t.Fatalf("expected api keys redacted, got %#v", got)
+	}
+}
+
+func TestRenderProfileRegistryReportText(t *testing.T) {
+	ctx := context.Background()
+	registry := testProfileReportRegistry(t)
+	report, err := BuildProfileRegistryReportFromRegistry(ctx, ProfileRegistryReportInput{
+		SourceEntries:       []string{"profiles.yaml"},
+		Registry:            registry,
+		DefaultRegistrySlug: gepprofiles.MustRegistrySlug("default"),
+	}, ProfileRegistryReportOptions{})
+	if err != nil {
+		t.Fatalf("BuildProfileRegistryReportFromRegistry: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := RenderProfileRegistryReport(&buf, report, "text"); err != nil {
+		t.Fatalf("RenderProfileRegistryReport: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"Profile sources", "Registries", "Profiles", "default", "fast", "gpt-4.1-mini", "openai"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func testProfileReportRegistry(t *testing.T) gepprofiles.Registry {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "profiles.yaml")
+	body := `slug: default
+profiles:
+  default:
+    slug: default
+    inference_settings:
+      chat:
+        api_type: openai
+        engine: gpt-4.1-mini
+      api:
+        api_keys:
+          openai-api-key: secret-value
+  fast:
+    slug: fast
+    description: Fast profile
+    stack:
+      - profile_slug: default
+    inference_settings:
+      chat:
+        engine: gpt-4.1-mini
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+	specs, err := gepprofiles.ParseRegistrySourceSpecs([]string{path})
+	if err != nil {
+		t.Fatalf("ParseRegistrySourceSpecs: %v", err)
+	}
+	registry, err := gepprofiles.NewChainedRegistryFromSourceSpecs(context.Background(), specs)
+	if err != nil {
+		t.Fatalf("NewChainedRegistryFromSourceSpecs: %v", err)
+	}
+	t.Cleanup(func() { _ = registry.Close() })
+	_ = aitypes.ApiTypeOpenAI // keep package import checked against profile YAML values used above
+	return registry
+}

--- a/pkg/sections/profile_introspection_section.go
+++ b/pkg/sections/profile_introspection_section.go
@@ -1,0 +1,41 @@
+package sections
+
+import (
+	"github.com/go-go-golems/glazed/pkg/cmds/fields"
+	"github.com/go-go-golems/glazed/pkg/cmds/schema"
+)
+
+const ProfileIntrospectionSectionSlug = "profile-introspection"
+
+type ProfileIntrospectionSettings struct {
+	PrintProfiles          bool   `glazed:"print-profiles"`
+	PrintProfileResolution bool   `glazed:"print-profile-resolution"`
+	ProfileOutput          string `glazed:"profile-output"`
+}
+
+func NewProfileIntrospectionSection() (schema.Section, error) {
+	return schema.NewSection(
+		ProfileIntrospectionSectionSlug,
+		"Profile introspection",
+		schema.WithFields(
+			fields.New(
+				"print-profiles",
+				fields.TypeBool,
+				fields.WithDefault(false),
+				fields.WithHelp("Print loaded profile registries and profiles, then exit before running inference"),
+			),
+			fields.New(
+				"print-profile-resolution",
+				fields.TypeBool,
+				fields.WithDefault(false),
+				fields.WithHelp("Include selected profile stack lineage and redacted merged settings in --print-profiles output"),
+			),
+			fields.New(
+				"profile-output",
+				fields.TypeString,
+				fields.WithDefault("text"),
+				fields.WithHelp("Profile introspection output format (text, json, yaml)"),
+			),
+		),
+	)
+}

--- a/ttmp/2026/05/13/GEPPETTO-005--profile-registry-resolution-and-print-profiles-design/README.md
+++ b/ttmp/2026/05/13/GEPPETTO-005--profile-registry-resolution-and-print-profiles-design/README.md
@@ -1,0 +1,21 @@
+# Profile registry resolution and print-profiles design
+
+This is the document workspace for ticket GEPPETTO-005.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GEPPETTO-005 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GEPPETTO-005 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GEPPETTO-005 --field Status --value review`

--- a/ttmp/2026/05/13/GEPPETTO-005--profile-registry-resolution-and-print-profiles-design/changelog.md
+++ b/ttmp/2026/05/13/GEPPETTO-005--profile-registry-resolution-and-print-profiles-design/changelog.md
@@ -1,0 +1,28 @@
+# Changelog
+
+## 2026-05-13
+
+- Initial workspace created
+
+
+## 2026-05-13
+
+Created the profile registry resolution and --print-profiles implementation guide, including Geppetto/Pinocchio/CoinVault architecture, file references, proposed APIs, CLI UX, security constraints, and intern implementation plan.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-13/coinvault-loop-analysis/geppetto/ttmp/2026/05/13/GEPPETTO-005--profile-registry-resolution-and-print-profiles-design/design-doc/01-profile-registry-resolution-and-print-profiles-implementation-guide.md — Primary design and implementation guide
+- /home/manuel/workspaces/2026-05-13/coinvault-loop-analysis/geppetto/ttmp/2026/05/13/GEPPETTO-005--profile-registry-resolution-and-print-profiles-design/reference/01-investigation-diary.md — Chronological investigation diary
+
+
+## 2026-05-13
+
+Implemented the first profile introspection slice: Geppetto now has reusable report/redaction/rendering helpers and a profile-introspection section, and CoinVault chat send has an early-exit --print-profiles path before DB/LLM startup.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-13/coinvault-loop-analysis/geppetto/../2026-03-16--gec-rag/cmd/coinvault/cmds/chat_send.go — Wires CoinVault chat send early-exit profile printing
+- /home/manuel/workspaces/2026-05-13/coinvault-loop-analysis/geppetto/pkg/cli/bootstrap/profile_introspection.go — Reusable profile registry report builder
+- /home/manuel/workspaces/2026-05-13/coinvault-loop-analysis/geppetto/pkg/cli/bootstrap/profile_introspection_test.go — Tests default/selected profile reporting
+- /home/manuel/workspaces/2026-05-13/coinvault-loop-analysis/geppetto/pkg/sections/profile_introspection_section.go — Defines --print-profiles and related profile introspection flags
+

--- a/ttmp/2026/05/13/GEPPETTO-005--profile-registry-resolution-and-print-profiles-design/design-doc/01-profile-registry-resolution-and-print-profiles-implementation-guide.md
+++ b/ttmp/2026/05/13/GEPPETTO-005--profile-registry-resolution-and-print-profiles-design/design-doc/01-profile-registry-resolution-and-print-profiles-implementation-guide.md
@@ -1,0 +1,1397 @@
+---
+Title: Profile registry resolution and print-profiles implementation guide
+Ticket: GEPPETTO-005
+Status: active
+Topics:
+    - geppetto
+    - pinocchio
+    - coinvault
+    - profiles
+    - cli
+    - configuration
+DocType: design-doc
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles:
+    - Path: ../../../../../../../2026-03-16--gec-rag/cmd/coinvault/cmds/chat_send.go
+      Note: First application integration for --print-profiles early exit
+    - Path: ../../../../../../../2026-03-16--gec-rag/cmd/coinvault/cmds/profile_settings.go
+      Note: CoinVault custom profile settings merger and local defaults
+    - Path: ../../../../../../../2026-03-16--gec-rag/internal/webchat/profiles.go
+      Note: CoinVault inference profile registry opener and HTTP profile APIs
+    - Path: ../../../../../../../2026-03-16--gec-rag/internal/webchat/sessionstream/sessionstream_runtime_resolver.go
+      Note: CoinVault runtime composition from application profile plus inference profile
+    - Path: ../../../../../../../pinocchio/pkg/cmds/profilebootstrap/profile_selection.go
+      Note: Pinocchio wrapper around Geppetto bootstrap with config docs and inline profiles
+    - Path: ../../../../../../../pinocchio/pkg/configdoc/profiles.go
+      Note: Converts Pinocchio inline profiles into a Geppetto registry and composes registries
+    - Path: pkg/cli/bootstrap/profile_introspection.go
+      Note: Implemented reusable report construction
+    - Path: pkg/cli/bootstrap/profile_introspection_test.go
+      Note: Covers report building
+    - Path: pkg/cli/bootstrap/profile_registry.go
+      Note: Constructs ResolvedProfileRegistryChain from profile settings
+    - Path: pkg/cli/bootstrap/profile_runtime.go
+      Note: Central Geppetto CLI profile runtime resolution from config/env/defaults plus explicit CLI
+    - Path: pkg/engineprofiles/service.go
+      Note: Resolves selected engine profiles
+    - Path: pkg/engineprofiles/source_chain.go
+      Note: Parses profile registry sources and builds ChainedRegistry precedence/defaults
+    - Path: pkg/sections/profile_introspection_section.go
+      Note: Implemented the Glazed profile-introspection flags
+    - Path: pkg/sections/profile_sections.go
+      Note: Defines the generic --profile and --profile-registries Glazed section
+ExternalSources: []
+Summary: ""
+LastUpdated: 0001-01-01T00:00:00Z
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+
+# Profile registry resolution and `--print-profiles` implementation guide
+
+## Executive summary
+
+This document explains how Geppetto, Pinocchio, and CoinVault currently load and resolve inference profiles, and proposes where to implement a `--print-profiles` CLI flag.
+
+The short answer is:
+
+- **The central profile model lives in Geppetto** under `pkg/engineprofiles`.
+- **The central reusable CLI bootstrap path also lives in Geppetto** under `pkg/cli/bootstrap`.
+- **Pinocchio mostly uses that bootstrap path**, then adds Pinocchio-specific unified config documents and inline profiles.
+- **CoinVault partially uses Geppetto profile flags**, but still has custom profile resolution glue for `profile-registry.local.yaml`, `application-profiles.yaml`, HTTP cookies, and its chat runtime.
+- The best long-term location for `--print-profiles` is therefore **Geppetto's CLI bootstrap/profile introspection layer**, with a small adapter for CoinVault's current custom path.
+
+The proposed feature should answer three user questions:
+
+1. **What profile registry sources were requested?**
+2. **What registries and profiles were actually loaded, and which default registry/profile won?**
+3. **For a selected profile, what stack layers and final merged inference settings/runtime overlays will the app use?**
+
+A good first implementation can print a concise table of loaded profiles and defaults. A second implementation can add `--print-profile-resolution` or `--print-profiles=resolved` to show lineage and merged settings.
+
+## Problem statement
+
+The current UX makes it hard to understand why a command used a particular model/profile. Users pass flags such as:
+
+```bash
+--profile-registries ./profile-registry.local.yaml \
+--profile gpt-5-low
+```
+
+or rely on implicit defaults such as:
+
+- `~/.config/pinocchio/profiles.yaml`
+- project-level `.pinocchio.yml`
+- CoinVault's `./profile-registry.local.yaml`
+- CoinVault's `./application-profiles.local.yaml`
+- registry default profile slugs
+- CLI overrides
+- HTTP body/cookie profile selection
+
+But there is no uniform CLI command or flag that prints the loaded registry stack and effective selection.
+
+This creates three recurring debugging problems:
+
+- A command appears to use the wrong model because a profile source higher in precedence shadowed another source.
+- A profile slug exists in one registry but the default registry points somewhere else.
+- App-specific layers, especially Pinocchio inline profiles and CoinVault application profiles, are confused with Geppetto inference profiles.
+
+## Vocabulary
+
+### Engine profile
+
+An **engine profile** is the Geppetto concept for named LLM/inference settings. It lives in `geppetto/pkg/engineprofiles` and is represented by `EngineProfile`.
+
+Important fields include:
+
+- `Slug`
+- `DisplayName`
+- `Description`
+- `Stack`
+- `InferenceSettings`
+- `Extensions`
+- `Metadata`
+
+Engine profiles are about **how to call the inference engine**: provider, model, API type, reasoning settings, middleware/runtime extensions, and related settings.
+
+### Engine profile registry
+
+An **engine profile registry** is a named collection of engine profiles. It is represented by `EngineProfileRegistry`.
+
+Important fields include:
+
+- `Slug`
+- `DisplayName`
+- `DefaultEngineProfileSlug`
+- `Profiles`
+- `Metadata`
+
+A registry can be loaded from YAML or SQLite.
+
+### Registry source
+
+A **registry source** is an input location passed by CLI/config, such as:
+
+```text
+./profile-registry.yaml
+yaml:./profiles.yaml
+sqlite:/tmp/profiles.db
+sqlite-dsn:file:/tmp/profiles.db?_foreign_keys=on
+```
+
+Geppetto parses these into `RegistrySourceSpec` values.
+
+### Chained registry
+
+A **chained registry** is Geppetto's multi-source registry. It loads multiple registry sources into one read interface, preserves source precedence, and resolves ambiguous profile slugs by searching top-of-stack sources first.
+
+The type is `engineprofiles.ChainedRegistry`.
+
+### Profile stack
+
+An engine profile can reference base profiles through `Stack`. Stack resolution expands a selected profile into base-to-leaf layers and merges them deterministically.
+
+Example conceptual YAML:
+
+```yaml
+profiles:
+  base-openai:
+    inference_settings:
+      chat:
+        engine: gpt-4.1-mini
+  gpt-5-low:
+    stack:
+      - profile: base-openai
+    inference_settings:
+      chat:
+        engine: gpt-5
+      inference:
+        reasoning_effort: low
+```
+
+The effective settings are:
+
+```text
+base-openai settings
+  overlaid by gpt-5-low settings
+```
+
+### Pinocchio unified config document
+
+Pinocchio adds `.pinocchio.yml` documents with top-level keys:
+
+- `app`
+- `profile`
+- `profiles`
+
+These can specify active profiles, imported registries, repositories, and inline profiles.
+
+### CoinVault application profile
+
+CoinVault has a separate concept called **application profile**. It is not the same as a Geppetto engine profile.
+
+Application profiles control CoinVault prompt/tool behavior:
+
+- selected system prompt
+- prompt template
+- enabled tool names
+
+They live in `application-profiles.yaml` and are loaded by `internal/appprofiles`.
+
+## High-level architecture
+
+```text
+                                ┌──────────────────────────────┐
+                                │          CLI command          │
+                                │ --profile, --profile-...      │
+                                │ --print-profiles (proposed)   │
+                                └──────────────┬───────────────┘
+                                               │
+                                               ▼
+                         ┌─────────────────────────────────────────┐
+                         │ Geppetto profile settings / bootstrap   │
+                         │ pkg/sections + pkg/cli/bootstrap        │
+                         └──────────────┬──────────────────────────┘
+                                        │
+                         registry source entries
+                                        │
+                                        ▼
+                         ┌─────────────────────────────────────────┐
+                         │ geppetto/pkg/engineprofiles             │
+                         │ ParseRegistrySourceSpecs                │
+                         │ NewChainedRegistryFromSourceSpecs       │
+                         │ ResolveEngineProfile                    │
+                         └──────────────┬──────────────────────────┘
+                                        │
+                    ┌───────────────────┴───────────────────┐
+                    ▼                                       ▼
+       ┌─────────────────────────┐             ┌─────────────────────────┐
+       │ Pinocchio adapters       │             │ CoinVault adapters       │
+       │ .pinocchio.yml           │             │ local profile registry   │
+       │ inline profiles          │             │ application profiles     │
+       │ profilebootstrap         │             │ webchat.OpenProfiles     │
+       └─────────────────────────┘             └─────────────────────────┘
+```
+
+The key point is that **profile registry parsing, loading, chain precedence, stack expansion, and inference-setting merge semantics are centralized in Geppetto**. Application-specific layers select when and how to call that central code.
+
+## File map
+
+### Geppetto core profile model
+
+| File | Responsibility |
+|---|---|
+| `geppetto/pkg/engineprofiles/types.go` | Data model for `EngineProfileRegistry`, `EngineProfile`, refs, metadata, and extensions. |
+| `geppetto/pkg/engineprofiles/registry.go` | Public read interfaces: `RegistryReader`, `Registry`, `ResolveInput`, `ResolvedEngineProfile`. |
+| `geppetto/pkg/engineprofiles/service.go` | `StoreRegistry`; applies default registry/profile slug and resolves a profile into stack+merged settings. |
+| `geppetto/pkg/engineprofiles/source_chain.go` | Parses source specs and builds `ChainedRegistry` from YAML/SQLite sources. |
+| `geppetto/pkg/engineprofiles/stack_resolver.go` | Expands profile stacks into deterministic base-to-leaf layers. |
+| `geppetto/pkg/engineprofiles/stack_merge.go` | Merges stack layers. Later layers override earlier layers. |
+| `geppetto/pkg/engineprofiles/inference_settings_merge.go` | Merges base and overlay `InferenceSettings`. |
+
+### Geppetto CLI profile bootstrap
+
+| File | Responsibility |
+|---|---|
+| `geppetto/pkg/sections/profile_sections.go` | Defines the generic Glazed `profile-settings` section with `--profile` and `--profile-registries`. |
+| `geppetto/pkg/cli/bootstrap/profile_selection.go` | Resolves profile settings from parsed values and applies default registry source discovery. |
+| `geppetto/pkg/cli/bootstrap/profile_registry_defaults.go` | Finds default `~/.config/<app>/profiles.yaml` if it exists. |
+| `geppetto/pkg/cli/bootstrap/profile_registry.go` | Builds `ResolvedProfileRegistryChain` from profile settings. |
+| `geppetto/pkg/cli/bootstrap/profile_runtime.go` | Resolves profile settings from config/env/defaults plus explicit CLI parsed values. |
+| `geppetto/pkg/cli/bootstrap/engine_settings.go` | Merges hidden/base inference settings with resolved profile settings. |
+
+### Pinocchio profile-specific code
+
+| File | Responsibility |
+|---|---|
+| `pinocchio/pkg/cmds/profilebootstrap/profile_selection.go` | Pinocchio wrapper around Geppetto bootstrap; adds Pinocchio app config, config docs, inline profiles, and composition. |
+| `pinocchio/pkg/cmds/profilebootstrap/engine_settings.go` | Resolves final engine settings for Pinocchio commands. |
+| `pinocchio/pkg/configdoc/types.go` | Defines `.pinocchio.yml` document schema: `app`, `profile`, `profiles`. |
+| `pinocchio/pkg/configdoc/load.go` | Loads and validates Pinocchio config docs. |
+| `pinocchio/pkg/configdoc/merge.go` | Merges multiple Pinocchio config documents by precedence. |
+| `pinocchio/pkg/configdoc/profiles.go` | Converts inline profiles to a Geppetto registry and composes imported+inline registries. |
+| `pinocchio/cmd/web-chat/profiles/resolver.go` | HTTP request-time profile selection and runtime-plan resolution for web-chat. |
+| `pinocchio/pkg/inference/runtime/runtime_plan.go` | Resolves Pinocchio runtime extensions from resolved engine profiles. |
+
+### CoinVault profile-specific code
+
+| File | Responsibility |
+|---|---|
+| `2026-03-16--gec-rag/cmd/coinvault/cmds/profile_settings.go` | CoinVault-specific profile settings, local file defaults, and merging with Geppetto `profile-settings`. |
+| `2026-03-16--gec-rag/cmd/coinvault/cmds/chat_send.go` | Mounts command flags/sections and passes profile settings into the local runner. |
+| `2026-03-16--gec-rag/cmd/coinvault/cmds/serve.go` | Mounts server flags/sections and passes profile settings into HTTP server runtime. |
+| `2026-03-16--gec-rag/internal/webchat/profiles.go` | Opens Geppetto profile registries for CoinVault and exposes HTTP profile APIs. |
+| `2026-03-16--gec-rag/internal/webchat/sessionstream/sessionstream_runtime_resolver.go` | Selects application profile + inference profile and composes the runtime. |
+| `2026-03-16--gec-rag/internal/appprofiles/store.go` | Loads CoinVault application profiles from `application-profiles.yaml`. |
+
+## Current Geppetto resolution path
+
+### 1. CLI section definition
+
+Geppetto defines the generic profile section in:
+
+```text
+geppetto/pkg/sections/profile_sections.go
+```
+
+It exposes:
+
+```go
+type ProfileSettings struct {
+    Profile           string   `glazed:"profile"`
+    ProfileRegistries []string `glazed:"profile-registries"`
+}
+```
+
+The corresponding flags are:
+
+```text
+--profile
+--profile-registries
+```
+
+This section is intentionally generic. It does not know about Pinocchio, CoinVault, web-chat, application profiles, SQL tools, or cookies.
+
+### 2. CLI/config/env/default resolution
+
+The reusable bootstrap layer lives in:
+
+```text
+geppetto/pkg/cli/bootstrap
+```
+
+The important call is:
+
+```go
+ResolveCLIProfileRuntime(ctx, cfg, parsed)
+```
+
+Conceptual pseudocode:
+
+```go
+func ResolveCLIProfileRuntime(ctx, cfg, parsed):
+    profileSection := cfg.NewProfileSection()
+    schema := schema(profileSection)
+
+    resolvedValues := values.New()
+
+    configMiddleware, configFiles := resolveConfigMiddleware(cfg, parsed)
+
+    sources.Execute(
+        schema,
+        resolvedValues,
+        FromEnv(cfg.EnvPrefix),
+        configMiddleware,
+        FromDefaults,
+    )
+
+    if parsed != nil:
+        resolvedValues.Merge(parsed)  // explicit CLI values win
+
+    settings := ResolveProfileSettings(resolvedValues)
+    settings = PrepareProfileSettingsForRuntime(cfg, settings)
+
+    registryChain := ResolveProfileRegistryChain(ctx, settings)
+
+    return ResolvedCLIProfileRuntime{
+        ProfileSettings: settings,
+        ConfigFiles: configFiles,
+        ProfileRegistryChain: registryChain,
+    }
+```
+
+### 3. Default profile registry source
+
+If no `profile-registries` are configured, Geppetto's bootstrap can discover:
+
+```text
+~/.config/<app>/profiles.yaml
+```
+
+This lives in:
+
+```text
+geppetto/pkg/cli/bootstrap/profile_registry_defaults.go
+```
+
+The behavior is intentionally app-name-aware:
+
+```go
+path := filepath.Join(os.UserConfigDir(), cfg.AppName, "profiles.yaml")
+```
+
+For Pinocchio, that is usually:
+
+```text
+~/.config/pinocchio/profiles.yaml
+```
+
+For another app using the same bootstrap, it would be:
+
+```text
+~/.config/<that-app>/profiles.yaml
+```
+
+### 4. Registry source parsing
+
+`profile-registries` eventually becomes source specs through:
+
+```go
+engineprofiles.ParseRegistrySourceSpecs(entries)
+```
+
+Supported forms include:
+
+```text
+yaml:PATH
+yaml://PATH
+sqlite:PATH
+sqlite-dsn:DSN
+PATH.yaml
+PATH.db
+```
+
+If no prefix is present, Geppetto infers YAML vs SQLite by extension/header.
+
+### 5. Chained registry construction
+
+The chain builder is:
+
+```go
+engineprofiles.NewChainedRegistryFromSourceSpecs(ctx, specs)
+```
+
+It loads every source and creates one aggregate read interface.
+
+Important behavior:
+
+- Duplicate registry slugs across sources are rejected.
+- The default registry is chosen from the last loaded source that had registries.
+- Profile slug lookup without an explicit registry searches top-of-stack sources first.
+
+Conceptually:
+
+```go
+for source in sources:
+    registries := load(source)
+    for reg in registries:
+        if reg.Slug already loaded:
+            error duplicate registry slug
+        aggregate[reg.Slug] = reg
+
+// Later sources have higher precedence for ambiguous profile lookup.
+precedenceTopFirst := reverse(sourceRegistryOrder)
+defaultRegistry := firstRegistryFromLastSource
+```
+
+### 6. Resolving a profile
+
+The central call is:
+
+```go
+registry.ResolveEngineProfile(ctx, engineprofiles.ResolveInput{
+    RegistrySlug:      selectedRegistry,
+    EngineProfileSlug: selectedProfile,
+})
+```
+
+In `StoreRegistry.ResolveEngineProfile(...)`:
+
+1. If no registry is provided, use the registry default.
+2. If no profile is provided, use the registry's `DefaultEngineProfileSlug`, or `default` if present.
+3. Expand the profile stack using `ExpandEngineProfileStack(...)`.
+4. Merge stack layers using `MergeEngineProfileStackLayers(...)`.
+5. Return `ResolvedEngineProfile` with lineage and metadata.
+
+### 7. Merging base settings with profile settings
+
+Geppetto has two merges that are easy to confuse:
+
+1. **Stack merge**: base profile -> leaf profile.
+2. **Runtime base merge**: command/env/config base inference settings -> resolved profile inference settings.
+
+The second merge happens in:
+
+```text
+geppetto/pkg/cli/bootstrap/engine_settings.go
+```
+
+Conceptual pseudocode:
+
+```go
+base := ResolveBaseInferenceSettings(cfg, parsed)
+profileRuntime := ResolveCLIProfileRuntime(ctx, cfg, parsed)
+resolved := profileRuntime.Registry.ResolveEngineProfile(ctx, profileRuntime.DefaultProfileResolve)
+final := engineprofiles.MergeInferenceSettings(base, resolved.InferenceSettings)
+```
+
+Overlay wins for scalars. Nested maps merge recursively. Cost objects are replaced as a unit.
+
+## Current Pinocchio resolution path
+
+Pinocchio uses Geppetto's bootstrap but adds a unified config document system.
+
+The adapter starts in:
+
+```text
+pinocchio/pkg/cmds/profilebootstrap/profile_selection.go
+```
+
+The Pinocchio bootstrap config declares:
+
+```go
+AppName:   "pinocchio"
+EnvPrefix: "PINOCCHIO"
+NewProfileSection: geppettosections.NewProfileSettingsSection
+BuildBaseSections: geppettosections.CreateGeppettoSections
+ConfigPlanBuilder: pinocchioConfigPlanBuilder
+```
+
+Pinocchio config files use this schema:
+
+```yaml
+app:
+  repositories: []
+profile:
+  active: gpt-5-low
+  registries:
+    - ./profiles.yaml
+profiles:
+  local-profile:
+    display_name: Local profile
+    inference_settings: {}
+    extensions: {}
+```
+
+Pinocchio's config plan searches paths such as:
+
+```text
+system app config
+home app config
+XDG app config
+git-root .pinocchio.yml
+git-root .pinocchio.override.yml
+cwd .pinocchio.yml
+cwd .pinocchio.override.yml
+explicit --config-file
+```
+
+### Inline profiles
+
+Pinocchio can define inline profiles inside `.pinocchio.yml`. These are converted to a normal Geppetto registry by:
+
+```text
+pinocchio/pkg/configdoc/profiles.go
+```
+
+The inline registry slug is:
+
+```text
+config-inline
+```
+
+Composition behavior:
+
+```text
+inline profiles first, imported registries second
+```
+
+That means inline profiles can be resolved through the same `geppetto/pkg/engineprofiles.Registry` interface.
+
+### Pinocchio-specific runtime extensions
+
+Pinocchio runtime overlays are not part of Geppetto's base inference settings. They live in profile extensions and are resolved in:
+
+```text
+pinocchio/pkg/inference/runtime/runtime_plan.go
+```
+
+A resolved profile may therefore affect:
+
+- inference settings
+- system prompt
+- tools
+- middleware list
+- runtime fingerprint/profile version
+
+## Current CoinVault resolution path
+
+CoinVault is similar but not identical.
+
+It mounts Geppetto's generic profile section, but it has its own profile settings resolver:
+
+```text
+2026-03-16--gec-rag/cmd/coinvault/cmds/profile_settings.go
+```
+
+CoinVault has two distinct profile families:
+
+### 1. Inference profiles
+
+These are Geppetto engine profiles selected by:
+
+```text
+--profile-registries
+--registry
+--profile
+```
+
+They control model/provider/inference behavior.
+
+CoinVault resolves them through:
+
+```go
+webchat.OpenInferenceProfiles(ctx, opts.ProfileRegistries, opts.Registry, opts.Profile)
+```
+
+in:
+
+```text
+2026-03-16--gec-rag/internal/webchat/profiles.go
+```
+
+This function calls the same Geppetto core profile APIs:
+
+```go
+entries := gepprofiles.ParseEngineProfileRegistrySourceEntries(registrySources)
+specs := gepprofiles.ParseRegistrySourceSpecs(entries)
+chain := gepprofiles.NewChainedRegistryFromSourceSpecs(ctx, specs)
+```
+
+But it is a CoinVault-local wrapper, not Geppetto bootstrap.
+
+### 2. Application profiles
+
+These are CoinVault prompt/tool profiles selected by:
+
+```text
+--application-profiles
+--application-profile
+```
+
+They are loaded by:
+
+```text
+2026-03-16--gec-rag/internal/appprofiles/store.go
+```
+
+Application profiles select:
+
+- prompt text or prompt template
+- tool list
+- default application behavior
+
+They do **not** select the LLM provider/model directly.
+
+### CoinVault runtime composition
+
+The core runtime resolver is:
+
+```text
+2026-03-16--gec-rag/internal/webchat/sessionstream/sessionstream_runtime_resolver.go
+```
+
+It does:
+
+```go
+appSlug, appProfile := resolveApplicationProfile(in.ApplicationProfile)
+profilePlan := resolveInferenceRuntimePlan(ctx, req, in)
+systemPrompt := RenderApplicationProfileSystemPromptWithSQLDoc(appProfile, sqlDocs)
+runtimeProfile := ProfileRuntime{SystemPrompt: systemPrompt, Tools: appProfile.Tools}
+
+if profilePlan != nil:
+    inferenceSettings = profilePlan.InferenceSettings
+    runtimeProfile = profilePlan.Runtime.Clone()
+    runtimeProfile.SystemPrompt = systemPrompt
+    runtimeProfile.Tools = appProfile.Tools
+```
+
+So CoinVault intentionally overlays application-profile prompt/tools on top of inference-profile runtime/inference settings.
+
+## Where should `--print-profiles` live?
+
+### Recommendation
+
+Implement the reusable feature in **Geppetto**, with one or two small app adapters.
+
+The best location is not the low-level `engineprofiles` package alone, because `engineprofiles` does not know about CLI config/env/default discovery. It only knows how to parse explicit source specs and resolve registries.
+
+The best central location is:
+
+```text
+geppetto/pkg/cli/bootstrap
+```
+
+with a small public API that can be used by:
+
+- Geppetto example commands
+- Pinocchio profilebootstrap commands
+- Pinocchio web-chat CLI/server commands
+- CoinVault `chat send` and `serve`
+
+The flag definition can live in one of two places:
+
+#### Option A: Add `--print-profiles` to `profile-settings`
+
+File:
+
+```text
+geppetto/pkg/sections/profile_sections.go
+```
+
+Pros:
+
+- Users naturally expect profile introspection next to `--profile` and `--profile-registries`.
+- Any command mounting the profile section automatically gets the flag.
+- Simple UX.
+
+Cons:
+
+- `ProfileSettings` currently contains only selection inputs. Adding an action flag mixes selection state with command behavior.
+- Existing code decoding `ProfileSettings` must tolerate the extra field. This is normally fine, but semantically it is a different concern.
+
+#### Option B: Add a new `profile-introspection` section
+
+Files:
+
+```text
+geppetto/pkg/sections/profile_introspection_section.go
+geppetto/pkg/cli/bootstrap/profile_introspection.go
+```
+
+Pros:
+
+- Cleaner separation between selection and introspection behavior.
+- Can grow additional flags without polluting `ProfileSettings`:
+  - `--print-profiles`
+  - `--print-profile-resolution`
+  - `--print-profile-format table|json|yaml`
+  - `--print-profile-settings`
+- Commands opt in explicitly.
+
+Cons:
+
+- Apps must remember to mount the section.
+- Slightly more boilerplate.
+
+### Preferred design
+
+Use **Option B internally**, while exposing the flag as plain `--print-profiles`.
+
+That means:
+
+- Add a new Geppetto section for introspection action flags.
+- Add helper functions in Geppetto bootstrap that consume existing `ProfileSettings` plus resolved registry chain.
+- Let apps decide whether to run this as an early-exit command behavior.
+
+This avoids making `ProfileSettings` responsible for command flow control.
+
+## Proposed command UX
+
+### Minimal UX
+
+```bash
+coinvault chat send \
+  --profile-registries ./profile-registry.local.yaml \
+  --print-profiles
+```
+
+Expected output:
+
+```text
+Profile sources:
+  1. ./profile-registry.local.yaml (yaml)
+
+Registries:
+  default *
+    default profile: gpt-5-low
+    profiles: 4
+
+Profiles:
+  registry  default  slug          model      api_type          description
+  default   *        gpt-5-low     gpt-5     openai-responses  GPT-5 low reasoning
+  default            gpt-5-nano    gpt-5-nano openai-responses Nano profile
+```
+
+No LLM call should be made. No database should be required unless the app chooses to validate DB before flags. For CoinVault specifically, `--print-profiles` should be handled **before** database startup checks.
+
+### JSON UX
+
+If the command already supports Glazed output, `--print-profiles --with-glaze-output --output json` should emit structured rows or a structured document.
+
+Example document shape:
+
+```json
+{
+  "sources": [
+    {"raw": "./profile-registry.local.yaml", "kind": "yaml", "path": "./profile-registry.local.yaml"}
+  ],
+  "default_registry": "default",
+  "selected_profile": "gpt-5-low",
+  "registries": [
+    {"slug": "default", "default_profile_slug": "gpt-5-low", "profile_count": 4}
+  ],
+  "profiles": [
+    {
+      "registry": "default",
+      "slug": "gpt-5-low",
+      "is_default": true,
+      "display_name": "GPT-5 Low",
+      "description": "OpenAI Responses GPT-5 profile with low reasoning effort.",
+      "version": 1
+    }
+  ]
+}
+```
+
+### Resolved-profile UX
+
+A later enhancement should include:
+
+```bash
+--print-profile-resolution
+```
+
+or:
+
+```bash
+--print-profiles=resolved
+```
+
+Expected output:
+
+```text
+Resolved profile: default/gpt-5-low
+
+Lineage:
+  1. default/base-openai        version 3  source profiles.yaml
+  2. default/gpt-5-low          version 7  source profiles.local.yaml
+
+Merged inference settings:
+  chat.engine: gpt-5
+  chat.api_type: openai-responses
+  inference.reasoning_effort: low
+  inference.reasoning_summary: concise
+
+Runtime extensions:
+  pinocchio.webchat_runtime@v1:
+    tools: [sql_query, sql_doc]
+    middlewares: [...]
+```
+
+Do not print provider API keys or secrets. The implementation must redact sensitive settings.
+
+## Proposed API design
+
+### Data structures
+
+Create a new package file:
+
+```text
+geppetto/pkg/cli/bootstrap/profile_introspection.go
+```
+
+Suggested types:
+
+```go
+type ProfileIntrospectionSettings struct {
+    PrintProfiles bool   `glazed:"print-profiles"`
+    PrintProfileResolution bool `glazed:"print-profile-resolution"`
+    ProfileOutput string `glazed:"profile-output"`
+}
+
+type ProfileRegistryReport struct {
+    Sources []ProfileRegistrySourceReport `json:"sources" yaml:"sources"`
+    DefaultRegistry string `json:"default_registry" yaml:"default_registry"`
+    SelectedProfile string `json:"selected_profile,omitempty" yaml:"selected_profile,omitempty"`
+    Registries []ProfileRegistrySummaryReport `json:"registries" yaml:"registries"`
+    Profiles []ProfileSummaryReport `json:"profiles" yaml:"profiles"`
+    Resolution *ProfileResolutionReport `json:"resolution,omitempty" yaml:"resolution,omitempty"`
+}
+
+type ProfileRegistrySourceReport struct {
+    Raw string `json:"raw" yaml:"raw"`
+    Kind string `json:"kind" yaml:"kind"`
+    Path string `json:"path,omitempty" yaml:"path,omitempty"`
+    DSN string `json:"dsn,omitempty" yaml:"dsn,omitempty"`
+}
+
+type ProfileSummaryReport struct {
+    Registry string `json:"registry" yaml:"registry"`
+    Slug string `json:"slug" yaml:"slug"`
+    DisplayName string `json:"display_name,omitempty" yaml:"display_name,omitempty"`
+    Description string `json:"description,omitempty" yaml:"description,omitempty"`
+    IsDefault bool `json:"is_default,omitempty" yaml:"is_default,omitempty"`
+    Version uint64 `json:"version,omitempty" yaml:"version,omitempty"`
+    Model string `json:"model,omitempty" yaml:"model,omitempty"`
+    APIType string `json:"api_type,omitempty" yaml:"api_type,omitempty"`
+}
+
+type ProfileResolutionReport struct {
+    Registry string `json:"registry" yaml:"registry"`
+    Profile string `json:"profile" yaml:"profile"`
+    Lineage []ResolvedProfileStackEntry `json:"lineage" yaml:"lineage"`
+    InferenceSettings map[string]any `json:"inference_settings,omitempty" yaml:"inference_settings,omitempty"`
+    Extensions map[string]any `json:"extensions,omitempty" yaml:"extensions,omitempty"`
+}
+```
+
+### Helper functions
+
+Suggested API:
+
+```go
+func NewProfileIntrospectionSection() (schema.Section, error)
+
+func ResolveProfileIntrospectionSettings(parsed *values.Values) ProfileIntrospectionSettings
+
+func BuildProfileRegistryReport(
+    ctx context.Context,
+    cfg AppBootstrapConfig,
+    parsed *values.Values,
+    opts ProfileRegistryReportOptions,
+) (*ProfileRegistryReport, func(), error)
+```
+
+Options:
+
+```go
+type ProfileRegistryReportOptions struct {
+    IncludeResolution bool
+    IncludeMergedSettings bool
+    RedactSecrets bool
+}
+```
+
+Pseudocode:
+
+```go
+func BuildProfileRegistryReport(ctx, cfg, parsed, opts):
+    runtime, err := ResolveCLIProfileRuntime(ctx, cfg, parsed)
+    if err != nil:
+        return nil, nil, err
+
+    chain := runtime.ProfileRegistryChain
+    if chain == nil || chain.Registry == nil:
+        return empty report with config file/source diagnostics
+
+    report.Sources = source specs from runtime.ProfileSettings.ProfileRegistries
+    report.DefaultRegistry = chain.DefaultRegistrySlug.String()
+
+    registries := chain.Registry.ListRegistries(ctx)
+    for each registrySummary:
+        report.Registries append summary
+        reg := chain.Registry.GetRegistry(ctx, registrySummary.Slug)
+        profiles := chain.Registry.ListEngineProfiles(ctx, registrySummary.Slug)
+        for profile in profiles:
+            report.Profiles append profile summary
+
+    if opts.IncludeResolution:
+        resolved := chain.Registry.ResolveEngineProfile(ctx, chain.DefaultProfileResolve)
+        report.Resolution = from resolved
+
+    redact secrets
+    return report, runtime.Close, nil
+```
+
+### Rendering
+
+Do not force every application to hand-write table rendering.
+
+Two approaches are possible:
+
+1. Return typed rows and let Glazed render them.
+2. Provide a small plain-text renderer for classic CLI output.
+
+Recommended first implementation:
+
+```go
+func RenderProfileRegistryReportText(w io.Writer, report *ProfileRegistryReport) error
+func ProfileRegistryReportRows(report *ProfileRegistryReport) []types.Row
+```
+
+This allows both classic and Glazed output.
+
+## How this wires into applications
+
+### Geppetto-native commands
+
+Commands that already use `bootstrap.AppBootstrapConfig` should:
+
+1. Add the new introspection section.
+2. Decode `ProfileIntrospectionSettings` early.
+3. If `PrintProfiles`, call `BuildProfileRegistryReport` and exit before inference.
+
+Pseudocode:
+
+```go
+func Run(ctx, parsed):
+    introspection := bootstrap.ResolveProfileIntrospectionSettings(parsed)
+    if introspection.PrintProfiles:
+        report, close, err := bootstrap.BuildProfileRegistryReport(ctx, cfg, parsed, opts)
+        defer close()
+        if err != nil: return err
+        return bootstrap.RenderProfileRegistryReportText(os.Stdout, report)
+
+    // existing command behavior
+```
+
+### Pinocchio commands
+
+Pinocchio can either expose the Geppetto helper directly or wrap it in `pkg/cmds/profilebootstrap`.
+
+Preferred wrapper:
+
+```go
+func NewProfileIntrospectionSection() (schema.Section, error) {
+    return bootstrap.NewProfileIntrospectionSection()
+}
+
+func BuildProfileRegistryReport(ctx context.Context, parsed *values.Values, opts bootstrap.ProfileRegistryReportOptions) (...) {
+    return bootstrap.BuildProfileRegistryReport(ctx, pinocchioBootstrapConfig(), parsed, opts)
+}
+```
+
+But Pinocchio has inline profiles. The generic Geppetto report should not ignore them.
+
+Pinocchio's `ResolveCLIProfileRuntime` currently composes imported registries with inline profiles. Therefore Pinocchio needs either:
+
+- a Pinocchio-specific report builder that calls `profilebootstrap.ResolveCLIProfileRuntime`, or
+- a Geppetto report builder extension point that lets apps provide their own `ResolveCLIProfileRuntime` function.
+
+For an intern, the safer implementation is:
+
+```go
+// In Pinocchio profilebootstrap:
+func BuildProfileRegistryReport(ctx, parsed, opts):
+    runtime, err := ResolveCLIProfileRuntime(ctx, parsed) // Pinocchio wrapper, includes inline profiles
+    return bootstrap.BuildReportFromResolvedProfileRuntime(ctx, runtime, opts)
+```
+
+This suggests splitting the Geppetto implementation into two layers:
+
+```go
+BuildProfileRegistryReportFromBootstrap(ctx, cfg, parsed, opts)
+BuildProfileRegistryReportFromRuntime(ctx, runtime, opts)
+```
+
+### CoinVault commands
+
+CoinVault currently does not use Geppetto's full bootstrap path. It does:
+
+```go
+profileSettings := resolveProfileSettings(vals)
+profileDeps, err := webchat.OpenInferenceProfiles(ctx, profileSettings.ProfileRegistries, profileSettings.Registry, profileSettings.Profile)
+```
+
+Therefore CoinVault can use the central Geppetto report types/renderers but will need a local bridge:
+
+```go
+func buildCoinVaultProfileReport(ctx context.Context, vals *values.Values) (*bootstrap.ProfileRegistryReport, func(), error) {
+    settings := resolveProfileSettings(vals)
+    deps, err := webchat.OpenInferenceProfiles(ctx, settings.ProfileRegistries, settings.Registry, settings.Profile)
+    if err != nil { return nil, nil, err }
+
+    report, err := bootstrap.BuildProfileRegistryReportFromRegistry(ctx, bootstrap.ProfileRegistryReportInput{
+        SourceEntries: parse entries from settings.ProfileRegistries,
+        Registry: deps.Registry,
+        DefaultRegistrySlug: deps.DefaultRegistrySlug,
+        DefaultProfileSlug: deps.DefaultProfileSlug,
+    })
+    return report, deps.Close, err
+}
+```
+
+CoinVault should handle `--print-profiles` before database startup. That matters because profile introspection does not require the application MySQL database.
+
+In `chat_send.go`, the early-exit shape should be:
+
+```go
+func (c *ChatSendCommand) Run(ctx context.Context, vals *values.Values) error {
+    if wantsPrintProfiles(vals) {
+        return runPrintProfiles(ctx, vals, os.Stdout)
+    }
+
+    settings, req, opts, timeout, err := prepareChatSend(vals)
+    ... existing behavior ...
+}
+```
+
+Do the same in `serve.go` if desired.
+
+### CoinVault application-profile report
+
+Because CoinVault has application profiles, a separate optional flag may be useful:
+
+```text
+--print-application-profiles
+```
+
+Do not overload `--print-profiles` to print both kinds unless the output labels them very clearly.
+
+Recommended CoinVault behavior:
+
+- `--print-profiles`: inference profiles only.
+- `--print-application-profiles`: CoinVault app prompt/tool profiles.
+- `--print-all-profiles`: both, clearly separated.
+
+## Security requirements
+
+Profile files often contain provider API keys. The implementation must not print secrets.
+
+Never print raw `InferenceSettings` without redaction.
+
+Redact fields whose names include:
+
+```text
+key
+api_key
+api-key
+token
+secret
+password
+credential
+authorization
+```
+
+Pseudocode:
+
+```go
+func redactAny(v any) any:
+    switch typed := v.(type):
+    case map[string]any:
+        out := map[string]any{}
+        for k, child := range typed:
+            if isSensitiveKey(k):
+                out[k] = "***REDACTED***"
+            else:
+                out[k] = redactAny(child)
+        return out
+    case []any:
+        return map(redactAny, typed)
+    default:
+        return typed
+```
+
+Also avoid logging raw registry YAML in debug output.
+
+## Implementation plan for a new intern
+
+### Phase 1: Add generic Geppetto introspection types
+
+Files:
+
+```text
+geppetto/pkg/cli/bootstrap/profile_introspection.go
+geppetto/pkg/cli/bootstrap/profile_introspection_test.go
+```
+
+Implement:
+
+- report structs
+- redaction helper
+- classic text renderer
+- rows helper if needed
+
+Tests:
+
+- redacts nested API keys
+- prints empty report cleanly
+- marks default registry/profile
+
+### Phase 2: Add profile introspection section
+
+File:
+
+```text
+geppetto/pkg/sections/profile_introspection_section.go
+```
+
+Fields:
+
+```text
+--print-profiles              bool
+--print-profile-resolution    bool
+--profile-output              string, optional, default table/text
+```
+
+Keep this separate from `ProfileSettings` unless there is a strong reason to couple them.
+
+### Phase 3: Build reports from resolved runtime
+
+Add a function that takes already-resolved profile runtime/registry inputs.
+
+Suggested minimal API:
+
+```go
+type ProfileRegistryReportInput struct {
+    SourceEntries []string
+    Registry gepprofiles.Registry
+    DefaultRegistrySlug gepprofiles.RegistrySlug
+    DefaultProfileSlug gepprofiles.EngineProfileSlug
+    ResolveInput gepprofiles.ResolveInput
+}
+
+func BuildProfileRegistryReportFromRegistry(ctx context.Context, in ProfileRegistryReportInput, opts ProfileRegistryReportOptions) (*ProfileRegistryReport, error)
+```
+
+This makes it usable by Geppetto bootstrap, Pinocchio wrappers, and CoinVault custom glue.
+
+### Phase 4: Build reports from Geppetto bootstrap
+
+Add:
+
+```go
+func BuildProfileRegistryReport(ctx context.Context, cfg AppBootstrapConfig, parsed *values.Values, opts ProfileRegistryReportOptions) (*ProfileRegistryReport, func(), error)
+```
+
+Internally:
+
+```go
+runtime, err := ResolveCLIProfileRuntime(ctx, cfg, parsed)
+return BuildProfileRegistryReportFromRegistry(...runtime...), runtime.Close, err
+```
+
+### Phase 5: Add Pinocchio wrapper
+
+File:
+
+```text
+pinocchio/pkg/cmds/profilebootstrap/profile_introspection.go
+```
+
+Use Pinocchio's own `ResolveCLIProfileRuntime(ctx, parsed)` so inline `.pinocchio.yml` profiles are included.
+
+### Phase 6: Wire to CoinVault `chat send`
+
+Files:
+
+```text
+2026-03-16--gec-rag/cmd/coinvault/cmds/chat_send.go
+2026-03-16--gec-rag/cmd/coinvault/cmds/serve.go
+2026-03-16--gec-rag/cmd/coinvault/cmds/profile_settings.go
+```
+
+Add the introspection section to command sections.
+
+Important ordering:
+
+```go
+if printProfiles {
+    // do this before NewLocalRunner, before DB checks, before LLM calls
+    return runCoinVaultPrintProfiles(ctx, vals, os.Stdout)
+}
+```
+
+### Phase 7: Add tests
+
+Geppetto tests:
+
+- YAML source loads and prints profiles.
+- Multiple source precedence is reported correctly.
+- Default registry/profile is marked.
+- Stack lineage appears in resolved report.
+- Redaction works.
+
+CoinVault tests:
+
+- `chat send --print-profiles` does not require a DB.
+- local `profile-registry.local.yaml` preference is reflected.
+- `--registry` selects the default registry used in the report.
+- `--profile` selects the profile shown as selected.
+
+Pinocchio tests:
+
+- imported registry appears.
+- inline `.pinocchio.yml` profile appears.
+- inline profile wins when resolving by unqualified profile slug.
+
+## Proposed output examples
+
+### Table output
+
+```text
+Profile sources
+  1. yaml ./profile-registry.local.yaml
+
+Default selection
+  registry: default
+  profile:  gpt-5-low
+
+Registries
+  * default  profiles=4  default_profile=gpt-5-low
+
+Profiles
+  default  *  gpt-5-low        gpt-5       openai-responses  GPT-5 low reasoning
+  default     gpt-5-nano-low   gpt-5-nano  openai-responses  GPT-5 nano low reasoning
+```
+
+### Resolution output
+
+```text
+Resolved profile
+  registry: default
+  profile:  gpt-5-low
+
+Stack lineage
+  1. default/base-openai   version=1 source=profile-registry.yaml
+  2. default/gpt-5-low     version=3 source=profile-registry.local.yaml
+
+Merged settings summary
+  chat.engine: gpt-5
+  chat.api_type: openai-responses
+  inference.reasoning_effort: low
+  inference.reasoning_summary: concise
+```
+
+## Key design decisions
+
+### Decision 1: Put the reusable feature in Geppetto
+
+Reason: Geppetto owns the core profile registry abstractions and generic bootstrap resolution. A `--print-profiles` implementation should not be duplicated in every app.
+
+### Decision 2: Let Pinocchio wrap the report builder
+
+Reason: Pinocchio has inline profiles from `.pinocchio.yml`. A purely generic Geppetto bootstrap report would miss those unless the report builder accepts already-composed registries.
+
+### Decision 3: Let CoinVault use a bridge first
+
+Reason: CoinVault currently has a custom profile-settings resolver and application-profile layer. Refactoring CoinVault to use Geppetto bootstrap is probably worthwhile, but it is larger than adding `--print-profiles`. The bridge gets the UX quickly while still using central Geppetto report code.
+
+### Decision 4: Keep inference profiles separate from application profiles
+
+Reason: CoinVault application profiles are prompt/tool profiles, not provider/model profiles. Mixing them under one flag would increase confusion.
+
+### Decision 5: Redact secrets by default
+
+Reason: Local profile registries commonly include API keys. A profile printer must be safe to paste into bug reports.
+
+## Open questions
+
+1. Should `--print-profiles` output be a boolean flag or a mode flag?
+
+   Options:
+
+   ```text
+   --print-profiles
+   --print-profiles=summary|resolved|settings
+   ```
+
+   Recommendation: start with boolean `--print-profiles` plus separate `--print-profile-resolution`.
+
+2. Should Geppetto's generic `ProfileSettings` grow a `Registry` field?
+
+   CoinVault currently has `--registry` separately. Geppetto's `ResolveInput` supports registry slug selection, but the generic CLI profile section only has `--profile` and `--profile-registries`. Adding `--registry` centrally would align HTTP submit bodies and CLI behavior.
+
+   Recommendation: consider adding a generic `--registry` in a follow-up. It is conceptually part of profile selection.
+
+3. Should CoinVault migrate fully to Geppetto bootstrap?
+
+   Recommendation: not as part of the first `--print-profiles` implementation. First expose the introspection report, then evaluate a cleanup ticket for reducing CoinVault's custom resolver.
+
+## Practical debugging commands today
+
+Until `--print-profiles` exists, these are useful manual probes.
+
+List CoinVault events/profiles indirectly through SQLite or HTTP once running:
+
+```bash
+curl http://localhost:8080/api/chat/profiles
+```
+
+Inspect a local registry file without printing secrets:
+
+```bash
+yq '.profiles | keys' profile-registry.local.yaml
+```
+
+Inspect Geppetto source parsing behavior in tests:
+
+```bash
+go test ./pkg/engineprofiles -run 'Source|Chain|Resolve' -count=1
+```
+
+Inspect CoinVault profile settings tests:
+
+```bash
+cd 2026-03-16--gec-rag
+go test ./cmd/coinvault/cmds -run ProfileSettings -count=1
+```
+
+## Final recommendation
+
+For the intern implementing this feature:
+
+1. Start in Geppetto with reusable report structs and renderers.
+2. Build the report from a generic `gepprofiles.Registry` plus source/default/selection metadata.
+3. Add a bootstrap wrapper for apps that use Geppetto `AppBootstrapConfig`.
+4. Add a Pinocchio wrapper that includes inline config profiles.
+5. Add a CoinVault bridge that reuses CoinVault's existing `resolveProfileSettings` and `OpenInferenceProfiles` but uses the central Geppetto report renderer.
+6. Wire `--print-profiles` as an early-exit path before database checks and before LLM calls.
+7. Redact secrets in all output.
+
+This path improves user-visible debugging immediately while keeping the core profile-introspection logic centralized in Geppetto.

--- a/ttmp/2026/05/13/GEPPETTO-005--profile-registry-resolution-and-print-profiles-design/index.md
+++ b/ttmp/2026/05/13/GEPPETTO-005--profile-registry-resolution-and-print-profiles-design/index.md
@@ -1,0 +1,63 @@
+---
+Title: Profile registry resolution and print-profiles design
+Ticket: GEPPETTO-005
+Status: active
+Topics:
+    - geppetto
+    - pinocchio
+    - coinvault
+    - profiles
+    - cli
+    - configuration
+DocType: index
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-05-13T13:19:38.522122891-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Profile registry resolution and print-profiles design
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- geppetto
+- pinocchio
+- coinvault
+- profiles
+- cli
+- configuration
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/05/13/GEPPETTO-005--profile-registry-resolution-and-print-profiles-design/reference/01-investigation-diary.md
+++ b/ttmp/2026/05/13/GEPPETTO-005--profile-registry-resolution-and-print-profiles-design/reference/01-investigation-diary.md
@@ -1,0 +1,92 @@
+---
+Title: Investigation diary
+Ticket: GEPPETTO-005
+DocType: reference
+Status: active
+Intent: long-term
+Topics:
+  - geppetto
+  - pinocchio
+  - coinvault
+  - profiles
+  - cli
+  - configuration
+Owners:
+  - manuel
+Created: 2026-05-13
+Updated: 2026-05-13
+---
+
+# Investigation diary
+
+## 2026-05-13 — Initial survey and design capture
+
+The investigation started from a practical CLI usability question: where should a `--print-profiles` flag live so a user can see where profiles came from, how profile registries were loaded, and how profile stacks/config overlays were resolved.
+
+I surveyed three repositories from the workspace root:
+
+- `geppetto/`
+- `pinocchio/`
+- `2026-03-16--gec-rag/` (CoinVault)
+
+The important findings were:
+
+1. Geppetto owns the core engine-profile model and registry abstractions in `pkg/engineprofiles`.
+2. Geppetto also owns a reusable CLI bootstrap layer in `pkg/cli/bootstrap`, including profile settings, config loading, default profile registry discovery, profile registry chain construction, and base+profile inference-settings merging.
+3. Pinocchio mostly delegates generic profile CLI bootstrapping to Geppetto, but extends it with Pinocchio-specific config documents, inline profiles, and composed imported+inline registries.
+4. CoinVault currently mounts Geppetto's generic `profile-settings` section but resolves profile sources using its own `cmd/coinvault/cmds/profile_settings.go` and `internal/webchat.OpenInferenceProfiles(...)` helper instead of the Geppetto bootstrap runtime. CoinVault also has a separate application-profile layer for prompts/tools.
+5. The most reusable home for a `--print-profiles` capability is therefore Geppetto, but CoinVault will need a small adapter/wiring step because it does not currently use Geppetto's full CLI bootstrap path.
+
+I then created this ticket in `geppetto/ttmp`:
+
+```bash
+docmgr --root ttmp ticket create-ticket \
+  --ticket GEPPETTO-005 \
+  --title "Profile registry resolution and print-profiles design" \
+  --topics geppetto,pinocchio,coinvault,profiles,cli,configuration
+```
+
+I created two documents:
+
+- `design-doc/01-profile-registry-resolution-and-print-profiles-implementation-guide.md`
+- `reference/01-investigation-diary.md`
+
+The design guide records the current architecture, file references, resolution order, API proposal, command UX, pseudocode, and a concrete implementation plan for a new intern.
+
+## 2026-05-13 — Implemented the first reusable profile introspection slice
+
+I implemented the first useful slice of the `--print-profiles` design.
+
+In Geppetto I added a reusable profile introspection section and report builder:
+
+- `pkg/sections/profile_introspection_section.go`
+- `pkg/cli/bootstrap/profile_introspection.go`
+- `pkg/cli/bootstrap/profile_introspection_test.go`
+
+The report builder can summarize source entries, loaded registries, profiles, selected/default profiles, optional stack lineage, and optional redacted merged inference settings. The redaction pass replaces sensitive keys such as API keys, tokens, secrets, credentials, passwords, and authorization fields with `***REDACTED***`.
+
+In CoinVault I wired `coinvault chat send --print-profiles` as an early-exit path before database startup and before any LLM run. This lets a user inspect profile registry behavior even when MySQL is not configured. The implementation uses CoinVault's existing `resolveProfileSettings` and `webchat.OpenInferenceProfiles(...)` bridge, then calls Geppetto's reusable report builder/renderer.
+
+Validation commands:
+
+```bash
+cd geppetto
+go test ./pkg/cli/bootstrap ./pkg/sections ./pkg/engineprofiles -count=1
+
+cd ../2026-03-16--gec-rag
+go test ./cmd/coinvault/cmds -count=1
+GOWORK=off go test ./cmd/coinvault/cmds -count=1
+go build -tags embed -o bin/coinvault ./cmd/coinvault
+
+env -u COINVAULT_HOST -u COINVAULT_DATABASE -u COINVAULT_USER -u COINVAULT_PASSWORD \
+  -u GEC_MYSQL_HOST -u GEC_MYSQL_DATABASE -u GEC_MYSQL_RO_USER -u GEC_MYSQL_RO_PASSWORD \
+  bin/coinvault chat send \
+  --profile-registries ./profile-registry.local.yaml \
+  --profile gpt-5-low \
+  --print-profiles \
+  --run-timeout 1s
+```
+
+The smoke test printed profile sources, default/selected profile, registry summaries, and profile summaries without requiring application database settings. A JSON `--print-profile-resolution` run showed `api_keys` redacted.
+
+Pinocchio's inline-profile wrapper remains a follow-up task because it should call Pinocchio's own `profilebootstrap.ResolveCLIProfileRuntime(...)` so `.pinocchio.yml` inline profiles are included.

--- a/ttmp/2026/05/13/GEPPETTO-005--profile-registry-resolution-and-print-profiles-design/tasks.md
+++ b/ttmp/2026/05/13/GEPPETTO-005--profile-registry-resolution-and-print-profiles-design/tasks.md
@@ -1,0 +1,14 @@
+# Tasks
+
+## TODO
+
+- [ ] Add tasks here
+
+- [x] Implement reusable Geppetto profile introspection report types and secret redaction
+- [x] Add a profile introspection Glazed section exposing --print-profiles
+- [ ] Wire Pinocchio wrapper so inline .pinocchio.yml profiles appear in profile reports
+- [x] Wire CoinVault early-exit --print-profiles before database and LLM startup
+- [x] Implement Geppetto reusable profile registry report and redaction helpers
+- [x] Expose --print-profiles through a Geppetto profile introspection Glazed section
+- [x] Wire CoinVault chat send to print profiles as an early-exit before DB and LLM startup
+- [x] Validate with focused Geppetto and CoinVault tests

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -109,6 +109,12 @@ topics:
       description: Engine profile system for AI inference configuration
     - slug: model-metadata
       description: Model metadata including capabilities, costs, and context windows
+    - slug: cli
+      description: Command-line interfaces and flags
+    - slug: coinvault
+      description: CoinVault application integration and behavior
+    - slug: configuration
+      description: Configuration loading, defaults, overlays, and runtime settings
 docTypes:
     - slug: index
       description: Ticket index


### PR DESCRIPTION
This change introduces new command-line flags to help users inspect and debug
their engine profile configuration. This functionality makes it easier to
understand which profiles are loaded, how they are resolved, and what the final
settings are.

Key changes:

- **New CLI Flags**:
  - `--print-profiles`: Generates and prints a report of all loaded profile
    registries and available profiles, then exits. The report includes
    sources, default selections, and key profile details.
  - `--print-profile-resolution`: When used with `--print-profiles`, this
    flag adds the selected profile's inheritance stack (lineage) and final
    merged settings to the report.
  - `--profile-output <format>`: Specifies the output format for the report.
    Supported formats are `text`, `json`, and `yaml`.

- **Profile Report Generation**:
  - Core logic is added to build a comprehensive report structure containing
    information about profile sources, registries, and individual profiles.

- **Secure by Default**:
  - Sensitive information such as API keys, tokens, and other credentials are
    automatically redacted from the output to prevent accidental exposure.