### PR TITLE
Feat: Add xgoja provider for geppetto module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-go-golems/clay v0.4.9
 	github.com/go-go-golems/glazed v1.2.7
 	github.com/go-go-golems/go-emrichen v0.0.10
-	github.com/go-go-golems/go-go-goja v0.4.15
+	github.com/go-go-golems/go-go-goja v0.4.17
 	github.com/go-go-golems/sanitize v0.0.1
 	github.com/google/generative-ai-go v0.20.1
 	github.com/huandu/go-clone v1.7.2

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/go-go-golems/clay v0.4.9
 	github.com/go-go-golems/glazed v1.2.7
 	github.com/go-go-golems/go-emrichen v0.0.10
-	github.com/go-go-golems/go-go-goja v0.4.17
+	github.com/go-go-golems/go-go-goja v0.5.0
 	github.com/go-go-golems/sanitize v0.0.1
 	github.com/google/generative-ai-go v0.20.1
 	github.com/huandu/go-clone v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/go-go-golems/glazed v1.2.7 h1:/zSSeteH++rsJDmTmIZappaGpEXKT40GvtZgBfG
 github.com/go-go-golems/glazed v1.2.7/go.mod h1:1oF2sFLSCHFJBGx7xQ/pIXI+9WLZhonD4U8X46AqQrM=
 github.com/go-go-golems/go-emrichen v0.0.10 h1:y6RzGopArsUSuHfWHh3dqPnOJwIlftPkdfyJxRZboGU=
 github.com/go-go-golems/go-emrichen v0.0.10/go.mod h1:XjfFqbY7l9cYqMX9jrlbgVdjRtMHdXGIBf92F3hezVM=
-github.com/go-go-golems/go-go-goja v0.4.15 h1:0PNFBk4yRpfvi3o/cP5ciduyJGB3b52EINGTpBcgOYg=
-github.com/go-go-golems/go-go-goja v0.4.15/go.mod h1:mnEFH70HM3+JROMsBSBNTV8REF0K4YSYes6d0NS900o=
+github.com/go-go-golems/go-go-goja v0.4.17 h1:ntiNh16h9GP1hhiBYpk2o0HnSozIoF2YQpSmhh80KgY=
+github.com/go-go-golems/go-go-goja v0.4.17/go.mod h1:h2eI4uVtUFy7UdOmUWVwUgg3iLl3CHpyk3gEbOYvbJc=
 github.com/go-go-golems/sanitize v0.0.1 h1:Kdi7QC5pNtc7H9BsskQQiuhXnly9lMei+LhXf1AtUiQ=
 github.com/go-go-golems/sanitize v0.0.1/go.mod h1:ahtFsvUHMZC+/CIRxbrC5RKEqgCcyDyd6fSns+zWEN0=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/go-go-golems/go-emrichen v0.0.10 h1:y6RzGopArsUSuHfWHh3dqPnOJwIlftPkd
 github.com/go-go-golems/go-emrichen v0.0.10/go.mod h1:XjfFqbY7l9cYqMX9jrlbgVdjRtMHdXGIBf92F3hezVM=
 github.com/go-go-golems/go-go-goja v0.4.17 h1:ntiNh16h9GP1hhiBYpk2o0HnSozIoF2YQpSmhh80KgY=
 github.com/go-go-golems/go-go-goja v0.4.17/go.mod h1:h2eI4uVtUFy7UdOmUWVwUgg3iLl3CHpyk3gEbOYvbJc=
+github.com/go-go-golems/go-go-goja v0.5.0 h1:1F0NB6d5x752JGbJn8rOG+CXtIgks04lx4m7FG0geZI=
+github.com/go-go-golems/go-go-goja v0.5.0/go.mod h1:h2eI4uVtUFy7UdOmUWVwUgg3iLl3CHpyk3gEbOYvbJc=
 github.com/go-go-golems/sanitize v0.0.1 h1:Kdi7QC5pNtc7H9BsskQQiuhXnly9lMei+LhXf1AtUiQ=
 github.com/go-go-golems/sanitize v0.0.1/go.mod h1:ahtFsvUHMZC+/CIRxbrC5RKEqgCcyDyd6fSns+zWEN0=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=

--- a/pkg/inference/tools/scopedjs/runtime.go
+++ b/pkg/inference/tools/scopedjs/runtime.go
@@ -21,7 +21,7 @@ func (s registeredModuleSpec) ID() string {
 	return s.id
 }
 
