### PR TITLE
Fix geppetto GoReleaser main path

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,5 @@
 version: 2
-project_name: pinocchio
+project_name: geppetto
 
 before:
   hooks:
@@ -8,7 +8,8 @@ before:
     # you may remove this if you don't need go generate
     - go generate ./...
 builds:
-  - binary: geppetto
+  - binary: geppetto-lint
+    main: ./cmd/tools/geppetto-lint
     goos:
       - linux
       - darwin


### PR DESCRIPTION
Fixes the GoReleaser build failure seen in release run 26584612650.\n\nChanges:\n- correct project_name to geppetto\n- build the real geppetto-lint command from ./cmd/tools/geppetto-lint instead of trying to build the module root\n\nValidation:\n- goreleaser release --snapshot --clean --skip=publish\n- GOWORK=off go test ./cmd/tools/geppetto-lint ./pkg/analysis/turnsdatalint ./pkg/analysis/turnsrefactor