### PR TITLE
Bump go-go-goja runtime API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/dop251/goja_nodejs v0.0.0-20250409162600-f7acab6894b0
 	github.com/go-go-golems/glazed v1.3.0
 	github.com/go-go-golems/go-emrichen v0.0.10
-	github.com/go-go-golems/go-go-goja v0.5.0
+	github.com/go-go-golems/go-go-goja v0.6.0
 	github.com/go-go-golems/logcopter v0.1.0
 	github.com/go-go-golems/sanitize v0.0.1
 	github.com/google/generative-ai-go v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/go-go-golems/glazed v1.3.0 h1:nuYnVNdjyhR/I7WKVUJM6OBfCDFz1I/N0Irw/Of
 github.com/go-go-golems/glazed v1.3.0/go.mod h1:ZzTG8NtSG3aLIZf8dKeolgPjC9DpHJwrN1IIoTapXr8=
 github.com/go-go-golems/go-emrichen v0.0.10 h1:y6RzGopArsUSuHfWHh3dqPnOJwIlftPkdfyJxRZboGU=
 github.com/go-go-golems/go-emrichen v0.0.10/go.mod h1:XjfFqbY7l9cYqMX9jrlbgVdjRtMHdXGIBf92F3hezVM=
-github.com/go-go-golems/go-go-goja v0.5.0 h1:1F0NB6d5x752JGbJn8rOG+CXtIgks04lx4m7FG0geZI=
-github.com/go-go-golems/go-go-goja v0.5.0/go.mod h1:h2eI4uVtUFy7UdOmUWVwUgg3iLl3CHpyk3gEbOYvbJc=
+github.com/go-go-golems/go-go-goja v0.6.0 h1:O2nPhg3j4TzK2zOElnMVcyBIYqrHVfBgXiXmaQ82ntw=
+github.com/go-go-golems/go-go-goja v0.6.0/go.mod h1:h2eI4uVtUFy7UdOmUWVwUgg3iLl3CHpyk3gEbOYvbJc=
 github.com/go-go-golems/logcopter v0.1.0 h1:CGBxAGudhoQOncJ6GEWDJ6c1g5LrU59/ewGlPFKBmdk=
 github.com/go-go-golems/logcopter v0.1.0/go.mod h1:HNCeqsUqxu+Jm5h05YlbN5+KFtK84D5ZnOimvVLyWH4=
 github.com/go-go-golems/sanitize v0.0.1 h1:Kdi7QC5pNtc7H9BsskQQiuhXnly9lMei+LhXf1AtUiQ=