-func (s registeredModuleSpec) Register(reg *require.Registry) error {
+func (s registeredModuleSpec) RegisterRuntimeModule(_ *gojengine.RuntimeModuleContext, reg *require.Registry) error {
 	if reg == nil {
 		return fmt.Errorf("require registry is nil")
 	}
@@ -93,8 +93,8 @@ func BuildRuntime[Scope any, Meta any](ctx context.Context, spec EnvironmentSpec
 	}, nil
 }
 
-func (b *Builder) moduleSpecs() []gojengine.ModuleSpec {
-	specs := make([]gojengine.ModuleSpec, 0, len(b.modules)+len(b.nativeModules))
+func (b *Builder) moduleSpecs() []gojengine.RuntimeModuleSpec {
+	specs := make([]gojengine.RuntimeModuleSpec, 0, len(b.modules)+len(b.nativeModules))
 	for _, mod := range b.modules {
 		specs = append(specs, registeredModuleSpec{
 			id:       "module:" + mod.name,

--- a/pkg/js/modules/geppetto/module.go
+++ b/pkg/js/modules/geppetto/module.go
@@ -48,13 +48,19 @@ type Options struct {
 	Logger                   zerolog.Logger
 }
 
+// NewLoader returns the native geppetto module loader for use with a require
+// registry or an xgoja provider wrapper.
+func NewLoader(opts Options) require.ModuleLoader {
+	mod := &module{opts: opts}
+	return mod.Loader
+}
+
 // Register registers the geppetto native module on a require registry.
 func Register(reg *require.Registry, opts Options) {
 	if reg == nil {
 		return
 	}
-	mod := &module{opts: opts}
-	reg.RegisterNativeModule(ModuleName, mod.Loader)
+	reg.RegisterNativeModule(ModuleName, NewLoader(opts))
 }
 
 type module struct {

--- a/pkg/js/modules/geppetto/provider/provider.go
+++ b/pkg/js/modules/geppetto/provider/provider.go
@@ -1,0 +1,69 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/dop251/goja_nodejs/require"
+	geppettomodule "github.com/go-go-golems/geppetto/pkg/js/modules/geppetto"
+	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
+)
+
+const PackageID = "geppetto"
+
+type Config struct {
+	Profile      string `json:"profile,omitempty"`
+	Registry     string `json:"registry,omitempty"`
+	AllowNetwork bool   `json:"allowNetwork,omitempty"`
+	AllowTools   bool   `json:"allowTools,omitempty"`
+}
+
+type HostServices interface {
+	GeppettoOptions(ctx context.Context, cfg Config) (geppettomodule.Options, error)
+}
+
+var configSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "profile": {"type": "string", "description": "Optional default engine profile selector interpreted by host services."},
+    "registry": {"type": "string", "description": "Optional profile registry selector interpreted by host services."},
+    "allowNetwork": {"type": "boolean", "description": "Explicitly allow host services to configure network-backed inference engines."},
+    "allowTools": {"type": "boolean", "description": "Explicitly allow host services to expose Go tool registries to JavaScript."}
+  },
+  "additionalProperties": false
+}`)
+
+func Register(registry *providerapi.Registry) error {
+	return registry.Package(PackageID, providerapi.Module{
+		Name:         geppettomodule.ModuleName,
+		DefaultAs:    geppettomodule.ModuleName,
+		Description:  "Geppetto inference, turns, engine, profile, and runner helpers exposed as require(\"geppetto\").",
+		ConfigSchema: configSchema,
+		New: func(ctx providerapi.ModuleContext) (require.ModuleLoader, error) {
+			cfg, err := decodeConfig(ctx.Config)
+			if err != nil {
+				return nil, fmt.Errorf("geppetto provider config: %w", err)
+			}
+			host, ok := ctx.Host.(HostServices)
+			if !ok || host == nil {
+				return nil, fmt.Errorf("geppetto provider requires geppetto provider HostServices")
+			}
+			opts, err := host.GeppettoOptions(ctx.Context, cfg)
+			if err != nil {
+				return nil, fmt.Errorf("geppetto provider host options: %w", err)
+			}
+			return geppettomodule.NewLoader(opts), nil
+		},
+	})
+}
+
+func decodeConfig(data json.RawMessage) (Config, error) {
+	cfg := Config{}
+	if len(data) > 0 && string(data) != "null" {
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return Config{}, err
+		}
+	}
+	return cfg, nil
+}

--- a/pkg/js/modules/geppetto/provider/provider_test.go
+++ b/pkg/js/modules/geppetto/provider/provider_test.go
@@ -1,0 +1,92 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/dop251/goja"
+	geppettomodule "github.com/go-go-golems/geppetto/pkg/js/modules/geppetto"
+	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
+)
+
+type fakeHost struct {
+	seen Config
+}
+
+func (h *fakeHost) GeppettoOptions(_ context.Context, cfg Config) (geppettomodule.Options, error) {
+	h.seen = cfg
+	return geppettomodule.Options{}, nil
+}
+
+func TestRegisterProvider(t *testing.T) {
+	registry := providerapi.NewRegistry()
+	if err := Register(registry); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	mod, ok := registry.ResolveModule(PackageID, geppettomodule.ModuleName)
+	if !ok {
+		t.Fatalf("missing module %s.%s", PackageID, geppettomodule.ModuleName)
+	}
+	if mod.DefaultAs != geppettomodule.ModuleName {
+		t.Fatalf("default alias = %q, want %q", mod.DefaultAs, geppettomodule.ModuleName)
+	}
+}
+
+func TestProviderRequiresHostServices(t *testing.T) {
+	mod := resolveModule(t)
+	if _, err := mod.New(providerapi.ModuleContext{}); err == nil {
+		t.Fatalf("expected missing host services error")
+	}
+}
+
+func TestModuleLoaderInstallsGeppettoExports(t *testing.T) {
+	mod := resolveModule(t)
+	host := &fakeHost{}
+	loader, err := mod.New(providerapi.ModuleContext{
+		Name:   geppettomodule.ModuleName,
+		As:     geppettomodule.ModuleName,
+		Host:   host,
+		Config: json.RawMessage(`{"profile":"test-profile","allowNetwork":true}`),
+	})
+	if err != nil {
+		t.Fatalf("create loader: %v", err)
+	}
+	if host.seen.Profile != "test-profile" || !host.seen.AllowNetwork {
+		t.Fatalf("host saw config %+v", host.seen)
+	}
+
+	vm := goja.New()
+	moduleObj := vm.NewObject()
+	exports := vm.NewObject()
+	if err := moduleObj.Set("exports", exports); err != nil {
+		t.Fatalf("set exports: %v", err)
+	}
+	loader(vm, moduleObj)
+	if got := exports.Get("version").String(); got != "0.1.0" {
+		t.Fatalf("version = %q, want 0.1.0", got)
+	}
+	for _, name := range []string{"createBuilder", "createSession", "runInference"} {
+		if _, ok := goja.AssertFunction(exports.Get(name)); !ok {
+			t.Fatalf("%s export is not a function", name)
+		}
+	}
+	for _, name := range []string{"turns", "engines", "profiles", "runner"} {
+		if obj := exports.Get(name).ToObject(vm); obj == nil {
+			t.Fatalf("%s export is not an object", name)
+		}
+	}
+}
+
+func resolveModule(t *testing.T) providerapi.Module {
+	t.Helper()
+	registry := providerapi.NewRegistry()
+	if err := Register(registry); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	mod, ok := registry.ResolveModule(PackageID, geppettomodule.ModuleName)
+	if !ok {
+		t.Fatalf("missing module")
+	}
+	return mod
+}

--- a/pkg/js/runtime/runtime.go
+++ b/pkg/js/runtime/runtime.go
@@ -7,7 +7,6 @@ import (
 	"github.com/dop251/goja_nodejs/require"
 	gp "github.com/go-go-golems/geppetto/pkg/js/modules/geppetto"
 	gojengine "github.com/go-go-golems/go-go-goja/engine"
-	ggmodules "github.com/go-go-golems/go-go-goja/modules"
 )
 
 // Options configure a geppetto JavaScript runtime bootstrapped on top of the
@@ -28,13 +27,39 @@ type Options struct {
 	RuntimeInitializers []gojengine.RuntimeInitializer
 }
 
+type geppettoModuleSpec struct {
+	opts gp.Options
+}
+
+func (s geppettoModuleSpec) ID() string { return "geppetto" }
+
+func (s geppettoModuleSpec) RegisterRuntimeModule(ctx *gojengine.RuntimeModuleContext, reg *require.Registry) error {
+	if ctx == nil {
+		return fmt.Errorf("runtime module context is nil")
+	}
+	if reg == nil {
+		return fmt.Errorf("require registry is nil")
+	}
+	opts := s.opts
+	opts.Runner = ctx.Owner
+	gp.Register(reg, opts)
+	return nil
+}
+
 // NewRuntime creates a new owned JS runtime that exposes require("geppetto").
 func NewRuntime(ctx context.Context, opts Options) (*gojengine.Runtime, error) {
 	builderOpts := make([]gojengine.Option, 0, 1)
 	if len(opts.RequireOptions) > 0 {
 		builderOpts = append(builderOpts, gojengine.WithRequireOptions(opts.RequireOptions...))
 	}
-	factory, err := gojengine.NewBuilder(builderOpts...).Build()
+	builder := gojengine.NewBuilder(builderOpts...).WithModules(geppettoModuleSpec{opts: opts.ModuleOptions})
+	if opts.IncludeDefaultModules {
+		builder = builder.UseModuleMiddleware(gojengine.Pipeline())
+	}
+	if len(opts.RuntimeInitializers) > 0 {
+		builder = builder.WithRuntimeInitializers(opts.RuntimeInitializers...)
+	}
+	factory, err := builder.Build()
 	if err != nil {
 		return nil, fmt.Errorf("build runtime factory: %w", err)
 	}
@@ -43,35 +68,5 @@ func NewRuntime(ctx context.Context, opts Options) (*gojengine.Runtime, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create runtime: %w", err)
 	}
-
-	moduleOpts := opts.ModuleOptions
-	moduleOpts.Runner = rt.Owner
-
-	reg := require.NewRegistry(opts.RequireOptions...)
-	if opts.IncludeDefaultModules {
-		ggmodules.EnableAll(reg)
-	}
-	gp.Register(reg, moduleOpts)
-	reqMod := reg.Enable(rt.VM)
-	rt.Require = reqMod
-
-	if len(opts.RuntimeInitializers) > 0 {
-		runtimeCtx := &gojengine.RuntimeContext{
-			VM:      rt.VM,
-			Require: reqMod,
-			Loop:    rt.Loop,
-			Owner:   rt.Owner,
-		}
-		for _, init := range opts.RuntimeInitializers {
-			if init == nil {
-				continue
-			}
-			if err := init.InitRuntime(runtimeCtx); err != nil {
-				_ = rt.Close(context.Background())
-				return nil, fmt.Errorf("runtime initializer %q: %w", init.ID(), err)
-			}
-		}
-	}
-
 	return rt, nil
 }

--- a/pkg/js/runtime/runtime.go
+++ b/pkg/js/runtime/runtime.go
@@ -48,7 +48,10 @@ func (s geppettoModuleSpec) RegisterRuntimeModule(ctx *gojengine.RuntimeModuleCo
 
 // NewRuntime creates a new owned JS runtime that exposes require("geppetto").
 func NewRuntime(ctx context.Context, opts Options) (*gojengine.Runtime, error) {
-	builderOpts := make([]gojengine.Option, 0, 1)
+	builderOpts := []gojengine.Option{
+		gojengine.WithImplicitDefaultRegistryModules(false),
+		gojengine.WithDataOnlyDefaultRegistryModules(opts.IncludeDefaultModules),
+	}
 	if len(opts.RequireOptions) > 0 {
 		builderOpts = append(builderOpts, gojengine.WithRequireOptions(opts.RequireOptions...))
 	}
@@ -56,8 +59,8 @@ func NewRuntime(ctx context.Context, opts Options) (*gojengine.Runtime, error) {
 	if opts.IncludeDefaultModules {
 		builder = builder.UseModuleMiddleware(gojengine.Pipeline())
 	}
-	if len(opts.RuntimeInitializers) > 0 {
-		builder = builder.WithRuntimeInitializers(opts.RuntimeInitializers...)
+	if runtimeInitializers := nonNilRuntimeInitializers(opts.RuntimeInitializers); len(runtimeInitializers) > 0 {
+		builder = builder.WithRuntimeInitializers(runtimeInitializers...)
 	}
 	factory, err := builder.Build()
 	if err != nil {
@@ -69,4 +72,14 @@ func NewRuntime(ctx context.Context, opts Options) (*gojengine.Runtime, error) {
 		return nil, fmt.Errorf("create runtime: %w", err)
 	}
 	return rt, nil
+}
+
+func nonNilRuntimeInitializers(inits []gojengine.RuntimeInitializer) []gojengine.RuntimeInitializer {
+	ret := make([]gojengine.RuntimeInitializer, 0, len(inits))
+	for _, init := range inits {
+		if init != nil {
+			ret = append(ret, init)
+		}
+	}
+	return ret
 }

--- a/pkg/js/runtime/runtime_test.go
+++ b/pkg/js/runtime/runtime_test.go
@@ -23,6 +23,76 @@ func (f runtimeInitFunc) InitRuntime(ctx *gojengine.RuntimeContext) error {
 	return f.fn(ctx)
 }
 
+func TestNewRuntime_IncludeDefaultModulesFalseOnlyRegistersGeppetto(t *testing.T) {
+	rt, err := NewRuntime(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("NewRuntime failed: %v", err)
+	}
+	defer func() {
+		_ = rt.Close(context.Background())
+	}()
+
+	if _, err := rt.VM.RunString(`require("geppetto")`); err != nil {
+		t.Fatalf("geppetto module missing: %v", err)
+	}
+	if _, err := rt.VM.RunString(`require("path")`); err == nil {
+		t.Fatalf("require(path) succeeded with IncludeDefaultModules=false, want missing module")
+	}
+}
+
+func TestNewRuntime_IncludeDefaultModulesTrueRegistersDefaultModules(t *testing.T) {
+	rt, err := NewRuntime(context.Background(), Options{IncludeDefaultModules: true})
+	if err != nil {
+		t.Fatalf("NewRuntime failed: %v", err)
+	}
+	defer func() {
+		_ = rt.Close(context.Background())
+	}()
+
+	value, err := rt.VM.RunString(`require("path").join("a", "b")`)
+	if err != nil {
+		t.Fatalf("path default module missing: %v", err)
+	}
+	if got := value.String(); got != "a/b" {
+		t.Fatalf("path.join result = %q, want %q", got, "a/b")
+	}
+}
+
+func TestNewRuntime_SkipsNilRuntimeInitializers(t *testing.T) {
+	var initCalls atomic.Int64
+
+	rt, err := NewRuntime(context.Background(), Options{
+		RuntimeInitializers: []gojengine.RuntimeInitializer{
+			nil,
+			runtimeInitFunc{
+				id: "real-init",
+				fn: func(ctx *gojengine.RuntimeContext) error {
+					initCalls.Add(1)
+					return ctx.VM.Set("runtimeInitWorked", true)
+				},
+			},
+			nil,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime failed: %v", err)
+	}
+	defer func() {
+		_ = rt.Close(context.Background())
+	}()
+
+	value, err := rt.VM.RunString(`runtimeInitWorked === true`)
+	if err != nil {
+		t.Fatalf("js run failed: %v", err)
+	}
+	if got := value.ToBoolean(); !got {
+		t.Fatalf("runtimeInitWorked = false, want true")
+	}
+	if initCalls.Load() != 1 {
+		t.Fatalf("init calls = %d, want 1", initCalls.Load())
+	}
+}
+
 func TestNewRuntime_RegistersGeppettoAndCustomBindings(t *testing.T) {
 	var reducerCalls atomic.Int64
 

--- a/ttmp/2026/05/25/GP-358--address-pr-358-xgoja-runtime-review/README.md
+++ b/ttmp/2026/05/25/GP-358--address-pr-358-xgoja-runtime-review/README.md
@@ -1,0 +1,21 @@
+# Address PR 358 xgoja runtime review
+
+This is the document workspace for ticket GP-358.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GP-358 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GP-358 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GP-358 --field Status --value review`

--- a/ttmp/2026/05/25/GP-358--address-pr-358-xgoja-runtime-review/changelog.md
+++ b/ttmp/2026/05/25/GP-358--address-pr-358-xgoja-runtime-review/changelog.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 2026-05-25
+
+- Initial workspace created.
+- Retrieved PR 358 review threads:
+  - `IncludeDefaultModules=false` leaked go-go-goja data-only default modules.
+  - nil runtime initializers were now rejected by the builder instead of skipped.
+- Updated `pkg/js/runtime/runtime.go` so default module inclusion is fully controlled by `Options.IncludeDefaultModules` and nil runtime initializers are filtered before builder registration.
+- Added regression tests in `pkg/js/runtime/runtime_test.go`.
+- Added ELI5 explanation in `reference/01-eli5-pr-358-runtime-review-comments.md`.
+- Validation passed: `go test ./pkg/js/runtime -count=1` and `go test ./pkg/js/... -count=1`.

--- a/ttmp/2026/05/25/GP-358--address-pr-358-xgoja-runtime-review/changelog.md
+++ b/ttmp/2026/05/25/GP-358--address-pr-358-xgoja-runtime-review/changelog.md
@@ -10,3 +10,5 @@
 - Added regression tests in `pkg/js/runtime/runtime_test.go`.
 - Added ELI5 explanation in `reference/01-eli5-pr-358-runtime-review-comments.md`.
 - Validation passed: `go test ./pkg/js/runtime -count=1` and `go test ./pkg/js/... -count=1`.
+- Committed and pushed fix commit `4de12305 fix: preserve geppetto runtime option contracts` to PR 358.
+- Resolved both Codex review threads and posted PR follow-up comment: https://github.com/go-go-golems/geppetto/pull/358#issuecomment-4538749186

--- a/ttmp/2026/05/25/GP-358--address-pr-358-xgoja-runtime-review/index.md
+++ b/ttmp/2026/05/25/GP-358--address-pr-358-xgoja-runtime-review/index.md
@@ -1,0 +1,57 @@
+---
+Title: Address PR 358 xgoja runtime review
+Ticket: GP-358
+Status: active
+Topics:
+    - geppetto
+    - js-bindings
+    - code-review
+DocType: index
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-05-25T21:12:29.300804036-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Address PR 358 xgoja runtime review
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- xgoja
+- code-review
+- goja
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/05/25/GP-358--address-pr-358-xgoja-runtime-review/reference/01-eli5-pr-358-runtime-review-comments.md
+++ b/ttmp/2026/05/25/GP-358--address-pr-358-xgoja-runtime-review/reference/01-eli5-pr-358-runtime-review-comments.md
@@ -1,0 +1,226 @@
+---
+Title: ELI5 PR 358 Runtime Review Comments
+Ticket: GP-358
+Status: active
+Topics:
+    - geppetto
+    - js-bindings
+    - code-review
+DocType: reference
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles:
+    - Path: pkg/js/runtime/runtime.go
+      Note: |-
+        Runtime builder options and initializer filtering fixed for PR 358 review comments
+        Runtime builder option and nil initializer fixes for PR 358
+    - Path: pkg/js/runtime/runtime_test.go
+      Note: |-
+        Regression tests for default-module opt-in behavior and nil runtime initializer compatibility
+        Regression tests for PR 358 review feedback
+ExternalSources:
+    - https://github.com/go-go-golems/geppetto/pull/358#discussion_r3300575225
+    - https://github.com/go-go-golems/geppetto/pull/358#discussion_r3300575227
+Summary: ELI5 explanation of the two PR 358 xgoja runtime review comments and how they were fixed.
+LastUpdated: 2026-05-25T21:25:00-04:00
+WhatFor: Explain the PR review comments in plain language and preserve the exact implementation response.
+WhenToUse: Use when reviewing PR 358 or explaining why the runtime builder options and initializer filtering matter.
+---
+
+
+# ELI5 PR 358 Runtime Review Comments
+
+## Goal
+
+Explain the two Codex review comments on PR 358 in simple terms, then map each comment to the code change and regression test that addresses it.
+
+## Context
+
+PR 358 adds a Geppetto JavaScript runtime on top of `go-go-goja`'s owned runtime builder. The Geppetto helper has an option named `IncludeDefaultModules`:
+
+- `false` means: create a small sandbox with `require("geppetto")` only.
+- `true` means: also include the standard `go-go-goja` built-in modules such as `path`, `time`, `timer`, etc.
+
+The review comments were both about preserving old behavior while moving from hand-written runtime setup to the newer `go-go-goja` builder.
+
+## ELI5 summary
+
+Think of `NewRuntime` like packing a lunchbox for JavaScript code.
+
+- The Geppetto module is the sandwich. It should always be in the lunchbox.
+- Default modules like `path`, `time`, and `timer` are extra snacks. They should only be added when the caller says `IncludeDefaultModules: true`.
+- Runtime initializers are sticky notes telling the runtime to do extra setup. Empty sticky notes (`nil`) should be ignored, not treated as a disaster.
+
+The bug was that the new lunchbox helper accidentally added some snacks even when the caller said “no snacks,” and it also choked on empty sticky notes that the old code used to ignore.
+
+## Review comment 1: `IncludeDefaultModules=false` still exposed default modules
+
+### What the reviewer said
+
+> Preserve IncludeDefaultModules=false behavior
+>
+> `NewRuntime` builds the runtime with `gojengine.NewBuilder(...)` defaults and only toggles `UseModuleMiddleware` when `IncludeDefaultModules` is true. In go-go-goja v0.5.0, builder defaults include data-only default-registry modules, so `IncludeDefaultModules=false` still exposes extra built-ins (instead of only `geppetto`), which breaks the option contract and changes sandbox surface for existing callers. Explicitly disable data-only defaults when this flag is false (or make default-module inclusion fully controlled by this flag).
+
+### Plain-language meaning
+
+`go-go-goja.NewBuilder()` has its own defaults. Even if Geppetto did not call `UseModuleMiddleware(...)`, the builder still automatically registered “safe/data-only” default modules like `path`, `time`, and `timer`.
+
+That means this Geppetto call:
+
+```go
+runtime.NewRuntime(ctx, runtime.Options{IncludeDefaultModules: false})
+```
+
+was not really “Geppetto only.” JavaScript could still do things like:
+
+```js
+require("path")
+```
+
+That is surprising for callers who use `IncludeDefaultModules: false` to keep the sandbox small and explicit.
+
+### Why it matters
+
+This is a small sandbox-surface bug. It probably does not expose dangerous modules like unrestricted `fs`, but it still changes the contract:
+
+- before: `IncludeDefaultModules=false` meant “only Geppetto plus Goja's unavoidable core globals”; 
+- after the PR: it accidentally meant “Geppetto plus some extra default modules.”
+
+When an option says “do not include defaults,” the implementation should not include hidden defaults.
+
+### Fix
+
+`NewRuntime` now starts the builder with explicit default-module settings:
+
+```go
+builderOpts := []gojengine.Option{
+    gojengine.WithImplicitDefaultRegistryModules(false),
+    gojengine.WithDataOnlyDefaultRegistryModules(opts.IncludeDefaultModules),
+}
+```
+
+Then it only enables the module middleware pipeline when `IncludeDefaultModules` is true:
+
+```go
+if opts.IncludeDefaultModules {
+    builder = builder.UseModuleMiddleware(gojengine.Pipeline())
+}
+```
+
+So the flag is now the single switch controlling default module inclusion.
+
+### Regression test
+
+`TestNewRuntime_IncludeDefaultModulesFalseOnlyRegistersGeppetto` proves that:
+
+- `require("geppetto")` works;
+- `require("path")` fails when `IncludeDefaultModules` is false.
+
+`TestNewRuntime_IncludeDefaultModulesTrueRegistersDefaultModules` proves that:
+
+- `require("path").join("a", "b")` works when `IncludeDefaultModules` is true.
+
+## Review comment 2: nil runtime initializers now failed runtime creation
+
+### What the reviewer said
+
+> Filter nil runtime initializers before builder registration
+>
+> The new builder path forwards `opts.RuntimeInitializers` directly to `WithRuntimeInitializers`, but the engine builder rejects nil initializers at `Build()` time. The previous implementation explicitly skipped nil entries, so callers that pass optional initializers now fail runtime creation with a build error instead of succeeding. Filter nil initializers before passing them to the builder to preserve prior behavior.
+
+### Plain-language meaning
+
+Runtime initializers are optional setup hooks. Some callers may build a slice like this:
+
+```go
+[]gojengine.RuntimeInitializer{
+    maybeInitA, // could be nil
+    realInit,
+    maybeInitB, // could be nil
+}
+```
+
+The old implementation skipped nil entries. The new builder is stricter: if it sees a nil initializer, it returns an error during `Build()`.
+
+So code that used to work could suddenly fail just because it had an empty optional initializer in the list.
+
+### Why it matters
+
+This is a backwards-compatibility bug. It does not affect the happy path where all initializers are non-nil, but it breaks callers that compose optional setup hooks.
+
+The runtime helper should keep the old behavior: ignore nil hooks, run the real hooks.
+
+### Fix
+
+`NewRuntime` now filters initializers before passing them to the builder:
+
+```go
+if runtimeInitializers := nonNilRuntimeInitializers(opts.RuntimeInitializers); len(runtimeInitializers) > 0 {
+    builder = builder.WithRuntimeInitializers(runtimeInitializers...)
+}
+```
+
+The helper is intentionally small and boring:
+
+```go
+func nonNilRuntimeInitializers(inits []gojengine.RuntimeInitializer) []gojengine.RuntimeInitializer {
+    ret := make([]gojengine.RuntimeInitializer, 0, len(inits))
+    for _, init := range inits {
+        if init != nil {
+            ret = append(ret, init)
+        }
+    }
+    return ret
+}
+```
+
+### Regression test
+
+`TestNewRuntime_SkipsNilRuntimeInitializers` passes a slice containing nil entries around a real initializer. It proves that:
+
+- `NewRuntime` succeeds;
+- the real initializer still runs exactly once;
+- the JavaScript runtime sees the binding installed by the real initializer.
+
+## Quick Reference
+
+| Review concern | Actual problem | Fix | Test |
+| --- | --- | --- | --- |
+| `IncludeDefaultModules=false` leaked default modules | `go-go-goja` builder auto-installed data-only defaults | Explicitly set `WithDataOnlyDefaultRegistryModules(opts.IncludeDefaultModules)` and `WithImplicitDefaultRegistryModules(false)` | `TestNewRuntime_IncludeDefaultModulesFalseOnlyRegistersGeppetto`, `TestNewRuntime_IncludeDefaultModulesTrueRegistersDefaultModules` |
+| nil runtime initializers caused build errors | New builder rejects nil initializers, old code skipped them | Filter nil entries with `nonNilRuntimeInitializers` before calling `WithRuntimeInitializers` | `TestNewRuntime_SkipsNilRuntimeInitializers` |
+
+## Validation
+
+Commands run:
+
+```bash
+cd geppetto
+gofmt -w pkg/js/runtime/runtime.go pkg/js/runtime/runtime_test.go
+go test ./pkg/js/runtime -count=1
+go test ./pkg/js/... -count=1
+```
+
+Both test commands passed.
+
+## Review checklist
+
+Start with:
+
+1. `pkg/js/runtime/runtime.go`
+   - Check `NewRuntime` builder options.
+   - Check `nonNilRuntimeInitializers`.
+2. `pkg/js/runtime/runtime_test.go`
+   - Check the three regression tests added for the review comments.
+
+The intended behavior after the fix:
+
+- `IncludeDefaultModules=false`: only `geppetto` is registered by Geppetto's runtime helper.
+- `IncludeDefaultModules=true`: default registry modules are available.
+- nil runtime initializers are ignored, not treated as fatal.
+
+## Related
+
+- PR: <https://github.com/go-go-golems/geppetto/pull/358>
+- Review thread: <https://github.com/go-go-golems/geppetto/pull/358#discussion_r3300575225>
+- Review thread: <https://github.com/go-go-golems/geppetto/pull/358#discussion_r3300575227>

--- a/ttmp/2026/05/25/GP-358--address-pr-358-xgoja-runtime-review/tasks.md
+++ b/ttmp/2026/05/25/GP-358--address-pr-358-xgoja-runtime-review/tasks.md
@@ -1,0 +1,12 @@
+# Tasks
+
+## PR 358 review follow-up
+
+- [x] Fetch and read unresolved PR 358 code review threads.
+- [x] Fix `IncludeDefaultModules=false` so Geppetto does not accidentally expose go-go-goja data-only default modules.
+- [x] Preserve old behavior of skipping nil runtime initializers.
+- [x] Add regression tests for both review comments.
+- [x] Write ELI5 explanation in `reference/01-eli5-pr-358-runtime-review-comments.md`.
+- [x] Run focused JS runtime validation.
+- [x] Commit code and docs after review.
+- [ ] Resolve/comment on PR review threads after pushing.

--- a/ttmp/2026/05/25/GP-358--address-pr-358-xgoja-runtime-review/tasks.md
+++ b/ttmp/2026/05/25/GP-358--address-pr-358-xgoja-runtime-review/tasks.md
@@ -9,4 +9,4 @@
 - [x] Write ELI5 explanation in `reference/01-eli5-pr-358-runtime-review-comments.md`.
 - [x] Run focused JS runtime validation.
 - [x] Commit code and docs after review.
-- [ ] Resolve/comment on PR review threads after pushing.
+- [x] Resolve/comment on PR review threads after pushing.


### PR DESCRIPTION
This PR introduces an `xgoja` provider for the `geppetto` JavaScript module,
aligning it with the modern `go-go-goja` module system. This change
simplifies how host applications configure and integrate the `geppetto` runtime.

Key changes:

- **New Geppetto Provider**: A new `provider` package is added. It registers the
  `geppetto` module with the `xgoja` provider API. This allows host
  applications to enable the module declaratively.

- **Host-Controlled Configuration**: The provider defines a `HostServices`
  interface, which the embedding application must implement. This gives the host
  full control over the `geppetto.Options` used to initialize the module,
  based on a configuration provided by the JS environment.

- **Runtime Refactoring**: The `NewRuntime` constructor is refactored to use the
  `gojengine.Builder` pattern. Instead of manually registering modules, it now
  uses a `geppettoModuleSpec` that implements the `RuntimeModuleSpec`
  interface from `go-go-goja`.

- **Dependency Update**: The `go-go-goja` library is updated to `v0.5.0` to
  leverage the new provider and runtime builder APIs. This prompted refactoring
  of existing module spec interfaces to `RuntimeModuleSpec`.