### PR TITLE
Fix release workflow tag trigger and Go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: release  # Adding name for clarity
-on: 
-  workflow_dispatch:  # Allow manual triggers only
-#  push:
-#    tags:
-#      - '*'
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: write
@@ -21,7 +21,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v6
         with:
-          go-version: '>=1.21.5'
+          go-version: '>=1.26.1'
           cache: true
       - name: OSXCross for CGO Support
         run: |


### PR DESCRIPTION
Fixes release workflow issues found while releasing v0.12.0.\n\nChanges:\n- re-enable tag push trigger for v* tags\n- require Go >=1.26.1 to match go.mod\n\nValidation:\n- inspected failed run 26583640689: go.mod requires go >=1.26.1 but workflow installed Go 1.25.10\n- release.yml now supports both workflow_dispatch and tag pushes