--- a/pkg/inference/tools/scopedjs/runtime.go
+++ b/pkg/inference/tools/scopedjs/runtime.go
@@ -73,7 +73,7 @@ func BuildRuntime[Scope any, Meta any](ctx context.Context, spec EnvironmentSpec
 	if err != nil {
 		return nil, fmt.Errorf("build runtime factory %q: %w", spec.RuntimeLabel, err)
 	}
-	rt, err := factory.NewRuntime(ctx)
+	rt, err := factory.NewRuntime(gojengine.WithStartupContext(ctx), gojengine.WithLifetimeContext(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("create runtime %q: %w", spec.RuntimeLabel, err)
 	}

--- a/pkg/js/modules/geppetto/api_owner_bridge.go
+++ b/pkg/js/modules/geppetto/api_owner_bridge.go
@@ -10,7 +10,7 @@ import (
 
 func (m *moduleRuntime) requireBridge(op string) (*runtimebridge.Bridge, error) {
 	if m == nil || m.bridge == nil {
-		return nil, fmt.Errorf("%s requires module options Runner to be configured", op)
+		return nil, fmt.Errorf("%s requires module options runner to be configured", op)
 	}
 	return m.bridge, nil
 }

--- a/pkg/js/modules/geppetto/module.go
+++ b/pkg/js/modules/geppetto/module.go
@@ -32,7 +32,7 @@ type MiddlewareFactory func(options map[string]any) (middleware.Middleware, erro
 
 // Options configures module behavior for a specific runtime.
 type Options struct {
-	Runner                   runtimeowner.Runner
+	RuntimeOwner             runtimeowner.RuntimeOwner
 	GoToolRegistry           tools.ToolRegistry
 	GoMiddlewareFactories    map[string]MiddlewareFactory
 	EngineProfileRegistry    profiles.RegistryReader
@@ -68,9 +68,9 @@ type module struct {
 }
 
 type moduleRuntime struct {
-	vm     *goja.Runtime
-	runner runtimeowner.Runner
-	bridge *runtimebridge.Bridge
+	vm           *goja.Runtime
+	runtimeOwner runtimeowner.RuntimeOwner
+	bridge       *runtimebridge.Bridge
 
 	logger zerolog.Logger
 
@@ -101,7 +101,7 @@ func newRuntime(vm *goja.Runtime, opts Options) *moduleRuntime {
 	}
 	m := &moduleRuntime{
 		vm:                       vm,
-		runner:                   opts.Runner,
+		runtimeOwner:             opts.RuntimeOwner,
 		logger:                   lg,
 		goToolRegistry:           opts.GoToolRegistry,
 		goMiddlewareFactories:    map[string]MiddlewareFactory{},
@@ -121,8 +121,8 @@ func newRuntime(vm *goja.Runtime, opts Options) *moduleRuntime {
 	}
 	m.baseEngineProfileRegistry = m.profileRegistry
 	m.baseEngineProfileRegistryCloser = m.profileRegistryCloser
-	if m.runner != nil {
-		m.bridge = runtimebridge.New(m.runner)
+	if m.runtimeOwner != nil {
+		m.bridge = runtimebridge.New(m.runtimeOwner)
 	}
 	for k, v := range defaultGoMiddlewareFactories(lg) {
 		m.goMiddlewareFactories[k] = v

--- a/pkg/js/modules/geppetto/module_test.go
+++ b/pkg/js/modules/geppetto/module_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 type jsRuntime struct {
-	vm     *goja.Runtime
-	runner runtimeowner.Runner
+	vm           *goja.Runtime
+	runtimeOwner runtimeowner.RuntimeOwner
 }
 
 func newJSRuntime(t *testing.T, opts Options) *jsRuntime {
@@ -32,11 +32,11 @@ func newJSRuntime(t *testing.T, opts Options) *jsRuntime {
 	if err != nil {
 		t.Fatalf("failed creating go-go-goja factory: %v", err)
 	}
-	rt, err := factory.NewRuntime(context.Background())
+	rt, err := factory.NewRuntime(gojengine.WithStartupContext(context.Background()), gojengine.WithLifetimeContext(context.Background()))
 	if err != nil {
 		t.Fatalf("failed creating go-go-goja runtime: %v", err)
 	}
-	opts.Runner = rt.Owner
+	opts.RuntimeOwner = rt.Owner
 	reg := require.NewRegistry()
 	Register(reg, opts)
 	reg.Enable(rt.VM)
@@ -44,8 +44,8 @@ func newJSRuntime(t *testing.T, opts Options) *jsRuntime {
 		_ = rt.Close(context.Background())
 	})
 	return &jsRuntime{
-		vm:     rt.VM,
-		runner: rt.Owner,
+		vm:           rt.VM,
+		runtimeOwner: rt.Owner,
 	}
 }
 
@@ -55,11 +55,11 @@ func newJSRuntimeWithoutRunner(t *testing.T, opts Options) *jsRuntime {
 	if err != nil {
 		t.Fatalf("failed creating go-go-goja factory: %v", err)
 	}
-	rt, err := factory.NewRuntime(context.Background())
+	rt, err := factory.NewRuntime(gojengine.WithStartupContext(context.Background()), gojengine.WithLifetimeContext(context.Background()))
 	if err != nil {
 		t.Fatalf("failed creating go-go-goja runtime: %v", err)
 	}
-	opts.Runner = nil
+	opts.RuntimeOwner = nil
 	reg := require.NewRegistry()
 	Register(reg, opts)
 	reg.Enable(rt.VM)
@@ -67,8 +67,8 @@ func newJSRuntimeWithoutRunner(t *testing.T, opts Options) *jsRuntime {
 		_ = rt.Close(context.Background())
 	})
 	return &jsRuntime{
-		vm:     rt.VM,
-		runner: rt.Owner,
+		vm:           rt.VM,
+		runtimeOwner: rt.Owner,
 	}
 }
 
@@ -90,7 +90,7 @@ func waitForPromiseExpr(t *testing.T, rt *jsRuntime, expr string, timeout time.D
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for {
-		ret, err := rt.runner.Call(context.Background(), "module_test.PromiseState", func(_ context.Context, vm *goja.Runtime) (any, error) {
+		ret, err := rt.runtimeOwner.Call(context.Background(), "module_test.PromiseState", func(_ context.Context, vm *goja.Runtime) (any, error) {
 			v, runErr := vm.RunString(expr)
 			if runErr != nil {
 				return nil, runErr
@@ -130,7 +130,7 @@ func waitForPromiseExpr(t *testing.T, rt *jsRuntime, expr string, timeout time.D
 
 func mustEvalExprExport(t *testing.T, rt *jsRuntime, expr string) any {
 	t.Helper()
-	ret, err := rt.runner.Call(context.Background(), "module_test.EvalExpr", func(_ context.Context, vm *goja.Runtime) (any, error) {
+	ret, err := rt.runtimeOwner.Call(context.Background(), "module_test.EvalExpr", func(_ context.Context, vm *goja.Runtime) (any, error) {
 		v, runErr := vm.RunString(expr)
 		if runErr != nil {
 			return nil, runErr

--- a/pkg/js/runtime/runtime.go
+++ b/pkg/js/runtime/runtime.go
@@ -12,8 +12,8 @@ import (
 // Options configure a geppetto JavaScript runtime bootstrapped on top of the
 // go-go-goja owned runtime builder.
 type Options struct {
-	// ModuleOptions are forwarded to geppetto.Register. Runner is always bound
-	// to the created runtime owner.
+	// ModuleOptions are forwarded to geppetto.Register. RuntimeOwner is always
+	// bound to the created runtime owner.
 	ModuleOptions gp.Options
 
 	// RequireOptions are applied to the runtime's module registry.
@@ -41,7 +41,7 @@ func (s geppettoModuleSpec) RegisterRuntimeModule(ctx *gojengine.RuntimeModuleCo
 		return fmt.Errorf("require registry is nil")
 	}
 	opts := s.opts
-	opts.Runner = ctx.Owner
+	opts.RuntimeOwner = ctx.Owner
 	gp.Register(reg, opts)
 	return nil
 }
@@ -67,7 +67,7 @@ func NewRuntime(ctx context.Context, opts Options) (*gojengine.Runtime, error) {
 		return nil, fmt.Errorf("build runtime factory: %w", err)
 	}
 
-	rt, err := factory.NewRuntime(ctx)
+	rt, err := factory.NewRuntime(gojengine.WithStartupContext(ctx), gojengine.WithLifetimeContext(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("create runtime: %w", err)
 	}

--- a/pkg/js/runtime/runtime.go
+++ b/pkg/js/runtime/runtime.go
@@ -67,7 +67,7 @@ func NewRuntime(ctx context.Context, opts Options) (*gojengine.Runtime, error) {
 		return nil, fmt.Errorf("build runtime factory: %w", err)
 	}
 
-	rt, err := factory.NewRuntime(gojengine.WithStartupContext(ctx), gojengine.WithLifetimeContext(ctx))
+	rt, err := factory.NewRuntime(gojengine.WithStartupContext(ctx))
 	if err != nil {
 		return nil, fmt.Errorf("create runtime: %w", err)
 	}

--- a/pkg/js/runtime/runtime_test.go
+++ b/pkg/js/runtime/runtime_test.go
@@ -58,6 +58,29 @@ func TestNewRuntime_IncludeDefaultModulesTrueRegistersDefaultModules(t *testing.
 	}
 }
 
+func TestNewRuntime_StartupContextDoesNotOwnRuntimeLifetime(t *testing.T) {
+	startupCtx, cancel := context.WithCancel(context.Background())
+	rt, err := NewRuntime(startupCtx, Options{})
+	if err != nil {
+		t.Fatalf("NewRuntime failed: %v", err)
+	}
+	defer func() {
+		_ = rt.Close(context.Background())
+	}()
+
+	cancel()
+
+	select {
+	case <-rt.Context().Done():
+		t.Fatalf("runtime lifetime was canceled when startup context was canceled")
+	default:
+	}
+
+	if _, err := rt.VM.RunString(`require("geppetto")`); err != nil {
+		t.Fatalf("geppetto module unusable after startup context cancel: %v", err)
+	}
+}
+
 func TestNewRuntime_SkipsNilRuntimeInitializers(t *testing.T) {
 	var initCalls atomic.Int64
 

--- a/pkg/js/runtimebridge/bridge.go
+++ b/pkg/js/runtimebridge/bridge.go
@@ -8,34 +8,34 @@ import (
 	"github.com/go-go-golems/go-go-goja/pkg/runtimeowner"
 )
 
-// Bridge wraps a runtimeowner.Runner with helpers tailored for goja callback usage.
+// Bridge wraps a runtimeowner.RuntimeOwner with helpers tailored for goja callback usage.
 type Bridge struct {
-	runner runtimeowner.Runner
+	runtimeOwner runtimeowner.RuntimeOwner
 }
 
-func New(runner runtimeowner.Runner) *Bridge {
-	if runner == nil {
-		panic("runtimebridge: runner is nil")
+func New(runtimeOwner runtimeowner.RuntimeOwner) *Bridge {
+	if runtimeOwner == nil {
+		panic("runtimebridge: runtimeOwner is nil")
 	}
-	return &Bridge{runner: runner}
+	return &Bridge{runtimeOwner: runtimeOwner}
 }
 
-func (b *Bridge) Runner() runtimeowner.Runner {
-	return b.runner
+func (b *Bridge) RuntimeOwner() runtimeowner.RuntimeOwner {
+	return b.runtimeOwner
 }
 
 func (b *Bridge) Call(ctx context.Context, op string, fn runtimeowner.CallFunc) (any, error) {
-	if b == nil || b.runner == nil {
+	if b == nil || b.runtimeOwner == nil {
 		return nil, fmt.Errorf("runtimebridge %s: nil bridge", op)
 	}
-	return b.runner.Call(ctx, op, fn)
+	return b.runtimeOwner.Call(ctx, op, fn)
 }
 
 func (b *Bridge) Post(ctx context.Context, op string, fn runtimeowner.PostFunc) error {
-	if b == nil || b.runner == nil {
+	if b == nil || b.runtimeOwner == nil {
 		return fmt.Errorf("runtimebridge %s: nil bridge", op)
 	}
-	return b.runner.Post(ctx, op, fn)
+	return b.runtimeOwner.Post(ctx, op, fn)
 }
 
 func (b *Bridge) InvokeCallable(ctx context.Context, op string, fn goja.Callable, this goja.Value, args ...goja.Value) (goja.Value, error) {


### PR DESCRIPTION
## Summary
- adopt the renamed go-go-goja runtime owner API in the Geppetto JS module bridge
- bump go-go-goja to v0.6.0

## Validation
- GOWORK=off go test ./pkg/js/runtime ./pkg/js/modules/geppetto ./pkg/js/runtimebridge ./pkg/inference/tools/scopedjs -count=1
- GOWORK=off go test ./... -count=1
