### PR TITLE
Refactor geppetto provider for host service contributions and Glazed config

### DIFF
--- a/cmd/examples/geppetto-js-run/main.go
+++ b/cmd/examples/geppetto-js-run/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/fields"
 	"github.com/go-go-golems/glazed/pkg/cmds/values"
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )

--- a/cmd/examples/scopedjs-dbserver/main.go
+++ b/cmd/examples/scopedjs-dbserver/main.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 
 	"github.com/dop251/goja"
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
 	ggjmodules "github.com/go-go-golems/go-go-goja/modules"
 	_ "github.com/go-go-golems/go-go-goja/modules/fs"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 
 	"github.com/go-go-golems/geppetto/cmd/examples/internal/examplecmd"
 	"github.com/go-go-golems/geppetto/pkg/inference/tools"
@@ -136,12 +136,12 @@ func (c *runCommand) RunIntoGlazeProcessor(ctx context.Context, _ *values.Values
 			if err := b.AddNativeModule(&obsidianModule{}); err != nil {
 				return struct{}{}, err
 			}
-			if err := b.AddGlobal("workspaceRoot", func(ctx *gojengine.RuntimeContext) error {
+			if err := b.AddGlobal("workspaceRoot", func(ctx *gojengine.RuntimeInitializationContext) error {
 				return ctx.VM.Set("workspaceRoot", root)
 			}, scopedjs.GlobalDoc{Type: "string", Description: "Writable temp directory used by the demo runtime."}); err != nil {
 				return struct{}{}, err
 			}
-			if err := b.AddGlobal("db", func(ctx *gojengine.RuntimeContext) error {
+			if err := b.AddGlobal("db", func(ctx *gojengine.RuntimeInitializationContext) error {
 				return ctx.VM.Set("db", map[string]any{
 					"query": func(sql string) []map[string]any {
 						return []map[string]any{

--- a/cmd/examples/scopedjs-tool/main.go
+++ b/cmd/examples/scopedjs-tool/main.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"path/filepath"
 
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
 	ggjmodules "github.com/go-go-golems/go-go-goja/modules"
 	_ "github.com/go-go-golems/go-go-goja/modules/fs"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 
 	"github.com/go-go-golems/geppetto/cmd/examples/internal/examplecmd"
 	"github.com/go-go-golems/geppetto/pkg/inference/tools"
@@ -79,7 +79,7 @@ func (c *runCommand) RunIntoGlazeProcessor(ctx context.Context, _ *values.Values
 			if err := b.AddNativeModule(fsModule); err != nil {
 				return struct{}{}, err
 			}
-			if err := b.AddGlobal("workspaceRoot", func(ctx *gojengine.RuntimeContext) error {
+			if err := b.AddGlobal("workspaceRoot", func(ctx *gojengine.RuntimeInitializationContext) error {
 				return ctx.VM.Set("workspaceRoot", root)
 			}, scopedjs.GlobalDoc{
 				Type:        "string",

--- a/go.mod
+++ b/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/dop251/goja_nodejs v0.0.0-20250409162600-f7acab6894b0
 	github.com/go-go-golems/glazed v1.3.6
 	github.com/go-go-golems/go-emrichen v0.0.11
-	github.com/go-go-golems/go-go-goja v0.7.4
+	github.com/go-go-golems/go-go-goja v0.8.0
 	github.com/go-go-golems/logcopter v0.1.0
-	github.com/go-go-golems/sanitize v0.0.1
+	github.com/go-go-golems/sanitize v0.0.2
 	github.com/google/generative-ai-go v0.20.1
 	github.com/huandu/go-clone v1.7.2
 	github.com/invopop/jsonschema v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -116,12 +116,12 @@ github.com/go-go-golems/glazed v1.3.6 h1:33jWLP0nE9cDapB8oG/Z6UeqdNszI/OB3OogkhA
 github.com/go-go-golems/glazed v1.3.6/go.mod h1:Q+GuLpSK6OHfDJBbrA4RFOkpYPw++2jj5FAquem8w8g=
 github.com/go-go-golems/go-emrichen v0.0.11 h1:LIN/5OrzczpNCTAGOEg6epPELgyVYV+2IJ01qilldag=
 github.com/go-go-golems/go-emrichen v0.0.11/go.mod h1:nBIzXZwbOD7l3UKmRnofLh09BPbqKRPaxM0BLpOso0g=
-github.com/go-go-golems/go-go-goja v0.7.4 h1:hmnevbBh/3bqG40RI71RBT7QZs6B8t38EZEhjlkcXjM=
-github.com/go-go-golems/go-go-goja v0.7.4/go.mod h1:p8zrYdfGjbBNqi3WHfKxjMzQaXIw+QSyJihn0Abs7TM=
+github.com/go-go-golems/go-go-goja v0.8.0 h1:Cm93aODLyCe8RWC04vjYZKfDDsqJqeRMMIH2P4U/Muk=
+github.com/go-go-golems/go-go-goja v0.8.0/go.mod h1:nBJcgJrQ660gf88vyffcAKpBgXghGMn8KSMuErRt2jg=
 github.com/go-go-golems/logcopter v0.1.0 h1:CGBxAGudhoQOncJ6GEWDJ6c1g5LrU59/ewGlPFKBmdk=
 github.com/go-go-golems/logcopter v0.1.0/go.mod h1:HNCeqsUqxu+Jm5h05YlbN5+KFtK84D5ZnOimvVLyWH4=
-github.com/go-go-golems/sanitize v0.0.1 h1:Kdi7QC5pNtc7H9BsskQQiuhXnly9lMei+LhXf1AtUiQ=
-github.com/go-go-golems/sanitize v0.0.1/go.mod h1:ahtFsvUHMZC+/CIRxbrC5RKEqgCcyDyd6fSns+zWEN0=
+github.com/go-go-golems/sanitize v0.0.2 h1:a1wImzNrhRMyY/1ujqkc7JD2OwdwMxGkMeY4EXwWD/M=
+github.com/go-go-golems/sanitize v0.0.2/go.mod h1:uw5CwHkswHW9VW3szX3eN1ndM8BHMDLYJpfaE/VpRqc=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/pkg/inference/tools/scopedjs/builder.go
+++ b/pkg/inference/tools/scopedjs/builder.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
 	ggjmodules "github.com/go-go-golems/go-go-goja/modules"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 )
 
 func (b *Builder) AddModule(name string, register ModuleRegistrar, doc ModuleDoc) error {

--- a/pkg/inference/tools/scopedjs/eval.go
+++ b/pkg/inference/tools/scopedjs/eval.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/dop251/goja"
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 )
 
 var evalCounter atomic.Uint64

--- a/pkg/inference/tools/scopedjs/executor.go
+++ b/pkg/inference/tools/scopedjs/executor.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 )
 
 type RuntimeExecutor struct {

--- a/pkg/inference/tools/scopedjs/runtime.go
+++ b/pkg/inference/tools/scopedjs/runtime.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/require"
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
 	ggjmodules "github.com/go-go-golems/go-go-goja/modules"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 )
 
 type registeredModuleSpec struct {
@@ -21,7 +21,7 @@ func (s registeredModuleSpec) ID() string {
 	return s.id
 }
 
-func (s registeredModuleSpec) RegisterRuntimeModule(_ *gojengine.RuntimeModuleContext, reg *require.Registry) error {
+func (s registeredModuleSpec) RegisterRuntimeModule(_ *gojengine.RuntimeModuleRegistrationContext, reg *require.Registry) error {
 	if reg == nil {
 		return fmt.Errorf("require registry is nil")
 	}
@@ -33,14 +33,14 @@ func (s registeredModuleSpec) RegisterRuntimeModule(_ *gojengine.RuntimeModuleCo
 
 type runtimeInitFunc struct {
 	id string
-	fn func(ctx *gojengine.RuntimeContext) error
+	fn func(ctx *gojengine.RuntimeInitializationContext) error
 }
 
 func (f runtimeInitFunc) ID() string {
 	return f.id
 }
 
-func (f runtimeInitFunc) InitRuntime(ctx *gojengine.RuntimeContext) error {
+func (f runtimeInitFunc) InitRuntime(ctx *gojengine.RuntimeInitializationContext) error {
 	if f.fn == nil {
 		return nil
 	}
@@ -61,7 +61,7 @@ func BuildRuntime[Scope any, Meta any](ctx context.Context, spec EnvironmentSpec
 		return nil, fmt.Errorf("configure runtime %q: %w", spec.RuntimeLabel, err)
 	}
 
-	engineBuilder := gojengine.NewBuilder()
+	engineBuilder := gojengine.NewRuntimeFactoryBuilder()
 	if len(builder.modules) > 0 || len(builder.nativeModules) > 0 {
 		engineBuilder = engineBuilder.WithModules(builder.moduleSpecs()...)
 	}
@@ -93,8 +93,8 @@ func BuildRuntime[Scope any, Meta any](ctx context.Context, spec EnvironmentSpec
 	}, nil
 }
 
-func (b *Builder) moduleSpecs() []gojengine.RuntimeModuleSpec {
-	specs := make([]gojengine.RuntimeModuleSpec, 0, len(b.modules)+len(b.nativeModules))
+func (b *Builder) moduleSpecs() []gojengine.RuntimeModuleRegistrar {
+	specs := make([]gojengine.RuntimeModuleRegistrar, 0, len(b.modules)+len(b.nativeModules))
 	for _, mod := range b.modules {
 		specs = append(specs, registeredModuleSpec{
 			id:       "module:" + mod.name,
@@ -105,7 +105,7 @@ func (b *Builder) moduleSpecs() []gojengine.RuntimeModuleSpec {
 		if mod == nil {
 			continue
 		}
-		specs = append(specs, gojengine.NativeModuleSpec{
+		specs = append(specs, gojengine.NativeModuleRegistrar{
 			ModuleID:   "native:" + strings.TrimSpace(mod.Name()),
 			ModuleName: strings.TrimSpace(mod.Name()),
 			Loader:     mod.Loader,
@@ -120,7 +120,7 @@ func (b *Builder) runtimeInitializers() []gojengine.RuntimeInitializer {
 		global_ := global
 		ret = append(ret, runtimeInitFunc{
 			id: "global:" + global_.name,
-			fn: func(ctx *gojengine.RuntimeContext) error {
+			fn: func(ctx *gojengine.RuntimeInitializationContext) error {
 				return global_.bind(ctx)
 			},
 		})

--- a/pkg/inference/tools/scopedjs/runtime_test.go
+++ b/pkg/inference/tools/scopedjs/runtime_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/dop251/goja"
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
 	ggjmodules "github.com/go-go-golems/go-go-goja/modules"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 )
 
 type mathModule struct{}
@@ -39,7 +39,7 @@ func TestBuildRuntimeLoadsGlobalsAndBootstrap(t *testing.T) {
 			if err := b.AddNativeModule(mathModule{}); err != nil {
 				return "", err
 			}
-			if err := b.AddGlobal("db", func(ctx *gojengine.RuntimeContext) error {
+			if err := b.AddGlobal("db", func(ctx *gojengine.RuntimeInitializationContext) error {
 				obj := ctx.VM.NewObject()
 				if err := obj.Set("answer", 42); err != nil {
 					return err

--- a/pkg/inference/tools/scopedjs/schema.go
+++ b/pkg/inference/tools/scopedjs/schema.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/dop251/goja_nodejs/require"
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
 	ggjmodules "github.com/go-go-golems/go-go-goja/modules"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 )
 
 type ToolDescription struct {
@@ -104,7 +104,7 @@ type EnvironmentManifest struct {
 
 type ModuleRegistrar func(*require.Registry) error
 
-type GlobalBinding func(ctx *gojengine.RuntimeContext) error
+type GlobalBinding func(ctx *gojengine.RuntimeInitializationContext) error
 
 type moduleEntry struct {
 	name     string

--- a/pkg/inference/tools/scopedjs/schema_test.go
+++ b/pkg/inference/tools/scopedjs/schema_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/require"
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
 	ggjmodules "github.com/go-go-golems/go-go-goja/modules"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 )
 
 type testNativeModule struct{}
@@ -23,7 +23,7 @@ type testRuntimeInitializer struct{}
 
 func (testRuntimeInitializer) ID() string { return "test-init" }
 
-func (testRuntimeInitializer) InitRuntime(*gojengine.RuntimeContext) error { return nil }
+func (testRuntimeInitializer) InitRuntime(*gojengine.RuntimeInitializationContext) error { return nil }
 
 var _ ggjmodules.NativeModule = (*testNativeModule)(nil)
 
@@ -96,7 +96,7 @@ func TestBuilderValidationAndManifest(t *testing.T) {
 	if err := b.AddNativeModule(testNativeModule{}); err != nil {
 		t.Fatalf("AddNativeModule failed: %v", err)
 	}
-	if err := b.AddGlobal("db", func(*gojengine.RuntimeContext) error { return nil }, GlobalDoc{
+	if err := b.AddGlobal("db", func(*gojengine.RuntimeInitializationContext) error { return nil }, GlobalDoc{
 		Type:        "DatabaseClient",
 		Description: "Scoped DB handle",
 	}); err != nil {

--- a/pkg/inference/tools/scopedjs/tool_test.go
+++ b/pkg/inference/tools/scopedjs/tool_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/go-go-golems/geppetto/pkg/inference/tools"
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 )
 
 type scopeKey struct{}
@@ -43,7 +43,7 @@ func TestRegisterPrebuiltAndLazyRegistrar(t *testing.T) {
 			if err := b.AddNativeModule(mathModule{}); err != nil {
 				return struct{}{}, err
 			}
-			if err := b.AddGlobal("prefix", func(ctx *gojengine.RuntimeContext) error {
+			if err := b.AddGlobal("prefix", func(ctx *gojengine.RuntimeInitializationContext) error {
 				return ctx.VM.Set("prefix", s.Prefix)
 			}, GlobalDoc{Type: "string"}); err != nil {
 				return struct{}{}, err

--- a/pkg/js/modules/geppetto/api_agent_profile_test.go
+++ b/pkg/js/modules/geppetto/api_agent_profile_test.go
@@ -1,0 +1,90 @@
+package geppetto
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dop251/goja"
+	aistepssettings "github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
+	aitypes "github.com/go-go-golems/geppetto/pkg/steps/ai/types"
+)
+
+func TestEnsureInferenceSettingsProviderDefaultsHandlesMissingAPISettings(t *testing.T) {
+	apiType := aitypes.ApiTypeOpenAI
+	settings := &aistepssettings.InferenceSettings{Chat: &aistepssettings.ChatSettings{ApiType: &apiType}}
+	ensureInferenceSettingsProviderDefaults(settings)
+	if settings.API == nil {
+		t.Fatalf("API settings were not initialized")
+	}
+	if settings.API.BaseUrls == nil {
+		t.Fatalf("API base URLs were not initialized")
+	}
+}
+
+func TestAgentSessionBuildFromProfileWithAPISettings(t *testing.T) {
+	profilePath := filepath.Join(t.TempDir(), "profiles.yaml")
+	if err := os.WriteFile(profilePath, []byte(`slug: workspace
+profiles:
+  default:
+    slug: default
+    display_name: Workspace Default
+    inference_settings:
+      api:
+        api_keys:
+          openai-api-key: test-key
+      chat:
+        api_type: openai
+        engine: gpt-4o-mini
+  assistant:
+    slug: assistant
+    display_name: Assistant
+    stack:
+      - profile_slug: default
+    inference_settings:
+      chat:
+        engine: gpt-5-mini
+`), 0o644); err != nil {
+		t.Fatalf("write profile fixture: %v", err)
+	}
+
+	rt := newJSRuntime(t, Options{})
+	_, err := rt.runtimeOwner.Call(context.Background(), "test.profileAgentSessionBuild", func(_ context.Context, vm *goja.Runtime) (any, error) {
+		if err := vm.Set("profilePath", profilePath); err != nil {
+			return nil, err
+		}
+		_, runErr := vm.RunString(`
+			const gp = require("geppetto");
+			const settings = gp.inferenceProfiles.load(globalThis.profilePath).resolve("assistant");
+			const snapshot = settings.toJSON();
+			const agent = gp.agent()
+				.name("missing-api-settings-smoke")
+				.inference(settings)
+				.build();
+			const session = agent.session().id("missing-api-settings-session").build();
+			globalThis.profileSmoke = {
+				profile: snapshot.provenance && snapshot.provenance.profileSlug || "",
+				registry: snapshot.provenance && snapshot.provenance.registrySlug || "",
+				model: snapshot.chat && snapshot.chat.engine || "",
+				apiType: snapshot.chat && snapshot.chat.api_type || "",
+				session: session.id(),
+				hasSessionNext: typeof session.next === "function",
+			};
+		`)
+		return nil, runErr
+	})
+	if err != nil {
+		t.Fatalf("profile agent/session build failed: %v", err)
+	}
+	got, err := rt.runtimeOwner.Call(context.Background(), "test.readProfileAgentSessionBuild", func(_ context.Context, vm *goja.Runtime) (any, error) {
+		return vm.RunString(`JSON.stringify(globalThis.profileSmoke)`)
+	})
+	if err != nil {
+		t.Fatalf("read profile smoke failed: %v", err)
+	}
+	want := `{"profile":"assistant","registry":"workspace","model":"gpt-5-mini","apiType":"openai","session":"missing-api-settings-session","hasSessionNext":true}`
+	if got.(goja.Value).String() != want {
+		t.Fatalf("profile smoke = %s, want %s", got.(goja.Value).String(), want)
+	}
+}

--- a/pkg/js/modules/geppetto/api_engines.go
+++ b/pkg/js/modules/geppetto/api_engines.go
@@ -52,6 +52,9 @@ func ensureInferenceSettingsProviderDefaults(ss *aistepssettings.InferenceSettin
 	if ss == nil || ss.Chat == nil || ss.Chat.ApiType == nil {
 		return
 	}
+	if ss.API == nil {
+		ss.API = aistepssettings.NewAPISettings()
+	}
 	if ss.API.BaseUrls == nil {
 		ss.API.BaseUrls = map[string]string{}
 	}

--- a/pkg/js/modules/geppetto/api_event_emitters_test.go
+++ b/pkg/js/modules/geppetto/api_event_emitters_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/go-go-golems/geppetto/pkg/events"
 	inferenceengine "github.com/go-go-golems/geppetto/pkg/inference/engine"
 	"github.com/go-go-golems/geppetto/pkg/turns"
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 	"github.com/go-go-golems/go-go-goja/pkg/jsevents"
 )
 
 func newJSEventEmitterTestRuntime(t *testing.T) (*gojengine.Runtime, *moduleRuntime) {
 	t.Helper()
-	factory, err := gojengine.NewBuilder(
+	factory, err := gojengine.NewRuntimeFactoryBuilder(
 		gojengine.WithDataOnlyDefaultRegistryModules(true),
 	).
 		UseModuleMiddleware(gojengine.Pipeline()).
@@ -137,7 +137,7 @@ type geppettoEventTestModuleSpec struct {
 
 func (s geppettoEventTestModuleSpec) ID() string { return "geppetto" }
 
-func (s geppettoEventTestModuleSpec) RegisterRuntimeModule(ctx *gojengine.RuntimeModuleContext, reg *require.Registry) error {
+func (s geppettoEventTestModuleSpec) RegisterRuntimeModule(ctx *gojengine.RuntimeModuleRegistrationContext, reg *require.Registry) error {
 	opts := s.opts
 	opts.RuntimeOwner = ctx.Owner
 	opts.EventEmitterManagerResolver = func() (*jsevents.Manager, bool) {
@@ -154,7 +154,7 @@ func (s geppettoEventTestModuleSpec) RegisterRuntimeModule(ctx *gojengine.Runtim
 
 func newGeppettoEventRuntime(t *testing.T) *gojengine.Runtime {
 	t.Helper()
-	factory, err := gojengine.NewBuilder(
+	factory, err := gojengine.NewRuntimeFactoryBuilder(
 		gojengine.WithDataOnlyDefaultRegistryModules(true),
 	).
 		UseModuleMiddleware(gojengine.Pipeline()).

--- a/pkg/js/modules/geppetto/module_hardcut_test.go
+++ b/pkg/js/modules/geppetto/module_hardcut_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/require"
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 	"github.com/go-go-golems/go-go-goja/pkg/runtimeowner"
 )
 
@@ -20,7 +20,7 @@ type jsRuntime struct {
 
 func newJSRuntime(t *testing.T, opts Options) *jsRuntime {
 	t.Helper()
-	factory, err := gojengine.NewBuilder().Build()
+	factory, err := gojengine.NewRuntimeFactoryBuilder().Build()
 	if err != nil {
 		t.Fatalf("failed creating go-go-goja factory: %v", err)
 	}

--- a/pkg/js/modules/geppetto/provider/host_options.go
+++ b/pkg/js/modules/geppetto/provider/host_options.go
@@ -1,0 +1,164 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-go-golems/geppetto/pkg/events"
+	"github.com/go-go-golems/geppetto/pkg/inference/tools"
+	geppettomodule "github.com/go-go-golems/geppetto/pkg/js/modules/geppetto"
+	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
+)
+
+const HostOptionsServiceKey = "geppetto.provider.host-options.v1"
+
+type HostOptionsContribution struct {
+	ToolRegistry        tools.ToolRegistry
+	MiddlewareFactories map[string]geppettomodule.MiddlewareFactory
+	DefaultEventSinks   []events.EventSink
+	Configure           func(context.Context, Config, *geppettomodule.Options) error
+}
+
+type HostOptionsContributionOption func(*HostOptionsContribution)
+
+func NewHostOptionsContribution(options ...HostOptionsContributionOption) HostOptionsContribution {
+	ret := HostOptionsContribution{}
+	for _, option := range options {
+		if option != nil {
+			option(&ret)
+		}
+	}
+	return ret
+}
+
+func WithToolRegistry(registry tools.ToolRegistry) HostOptionsContributionOption {
+	return func(c *HostOptionsContribution) { c.ToolRegistry = registry }
+}
+
+func WithMiddlewareFactory(name string, factory geppettomodule.MiddlewareFactory) HostOptionsContributionOption {
+	return func(c *HostOptionsContribution) {
+		name = strings.TrimSpace(name)
+		if name == "" || factory == nil {
+			return
+		}
+		if c.MiddlewareFactories == nil {
+			c.MiddlewareFactories = map[string]geppettomodule.MiddlewareFactory{}
+		}
+		c.MiddlewareFactories[name] = factory
+	}
+}
+
+func WithDefaultEventSink(sink events.EventSink) HostOptionsContributionOption {
+	return func(c *HostOptionsContribution) {
+		if sink != nil {
+			c.DefaultEventSinks = append(c.DefaultEventSinks, sink)
+		}
+	}
+}
+
+func WithOptionsConfigurator(configure func(context.Context, Config, *geppettomodule.Options) error) HostOptionsContributionOption {
+	return func(c *HostOptionsContribution) { c.Configure = configure }
+}
+
+func applyHostOptionsContributions(ctx context.Context, host providerapi.HostServices, cfg Config, opts *geppettomodule.Options) error {
+	if opts == nil || host == nil {
+		return nil
+	}
+	lookup, ok := host.(providerapi.HostServiceLookup)
+	if !ok || lookup == nil {
+		return nil
+	}
+	for i, raw := range lookup.HostServiceValues(HostOptionsServiceKey) {
+		contribution, err := normalizeHostOptionsContribution(raw)
+		if err != nil {
+			return fmt.Errorf("geppetto host options contribution %d: %w", i, err)
+		}
+		if err := applyHostOptionsContribution(ctx, cfg, opts, contribution); err != nil {
+			return fmt.Errorf("geppetto host options contribution %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+func normalizeHostOptionsContribution(raw any) (HostOptionsContribution, error) {
+	switch x := raw.(type) {
+	case HostOptionsContribution:
+		return x, nil
+	case *HostOptionsContribution:
+		if x == nil {
+			return HostOptionsContribution{}, fmt.Errorf("nil contribution")
+		}
+		return *x, nil
+	default:
+		return HostOptionsContribution{}, fmt.Errorf("expected HostOptionsContribution, got %T", raw)
+	}
+}
+
+func applyHostOptionsContribution(ctx context.Context, cfg Config, opts *geppettomodule.Options, contribution HostOptionsContribution) error {
+	if contribution.ToolRegistry != nil {
+		merged, err := mergeToolRegistriesStrict(opts.GoToolRegistry, contribution.ToolRegistry)
+		if err != nil {
+			return err
+		}
+		opts.GoToolRegistry = merged
+	}
+	if len(contribution.MiddlewareFactories) > 0 {
+		if opts.GoMiddlewareFactories == nil {
+			opts.GoMiddlewareFactories = map[string]geppettomodule.MiddlewareFactory{}
+		}
+		for name, factory := range contribution.MiddlewareFactories {
+			name = strings.TrimSpace(name)
+			if name == "" || factory == nil {
+				continue
+			}
+			if _, ok := opts.GoMiddlewareFactories[name]; ok {
+				return fmt.Errorf("duplicate Geppetto middleware factory %q", name)
+			}
+			opts.GoMiddlewareFactories[name] = factory
+		}
+	}
+	if len(contribution.DefaultEventSinks) > 0 {
+		opts.DefaultEventSinks = append(opts.DefaultEventSinks, contribution.DefaultEventSinks...)
+	}
+	if contribution.Configure != nil {
+		if err := contribution.Configure(ctx, cfg, opts); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mergeToolRegistriesStrict(existing, incoming tools.ToolRegistry) (tools.ToolRegistry, error) {
+	if existing == nil {
+		return incoming, nil
+	}
+	if incoming == nil {
+		return existing, nil
+	}
+	out := tools.NewInMemoryToolRegistry()
+	seen := map[string]struct{}{}
+	for _, tool := range existing.ListTools() {
+		name := strings.TrimSpace(tool.Name)
+		if name == "" {
+			continue
+		}
+		if err := out.RegisterTool(name, tool); err != nil {
+			return nil, err
+		}
+		seen[name] = struct{}{}
+	}
+	for _, tool := range incoming.ListTools() {
+		name := strings.TrimSpace(tool.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("duplicate Geppetto tool %q", name)
+		}
+		if err := out.RegisterTool(name, tool); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}

--- a/pkg/js/modules/geppetto/provider/host_options_test.go
+++ b/pkg/js/modules/geppetto/provider/host_options_test.go
@@ -15,7 +15,9 @@ func TestApplyHostOptionsContributionsMergesToolsMiddlewareAndSinks(t *testing.T
 	registry := tools.NewInMemoryToolRegistry()
 	tool, err := tools.NewToolFromFunc("wordCount", "Count words", func(in struct {
 		Text string `json:"text"`
-	}) (map[string]int, error) { return map[string]int{"count": len(in.Text)}, nil })
+	}) (map[string]int, error) {
+		return map[string]int{"count": len(in.Text)}, nil
+	})
 	if err != nil {
 		t.Fatalf("NewToolFromFunc: %v", err)
 	}

--- a/pkg/js/modules/geppetto/provider/host_options_test.go
+++ b/pkg/js/modules/geppetto/provider/host_options_test.go
@@ -1,0 +1,99 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-go-golems/geppetto/pkg/events"
+	"github.com/go-go-golems/geppetto/pkg/inference/middleware"
+	"github.com/go-go-golems/geppetto/pkg/inference/tools"
+	geppettomodule "github.com/go-go-golems/geppetto/pkg/js/modules/geppetto"
+	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
+)
+
+func TestApplyHostOptionsContributionsMergesToolsMiddlewareAndSinks(t *testing.T) {
+	registry := tools.NewInMemoryToolRegistry()
+	tool, err := tools.NewToolFromFunc("wordCount", "Count words", func(in struct {
+		Text string `json:"text"`
+	}) (map[string]int, error) { return map[string]int{"count": len(in.Text)}, nil })
+	if err != nil {
+		t.Fatalf("NewToolFromFunc: %v", err)
+	}
+	if err := registry.RegisterTool("wordCount", *tool); err != nil {
+		t.Fatalf("RegisterTool: %v", err)
+	}
+	sink := &recordingEventSink{}
+	host := hostServicesForTest{values: map[string][]any{HostOptionsServiceKey: {
+		NewHostOptionsContribution(
+			WithToolRegistry(registry),
+			WithMiddlewareFactory("addSystemPrompt", func(options map[string]any) (middleware.Middleware, error) {
+				return middleware.NewSystemPromptMiddleware("demo"), nil
+			}),
+			WithDefaultEventSink(sink),
+		),
+	}}}
+	opts := geppettomodule.Options{}
+	if err := applyHostOptionsContributions(context.Background(), host, Config{}, &opts); err != nil {
+		t.Fatalf("applyHostOptionsContributions: %v", err)
+	}
+	if opts.GoToolRegistry == nil {
+		t.Fatalf("GoToolRegistry missing")
+	}
+	if _, err := opts.GoToolRegistry.GetTool("wordCount"); err != nil {
+		t.Fatalf("wordCount missing: %v", err)
+	}
+	if opts.GoMiddlewareFactories["addSystemPrompt"] == nil {
+		t.Fatalf("middleware factory missing")
+	}
+	if len(opts.DefaultEventSinks) != 1 || opts.DefaultEventSinks[0] != sink {
+		t.Fatalf("event sinks = %#v", opts.DefaultEventSinks)
+	}
+}
+
+func TestApplyHostOptionsContributionsRejectsDuplicateTools(t *testing.T) {
+	first := tools.NewInMemoryToolRegistry()
+	second := tools.NewInMemoryToolRegistry()
+	for _, registry := range []*tools.InMemoryToolRegistry{first, second} {
+		tool, err := tools.NewToolFromFunc("wordCount", "Count words", func() (string, error) { return "ok", nil })
+		if err != nil {
+			t.Fatalf("NewToolFromFunc: %v", err)
+		}
+		if err := registry.RegisterTool("wordCount", *tool); err != nil {
+			t.Fatalf("RegisterTool: %v", err)
+		}
+	}
+	host := hostServicesForTest{values: map[string][]any{HostOptionsServiceKey: {
+		NewHostOptionsContribution(WithToolRegistry(first)),
+		NewHostOptionsContribution(WithToolRegistry(second)),
+	}}}
+	err := applyHostOptionsContributions(context.Background(), host, Config{}, &geppettomodule.Options{})
+	if err == nil {
+		t.Fatalf("expected duplicate tool error")
+	}
+}
+
+type hostServicesForTest struct {
+	values map[string][]any
+}
+
+func (h hostServicesForTest) AssetResolver() providerapi.AssetResolver { return nil }
+func (h hostServicesForTest) HostService(key string) (any, bool) {
+	values := h.HostServiceValues(key)
+	if len(values) == 0 {
+		return nil, false
+	}
+	if len(values) == 1 {
+		return values[0], true
+	}
+	return values, true
+}
+func (h hostServicesForTest) HostServiceValues(key string) []any {
+	return append([]any(nil), h.values[key]...)
+}
+
+type recordingEventSink struct{ events []events.Event }
+
+func (s *recordingEventSink) PublishEvent(event events.Event) error {
+	s.events = append(s.events, event)
+	return nil
+}

--- a/pkg/js/modules/geppetto/provider/hostservicesexample/register.go
+++ b/pkg/js/modules/geppetto/provider/hostservicesexample/register.go
@@ -1,0 +1,177 @@
+package hostservicesexample
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+	"github.com/go-go-golems/geppetto/pkg/events"
+	"github.com/go-go-golems/geppetto/pkg/inference/middleware"
+	"github.com/go-go-golems/geppetto/pkg/inference/tools"
+	geppettoprovider "github.com/go-go-golems/geppetto/pkg/js/modules/geppetto/provider"
+	"github.com/go-go-golems/glazed/pkg/cmds/fields"
+	"github.com/go-go-golems/glazed/pkg/cmds/schema"
+	"github.com/go-go-golems/glazed/pkg/cmds/values"
+	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
+)
+
+const PackageID = "geppetto-host-services-example"
+const sectionSlug = "geppetto-host-services"
+
+func Register(registry *providerapi.ProviderRegistry) error {
+	capability := capability{}
+	return registry.Package(PackageID,
+		providerapi.Module{
+			Name:        "host-services",
+			DefaultAs:   "geppetto-host-services",
+			Description: "Contributes example Geppetto host services for generated xgoja demos.",
+			NewModuleFactory: func(providerapi.ModuleSetupContext) (require.ModuleLoader, error) {
+				return func(vm *goja.Runtime, module *goja.Object) {
+					exports := module.Get("exports").(*goja.Object)
+					_ = exports.Set("version", "0.1.0")
+				}, nil
+			},
+		},
+		providerapi.WithPackageCapability(capability),
+	)
+}
+
+type capability struct{}
+
+func (capability) CapabilityID() string { return "geppetto-host-services-example" }
+
+func (capability) GlazedConfigSections(providerapi.SectionRequest) ([]schema.Section, error) {
+	section, err := schema.NewSection(sectionSlug, "Geppetto host services example",
+		schema.WithFields(
+			fields.New("event-log", fields.TypeString, fields.WithHelp("JSONL file that receives Geppetto inference events")),
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return []schema.Section{section}, nil
+}
+
+func (capability) ContributeHostServices(ctx context.Context, req providerapi.HostServiceContributionRequest, sink providerapi.HostServiceSink) error {
+	registry, err := exampleToolRegistry()
+	if err != nil {
+		return err
+	}
+	contribution := geppettoprovider.NewHostOptionsContribution(
+		geppettoprovider.WithToolRegistry(registry),
+		geppettoprovider.WithMiddlewareFactory("addSystemPrompt", addSystemPromptFactory),
+	)
+	if eventLog := eventLogPath(req.Values); eventLog != "" {
+		eventSink, err := newJSONLEventSink(eventLog)
+		if err != nil {
+			return err
+		}
+		contribution.DefaultEventSinks = append(contribution.DefaultEventSinks, eventSink)
+	}
+	return sink.AddHostService(geppettoprovider.HostOptionsServiceKey, contribution)
+}
+
+func eventLogPath(vals *values.Values) string {
+	if vals == nil {
+		return ""
+	}
+	field, ok := vals.GetField(sectionSlug, "event-log")
+	if !ok || field == nil || field.Value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(field.Value))
+}
+
+type wordCountInput struct {
+	Text string `json:"text"`
+}
+
+func exampleToolRegistry() (tools.ToolRegistry, error) {
+	registry := tools.NewInMemoryToolRegistry()
+	tool, err := tools.NewToolFromFunc("wordCount", "Count whitespace-separated words", func(_ context.Context, input wordCountInput) (map[string]any, error) {
+		return map[string]any{"count": len(strings.Fields(input.Text))}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := registry.RegisterTool("wordCount", *tool); err != nil {
+		return nil, err
+	}
+	return registry, nil
+}
+
+func addSystemPromptFactory(options map[string]any) (middleware.Middleware, error) {
+	prompt := "Answer briefly."
+	if raw, ok := options["prompt"]; ok {
+		if s := strings.TrimSpace(fmt.Sprint(raw)); s != "" {
+			prompt = s
+		}
+	}
+	return middleware.NewSystemPromptMiddleware(prompt), nil
+}
+
+type jsonlEventSink struct {
+	mu     sync.Mutex
+	file   *os.File
+	writer *bufio.Writer
+}
+
+func newJSONLEventSink(path string) (*jsonlEventSink, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, fmt.Errorf("event log path is empty")
+	}
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, err
+		}
+	}
+	file, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	return &jsonlEventSink{file: file, writer: bufio.NewWriter(file)}, nil
+}
+
+func (s *jsonlEventSink) PublishEvent(ev events.Event) error {
+	if s == nil || ev == nil || s.writer == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	payload := map[string]any{
+		"type": string(ev.Type()),
+		"meta": ev.Metadata(),
+	}
+	if raw := ev.Payload(); len(raw) > 0 {
+		payload["payload"] = json.RawMessage(raw)
+	}
+	if err := json.NewEncoder(s.writer).Encode(payload); err != nil {
+		return err
+	}
+	return s.writer.Flush()
+}
+
+func (s *jsonlEventSink) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.writer != nil {
+		if err := s.writer.Flush(); err != nil {
+			return err
+		}
+	}
+	if s.file != nil {
+		return s.file.Close()
+	}
+	return nil
+}

--- a/pkg/js/modules/geppetto/provider/hostservicesexample/register.go
+++ b/pkg/js/modules/geppetto/provider/hostservicesexample/register.go
@@ -74,6 +74,10 @@ func (capability) ContributeHostServices(ctx context.Context, req providerapi.Ho
 			return err
 		}
 		contribution.DefaultEventSinks = append(contribution.DefaultEventSinks, eventSink)
+		if err := sink.AddCloser(func(context.Context) error { return eventSink.Close() }); err != nil {
+			_ = eventSink.Close()
+			return fmt.Errorf("register event log closer: %w", err)
+		}
 	}
 	return sink.AddHostService(geppettoprovider.HostOptionsServiceKey, contribution)
 }

--- a/pkg/js/modules/geppetto/provider/provider.go
+++ b/pkg/js/modules/geppetto/provider/provider.go
@@ -7,100 +7,71 @@ import (
 	"strings"
 
 	"github.com/dop251/goja_nodejs/require"
-	profiles "github.com/go-go-golems/geppetto/pkg/engineprofiles"
+	"github.com/go-go-golems/geppetto/pkg/engineprofiles"
 	geppettomodule "github.com/go-go-golems/geppetto/pkg/js/modules/geppetto"
+	"github.com/go-go-golems/glazed/pkg/cmds/fields"
+	"github.com/go-go-golems/glazed/pkg/cmds/schema"
+	"github.com/go-go-golems/glazed/pkg/cmds/values"
 	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
 )
 
 const PackageID = "geppetto"
 
-type Config struct {
-	Profile           string       `json:"profile,omitempty"`
-	ProfileRegistries []string     `json:"profileRegistries,omitempty"`
-	DefaultProfile    string       `json:"defaultProfile,omitempty"`
-	AllowRegistryLoad bool         `json:"allowRegistryLoad,omitempty"`
-	AllowNetwork      bool         `json:"allowNetwork,omitempty"`
-	AllowTools        bool         `json:"allowTools,omitempty"`
-	EnableStorage     bool         `json:"enableStorage,omitempty"`
-	Turns             *TurnsConfig `json:"turns,omitempty"`
-}
+const configSectionSlug = "geppetto"
 
-type TurnsConfig struct {
-	DSN      string `json:"dsn,omitempty"`
-	DB       string `json:"db,omitempty"`
-	Default  bool   `json:"default,omitempty"`
-	Phase    string `json:"phase,omitempty"`
-	Readonly bool   `json:"readonly,omitempty"`
+type Config struct {
+	DefaultProfileRegistries []string `json:"defaultProfileRegistries,omitempty"`
+	DefaultProfile           string   `json:"defaultProfile,omitempty"`
 }
 
 type HostServices interface {
 	GeppettoOptions(ctx context.Context, cfg Config) (geppettomodule.Options, error)
 }
 
-type StorageHostServices interface {
-	GeppettoTurnStores(ctx context.Context, cfg Config) (geppettomodule.StorageOptions, error)
-}
-
 var configSchema = json.RawMessage(`{
   "type": "object",
   "properties": {
-    "profile": {"type": "string", "description": "Legacy optional default engine profile selector interpreted by host services."},
-    "profileRegistries": {
-      "description": "Geppetto engine profile registry sources to load (YAML path, yaml:PATH, yaml://PATH, SQLite path, sqlite:PATH, sqlite-dsn:DSN).",
+    "defaultProfileRegistries": {
+      "description": "Default Geppetto engine profile registry sources to load (YAML path, yaml:PATH, yaml://PATH, SQLite path, sqlite:PATH, sqlite-dsn:DSN).",
       "oneOf": [
         {"type": "string"},
         {"type": "array", "items": {"type": "string"}}
       ]
     },
-    "defaultProfile": {"type": "string", "description": "Default engine profile slug for gp.inferenceProfiles.resolve() when no profile is supplied."},
-    "allowRegistryLoad": {"type": "boolean", "description": "Allow this provider instance to load profileRegistries itself."},
-    "allowNetwork": {"type": "boolean", "description": "Explicitly allow host services to configure network-backed inference engines."},
-    "allowTools": {"type": "boolean", "description": "Explicitly allow host services to expose Go tool registries to JavaScript."},
-    "enableStorage": {"type": "boolean", "description": "Allow this provider instance to request host-backed turn storage."},
-    "turns": {
-      "type": "object",
-      "description": "Host-mediated turn-store configuration, such as Pinocchio-style turns DSNs.",
-      "properties": {
-        "dsn": {"type": "string", "description": "Turn-store DSN interpreted by host services."},
-        "db": {"type": "string", "description": "Turn-store database path interpreted by host services."},
-        "default": {"type": "boolean", "description": "Install the resolved turn store as the module default persister."},
-        "phase": {"type": "string", "description": "Preferred persisted phase, usually final."},
-        "readonly": {"type": "boolean", "description": "Open the store read-only when supported by the host."}
-      },
-      "additionalProperties": false
-    }
+    "defaultProfile": {"type": "string", "description": "Default engine profile slug for gp.inferenceProfiles.resolve() when no profile is supplied."}
   },
   "additionalProperties": false
 }`)
 
-func Register(registry *providerapi.Registry) error {
-	return registry.Package(PackageID, providerapi.Module{
-		Name:         geppettomodule.ModuleName,
-		DefaultAs:    geppettomodule.ModuleName,
-		Description:  "Geppetto inference, turns, engine, profile, and runner helpers exposed as require(\"geppetto\").",
-		ConfigSchema: configSchema,
-		New: func(ctx providerapi.ModuleContext) (require.ModuleLoader, error) {
-			cfg, err := decodeConfig(ctx.Config)
-			if err != nil {
-				return nil, fmt.Errorf("geppetto provider config: %w", err)
-			}
-			host, ok := ctx.Host.(HostServices)
-			if !ok || host == nil {
-				return nil, fmt.Errorf("geppetto provider requires geppetto provider HostServices")
-			}
-			opts, err := host.GeppettoOptions(ctx.Context, cfg)
-			if err != nil {
-				return nil, fmt.Errorf("geppetto provider host options: %w", err)
-			}
-			if err := applyConfigRegistryOptions(ctx.Context, cfg, &opts); err != nil {
-				return nil, err
-			}
-			if err := applyConfigStorageOptions(ctx.Context, cfg, ctx.Host, &opts); err != nil {
-				return nil, err
-			}
-			return geppettomodule.NewLoader(opts), nil
+func Register(registry *providerapi.ProviderRegistry) error {
+	capability := capability{}
+	return registry.Package(PackageID,
+		providerapi.Module{
+			Name:         geppettomodule.ModuleName,
+			DefaultAs:    geppettomodule.ModuleName,
+			Description:  "Geppetto inference, turns, engine, profile, and runner helpers exposed as require(\"geppetto\").",
+			ConfigSchema: configSchema,
+			NewModuleFactory: func(ctx providerapi.ModuleSetupContext) (require.ModuleLoader, error) {
+				cfg, err := decodeConfig(ctx.Config)
+				if err != nil {
+					return nil, fmt.Errorf("geppetto provider config: %w", err)
+				}
+				host, ok := ctx.Host.(HostServices)
+				if !ok || host == nil {
+					return nil, fmt.Errorf("geppetto provider requires geppetto provider HostServices")
+				}
+				opts, err := host.GeppettoOptions(ctx.Context, cfg)
+				if err != nil {
+					return nil, fmt.Errorf("geppetto provider host options: %w", err)
+				}
+				if err := applyConfigRegistryOptions(ctx.Context, cfg, &opts); err != nil {
+					return nil, err
+				}
+				return geppettomodule.NewLoader(opts), nil
+			},
 		},
-	})
+		providerapi.WithPackageCapability(capability),
+	)
 }
 
 func decodeConfig(data json.RawMessage) (Config, error) {
@@ -109,45 +80,42 @@ func decodeConfig(data json.RawMessage) (Config, error) {
 		type configAlias Config
 		var raw struct {
 			*configAlias
-			ProfileRegistries any `json:"profileRegistries"`
+			DefaultProfileRegistries any `json:"defaultProfileRegistries"`
 		}
 		raw.configAlias = (*configAlias)(&cfg)
 		if err := json.Unmarshal(data, &raw); err != nil {
 			return Config{}, err
 		}
-		if raw.ProfileRegistries != nil {
-			entries, err := decodeSourceEntries(raw.ProfileRegistries)
+		if raw.DefaultProfileRegistries != nil {
+			entries, err := decodeSourceEntries(raw.DefaultProfileRegistries, "defaultProfileRegistries")
 			if err != nil {
 				return Config{}, err
 			}
-			cfg.ProfileRegistries = entries
+			cfg.DefaultProfileRegistries = entries
 		}
-	}
-	if cfg.DefaultProfile == "" {
-		cfg.DefaultProfile = cfg.Profile
 	}
 	return cfg, nil
 }
 
-func decodeSourceEntries(raw any) ([]string, error) {
+func decodeSourceEntries(raw any, fieldName string) ([]string, error) {
 	switch v := raw.(type) {
 	case string:
 		if strings.TrimSpace(v) == "" {
 			return nil, nil
 		}
-		return profiles.ParseEngineProfileRegistrySourceEntries(v)
+		return engineprofiles.ParseEngineProfileRegistrySourceEntries(v)
 	case []any:
 		out := make([]string, 0, len(v))
 		for i, item := range v {
 			s, ok := item.(string)
 			if !ok || strings.TrimSpace(s) == "" {
-				return nil, fmt.Errorf("profileRegistries[%d] must be a non-empty string", i)
+				return nil, fmt.Errorf("%s[%d] must be a non-empty string", fieldName, i)
 			}
 			out = append(out, strings.TrimSpace(s))
 		}
 		return out, nil
 	default:
-		return nil, fmt.Errorf("profileRegistries must be a string or string array")
+		return nil, fmt.Errorf("%s must be a string or string array", fieldName)
 	}
 }
 
@@ -155,23 +123,20 @@ func applyConfigRegistryOptions(ctx context.Context, cfg Config, opts *geppettom
 	if opts == nil {
 		return nil
 	}
-	if len(cfg.ProfileRegistries) > 0 {
-		if !cfg.AllowRegistryLoad {
-			return fmt.Errorf("geppetto provider profileRegistries require allowRegistryLoad=true")
-		}
-		specs, err := profiles.ParseRegistrySourceSpecs(cfg.ProfileRegistries)
+	if len(cfg.DefaultProfileRegistries) > 0 {
+		specs, err := engineprofiles.ParseRegistrySourceSpecs(cfg.DefaultProfileRegistries)
 		if err != nil {
-			return fmt.Errorf("geppetto provider profileRegistries: %w", err)
+			return fmt.Errorf("geppetto provider defaultProfileRegistries: %w", err)
 		}
-		chain, err := profiles.NewChainedRegistryFromSourceSpecs(ctx, specs)
+		chain, err := engineprofiles.NewChainedRegistryFromSourceSpecs(ctx, specs)
 		if err != nil {
-			return fmt.Errorf("geppetto provider load profileRegistries: %w", err)
+			return fmt.Errorf("geppetto provider load defaultProfileRegistries: %w", err)
 		}
 		opts.EngineProfileRegistry = chain
-		opts.EngineProfileRegistrySpec = append([]string(nil), cfg.ProfileRegistries...)
+		opts.EngineProfileRegistrySpec = append([]string(nil), cfg.DefaultProfileRegistries...)
 	}
 	if strings.TrimSpace(cfg.DefaultProfile) != "" {
-		profileSlug, err := profiles.ParseEngineProfileSlug(cfg.DefaultProfile)
+		profileSlug, err := engineprofiles.ParseEngineProfileSlug(cfg.DefaultProfile)
 		if err != nil {
 			return fmt.Errorf("geppetto provider defaultProfile: %w", err)
 		}
@@ -181,41 +146,62 @@ func applyConfigRegistryOptions(ctx context.Context, cfg Config, opts *geppettom
 	return nil
 }
 
-func applyConfigStorageOptions(ctx context.Context, cfg Config, host any, opts *geppettomodule.Options) error {
-	if opts == nil {
-		return nil
-	}
-	if cfg.Turns != nil && !cfg.EnableStorage {
-		return fmt.Errorf("geppetto provider turns config requires enableStorage=true")
-	}
-	if !cfg.EnableStorage {
-		return nil
-	}
-	storageHost, ok := host.(StorageHostServices)
-	if !ok || storageHost == nil {
-		return fmt.Errorf("geppetto provider enableStorage requires GeppettoTurnStores host capability")
-	}
-	storage, err := storageHost.GeppettoTurnStores(ctx, cfg)
+type capability struct{}
+
+func (capability) CapabilityID() string { return "geppetto-config" }
+
+func (capability) GlazedConfigSections(providerapi.SectionRequest) ([]schema.Section, error) {
+	section, err := schema.NewSection(configSectionSlug, "Geppetto",
+		schema.WithPrefix("geppetto-"),
+		schema.WithFields(
+			fields.New("default-profile-registries", fields.TypeStringList, fields.WithHelp("Default Geppetto profile registry sources for this module instance")),
+			fields.New("default-profile", fields.TypeString, fields.WithHelp("Default Geppetto engine profile slug for this module instance")),
+		),
+	)
 	if err != nil {
-		return fmt.Errorf("geppetto provider host turn stores: %w", err)
+		return nil, err
 	}
-	opts.EnableStorage = true
-	if storage.Default != nil {
-		opts.DefaultTurnStore = storage.Default
+	return []schema.Section{section}, nil
+}
+
+func (capability) XGojaConfigSection(providerapi.SectionRequest, providerapi.ModuleDescriptor) (schema.Section, error) {
+	return xgojaConfigSection()
+}
+
+func (capability) XGojaConfigFromGlazed(_ context.Context, req providerapi.XGojaConfigRequest) (*values.SectionValues, error) {
+	out, err := values.NewSectionValues(req.ConfigSection)
+	if err != nil {
+		return nil, err
 	}
-	if len(storage.Stores) > 0 {
-		if opts.TurnStores == nil {
-			opts.TurnStores = map[string]geppettomodule.TurnStore{}
-		}
-		for name, store := range storage.Stores {
-			if strings.TrimSpace(name) == "" || store == nil {
-				continue
-			}
-			opts.TurnStores[strings.TrimSpace(name)] = store
-		}
+	if req.GlazedValues == nil {
+		return out, nil
 	}
-	if cfg.Turns != nil && cfg.Turns.Default && opts.DefaultTurnStore != nil {
-		opts.DefaultPersister = opts.DefaultTurnStore
+	if err := copyGlazedField(req.GlazedValues, out, "default-profile-registries", "defaultProfileRegistries"); err != nil {
+		return nil, err
 	}
-	return nil
+	if err := copyGlazedField(req.GlazedValues, out, "default-profile", "defaultProfile"); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func xgojaConfigSection() (schema.Section, error) {
+	return schema.NewSection(configSectionSlug+"-xgoja", "Geppetto xgoja config",
+		schema.WithFields(
+			fields.New("defaultProfileRegistries", fields.TypeStringList),
+			fields.New("defaultProfile", fields.TypeString),
+		),
+	)
+}
+
+func copyGlazedField(vals *values.Values, out *values.SectionValues, glazedField, xgojaField string) error {
+	field, ok := vals.GetField(configSectionSlug, glazedField)
+	if !ok {
+		return nil
+	}
+	definition, ok := out.Section.GetDefinitions().Get(xgojaField)
+	if !ok {
+		return fmt.Errorf("xgoja config field %q not found", xgojaField)
+	}
+	return out.Fields.UpdateWithLog(xgojaField, definition, field.Value, field.Log...)
 }

--- a/pkg/js/modules/geppetto/provider/provider.go
+++ b/pkg/js/modules/geppetto/provider/provider.go
@@ -22,6 +22,8 @@ const configSectionSlug = "geppetto"
 type Config struct {
 	DefaultProfileRegistries []string `json:"defaultProfileRegistries,omitempty"`
 	DefaultProfile           string   `json:"defaultProfile,omitempty"`
+	TurnsDSN                 string   `json:"turnsDSN,omitempty"`
+	TurnsDB                  string   `json:"turnsDB,omitempty"`
 }
 
 type HostServices interface {
@@ -38,7 +40,9 @@ var configSchema = json.RawMessage(`{
         {"type": "array", "items": {"type": "string"}}
       ]
     },
-    "defaultProfile": {"type": "string", "description": "Default engine profile slug for gp.inferenceProfiles.resolve() when no profile is supplied."}
+    "defaultProfile": {"type": "string", "description": "Default engine profile slug for gp.inferenceProfiles.resolve() when no profile is supplied."},
+    "turnsDSN": {"type": "string", "description": "SQLite DSN for the default gp.turnStores.default() store; preferred over turnsDB."},
+    "turnsDB": {"type": "string", "description": "SQLite database path for the default gp.turnStores.default() store."}
   },
   "additionalProperties": false
 }`)
@@ -56,15 +60,17 @@ func Register(registry *providerapi.ProviderRegistry) error {
 				if err != nil {
 					return nil, fmt.Errorf("geppetto provider config: %w", err)
 				}
-				host, ok := ctx.Host.(HostServices)
-				if !ok || host == nil {
-					return nil, fmt.Errorf("geppetto provider requires geppetto provider HostServices")
-				}
-				opts, err := host.GeppettoOptions(ctx.Context, cfg)
-				if err != nil {
-					return nil, fmt.Errorf("geppetto provider host options: %w", err)
+				opts := geppettomodule.Options{}
+				if host, ok := ctx.Host.(HostServices); ok && host != nil {
+					opts, err = host.GeppettoOptions(ctx.Context, cfg)
+					if err != nil {
+						return nil, fmt.Errorf("geppetto provider host options: %w", err)
+					}
 				}
 				if err := applyConfigRegistryOptions(ctx.Context, cfg, &opts); err != nil {
+					return nil, err
+				}
+				if err := applyConfigTurnStoreOptions(cfg, &opts); err != nil {
 					return nil, err
 				}
 				return geppettomodule.NewLoader(opts), nil
@@ -146,16 +152,35 @@ func applyConfigRegistryOptions(ctx context.Context, cfg Config, opts *geppettom
 	return nil
 }
 
+func applyConfigTurnStoreOptions(cfg Config, opts *geppettomodule.Options) error {
+	if opts == nil || (strings.TrimSpace(cfg.TurnsDSN) == "" && strings.TrimSpace(cfg.TurnsDB) == "") {
+		return nil
+	}
+	store, err := openSQLiteTurnStore(cfg.TurnsDSN, cfg.TurnsDB)
+	if err != nil {
+		return err
+	}
+	opts.EnableStorage = true
+	opts.DefaultTurnStore = store
+	opts.DefaultPersister = store
+	if opts.TurnStores == nil {
+		opts.TurnStores = map[string]geppettomodule.TurnStore{}
+	}
+	opts.TurnStores["default"] = store
+	return nil
+}
+
 type capability struct{}
 
 func (capability) CapabilityID() string { return "geppetto-config" }
 
 func (capability) GlazedConfigSections(providerapi.SectionRequest) ([]schema.Section, error) {
 	section, err := schema.NewSection(configSectionSlug, "Geppetto",
-		schema.WithPrefix("geppetto-"),
 		schema.WithFields(
-			fields.New("default-profile-registries", fields.TypeStringList, fields.WithHelp("Default Geppetto profile registry sources for this module instance")),
-			fields.New("default-profile", fields.TypeString, fields.WithHelp("Default Geppetto engine profile slug for this module instance")),
+			fields.New("profile-registries", fields.TypeStringList, fields.WithHelp("Default Geppetto profile registry sources for this module instance")),
+			fields.New("profile", fields.TypeString, fields.WithHelp("Default Geppetto engine profile slug for this module instance")),
+			fields.New("turns-dsn", fields.TypeString, fields.WithHelp("SQLite DSN for the default Geppetto turn store")),
+			fields.New("turns-db", fields.TypeString, fields.WithHelp("SQLite DB file path for the default Geppetto turn store")),
 		),
 	)
 	if err != nil {
@@ -176,10 +201,16 @@ func (capability) XGojaConfigFromGlazed(_ context.Context, req providerapi.XGoja
 	if req.GlazedValues == nil {
 		return out, nil
 	}
-	if err := copyGlazedField(req.GlazedValues, out, "default-profile-registries", "defaultProfileRegistries"); err != nil {
+	if err := copyGlazedField(req.GlazedValues, out, "profile-registries", "defaultProfileRegistries"); err != nil {
 		return nil, err
 	}
-	if err := copyGlazedField(req.GlazedValues, out, "default-profile", "defaultProfile"); err != nil {
+	if err := copyGlazedField(req.GlazedValues, out, "profile", "defaultProfile"); err != nil {
+		return nil, err
+	}
+	if err := copyGlazedField(req.GlazedValues, out, "turns-dsn", "turnsDSN"); err != nil {
+		return nil, err
+	}
+	if err := copyGlazedField(req.GlazedValues, out, "turns-db", "turnsDB"); err != nil {
 		return nil, err
 	}
 	return out, nil
@@ -190,6 +221,8 @@ func xgojaConfigSection() (schema.Section, error) {
 		schema.WithFields(
 			fields.New("defaultProfileRegistries", fields.TypeStringList),
 			fields.New("defaultProfile", fields.TypeString),
+			fields.New("turnsDSN", fields.TypeString),
+			fields.New("turnsDB", fields.TypeString),
 		),
 	)
 }

--- a/pkg/js/modules/geppetto/provider/provider.go
+++ b/pkg/js/modules/geppetto/provider/provider.go
@@ -73,7 +73,7 @@ func Register(registry *providerapi.ProviderRegistry) error {
 				if err := applyConfigRegistryOptions(ctx.Context, cfg, &opts); err != nil {
 					return nil, err
 				}
-				if err := applyConfigTurnStoreOptions(cfg, &opts); err != nil {
+				if err := applyConfigTurnStoreOptions(cfg, &opts, ctx.AddCloser); err != nil {
 					return nil, err
 				}
 				return geppettomodule.NewLoader(opts), nil
@@ -155,13 +155,19 @@ func applyConfigRegistryOptions(ctx context.Context, cfg Config, opts *geppettom
 	return nil
 }
 
-func applyConfigTurnStoreOptions(cfg Config, opts *geppettomodule.Options) error {
+func applyConfigTurnStoreOptions(cfg Config, opts *geppettomodule.Options, addCloser func(func(context.Context) error) error) error {
 	if opts == nil || (strings.TrimSpace(cfg.TurnsDSN) == "" && strings.TrimSpace(cfg.TurnsDB) == "") {
 		return nil
 	}
 	store, err := openSQLiteTurnStore(cfg.TurnsDSN, cfg.TurnsDB)
 	if err != nil {
 		return err
+	}
+	if addCloser != nil {
+		if err := addCloser(func(context.Context) error { return store.Close() }); err != nil {
+			_ = store.Close()
+			return fmt.Errorf("geppetto provider register turns sqlite closer: %w", err)
+		}
 	}
 	opts.EnableStorage = true
 	opts.DefaultTurnStore = store

--- a/pkg/js/modules/geppetto/provider/provider.go
+++ b/pkg/js/modules/geppetto/provider/provider.go
@@ -67,6 +67,9 @@ func Register(registry *providerapi.ProviderRegistry) error {
 						return nil, fmt.Errorf("geppetto provider host options: %w", err)
 					}
 				}
+				if err := applyHostOptionsContributions(ctx.Context, ctx.Host, cfg, &opts); err != nil {
+					return nil, err
+				}
 				if err := applyConfigRegistryOptions(ctx.Context, cfg, &opts); err != nil {
 					return nil, err
 				}

--- a/pkg/js/modules/geppetto/provider/provider_test.go
+++ b/pkg/js/modules/geppetto/provider/provider_test.go
@@ -259,6 +259,39 @@ func TestSQLiteTurnStorePersistsAndReadsTurns(t *testing.T) {
 	}
 }
 
+func TestSQLiteTurnStoreLoadLatestKeepsConvAndSessionPredicatesSeparate(t *testing.T) {
+	store, err := openSQLiteTurnStore("", filepath.Join(t.TempDir(), "turns.db"))
+	if err != nil {
+		t.Fatalf("openSQLiteTurnStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	_, err = store.db.Exec(`
+INSERT INTO geppetto_turns (conv_id, session_id, turn_id, phase, runtime_key, inference_id, created_at_ms, payload)
+VALUES
+	('conv-a', 'session-a', 'turn-a', 'final', '', '', 100, ''),
+	('conv-a', 'session-b', 'turn-b', 'final', '', '', 200, '')`)
+	if err != nil {
+		t.Fatalf("insert turns: %v", err)
+	}
+
+	latest, err := store.LoadLatestTurn(context.Background(), geppettomodule.TurnStoreQuery{SessionID: "session-a", Phase: "final"})
+	if err != nil {
+		t.Fatalf("LoadLatestTurn by session failed: %v", err)
+	}
+	if latest == nil || latest.ConvID != "conv-a" || latest.SessionID != "session-a" || latest.TurnID != "turn-a" {
+		t.Fatalf("session-only latest = %#v", latest)
+	}
+
+	latest, err = store.LoadLatestTurn(context.Background(), geppettomodule.TurnStoreQuery{ConvID: "conv-a", SessionID: "session-a", Phase: "final"})
+	if err != nil {
+		t.Fatalf("LoadLatestTurn by conv+session failed: %v", err)
+	}
+	if latest == nil || latest.ConvID != "conv-a" || latest.SessionID != "session-a" || latest.TurnID != "turn-a" {
+		t.Fatalf("conv+session latest = %#v", latest)
+	}
+}
+
 func assertSectionField(t *testing.T, sectionValues *values.SectionValues, key string, want any) {
 	t.Helper()
 	got, ok := sectionValues.GetField(key)

--- a/pkg/js/modules/geppetto/provider/provider_test.go
+++ b/pkg/js/modules/geppetto/provider/provider_test.go
@@ -16,16 +16,15 @@ import (
 	inferenceengine "github.com/go-go-golems/geppetto/pkg/inference/engine"
 	geppettomodule "github.com/go-go-golems/geppetto/pkg/js/modules/geppetto"
 	"github.com/go-go-golems/geppetto/pkg/turns"
+	"github.com/go-go-golems/glazed/pkg/cmds/values"
 	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 	"github.com/go-go-golems/go-go-goja/pkg/jsevents"
 	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
 )
 
 type fakeHost struct {
-	seen        Config
-	opts        geppettomodule.Options
-	storage     geppettomodule.StorageOptions
-	storageSeen bool
+	seen Config
+	opts geppettomodule.Options
 }
 
 func (h *fakeHost) GeppettoOptions(_ context.Context, cfg Config) (geppettomodule.Options, error) {
@@ -33,28 +32,9 @@ func (h *fakeHost) GeppettoOptions(_ context.Context, cfg Config) (geppettomodul
 	return h.opts, nil
 }
 
-func (h *fakeHost) GeppettoTurnStores(_ context.Context, cfg Config) (geppettomodule.StorageOptions, error) {
-	h.seen = cfg
-	h.storageSeen = true
-	return h.storage, nil
-}
-
 func (h *fakeHost) AssetResolver() providerapi.AssetResolver {
 	return nil
 }
-
-type providerRecordingStore struct{}
-
-var _ geppettomodule.TurnStore = (*providerRecordingStore)(nil)
-
-func (s *providerRecordingStore) PersistTurn(context.Context, *turns.Turn) error { return nil }
-func (s *providerRecordingStore) ListTurns(context.Context, geppettomodule.TurnStoreQuery) ([]geppettomodule.TurnStoreSnapshot, error) {
-	return nil, nil
-}
-func (s *providerRecordingStore) LoadLatestTurn(context.Context, geppettomodule.TurnStoreQuery) (*geppettomodule.TurnStoreSnapshot, error) {
-	return nil, nil
-}
-func (s *providerRecordingStore) Close() error { return nil }
 
 func TestRegisterProvider(t *testing.T) {
 	registry := providerapi.NewProviderRegistry()
@@ -70,10 +50,14 @@ func TestRegisterProvider(t *testing.T) {
 	}
 }
 
-func TestProviderRequiresHostServices(t *testing.T) {
+func TestProviderWorksWithoutHostServices(t *testing.T) {
 	mod := resolveModule(t)
-	if _, err := mod.NewModuleFactory(providerapi.ModuleSetupContext{}); err == nil {
-		t.Fatalf("expected missing host services error")
+	loader, err := mod.NewModuleFactory(providerapi.ModuleSetupContext{})
+	if err != nil {
+		t.Fatalf("expected provider to work without host services: %v", err)
+	}
+	if loader == nil {
+		t.Fatalf("loader is nil")
 	}
 }
 
@@ -172,8 +156,91 @@ func TestProviderIgnoresRemovedLegacyStorageFields(t *testing.T) {
 	if loader == nil {
 		t.Fatalf("loader is nil")
 	}
-	if host.storageSeen {
-		t.Fatalf("storage host should not be invoked by provider config")
+}
+
+func TestProviderMapsGlazedFlagsToXGojaConfig(t *testing.T) {
+	cap := capability{}
+	sections, err := cap.GlazedConfigSections(providerapi.SectionRequest{})
+	if err != nil {
+		t.Fatalf("GlazedConfigSections failed: %v", err)
+	}
+	if len(sections) != 1 {
+		t.Fatalf("sections = %d, want 1", len(sections))
+	}
+	if sections[0].GetPrefix() != "" {
+		t.Fatalf("geppetto public flags should be unprefixed, got prefix %q", sections[0].GetPrefix())
+	}
+	glazedSection, err := values.NewSectionValues(sections[0],
+		values.WithFieldValue("profile-registries", []string{"profiles.yaml"}),
+		values.WithFieldValue("profile", "assistant"),
+		values.WithFieldValue("turns-db", "/tmp/turns.db"),
+	)
+	if err != nil {
+		t.Fatalf("NewSectionValues failed: %v", err)
+	}
+	configSection, err := xgojaConfigSection()
+	if err != nil {
+		t.Fatalf("xgojaConfigSection failed: %v", err)
+	}
+	out, err := cap.XGojaConfigFromGlazed(context.Background(), providerapi.XGojaConfigRequest{
+		ConfigSection: configSection,
+		GlazedValues:  values.New(values.WithSectionValues(configSectionSlug, glazedSection)),
+	})
+	if err != nil {
+		t.Fatalf("XGojaConfigFromGlazed failed: %v", err)
+	}
+	assertSectionField(t, out, "defaultProfile", "assistant")
+	assertSectionField(t, out, "turnsDB", "/tmp/turns.db")
+	registries, ok := out.GetField("defaultProfileRegistries")
+	if !ok {
+		t.Fatalf("defaultProfileRegistries missing")
+	}
+	entries, ok := registries.([]string)
+	if !ok || len(entries) != 1 || entries[0] != "profiles.yaml" {
+		t.Fatalf("defaultProfileRegistries = %#v", registries)
+	}
+}
+
+func TestSQLiteTurnStorePersistsAndReadsTurns(t *testing.T) {
+	store, err := openSQLiteTurnStore("", filepath.Join(t.TempDir(), "turns.db"))
+	if err != nil {
+		t.Fatalf("openSQLiteTurnStore failed: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	turn := &turns.Turn{ID: "turn-a"}
+	if err := turns.KeyTurnMetaSessionID.Set(&turn.Metadata, "session-a"); err != nil {
+		t.Fatalf("set session id: %v", err)
+	}
+	turns.AppendBlock(turn, turns.NewUserTextBlock("hello"))
+	turns.AppendBlock(turn, turns.NewAssistantTextBlock("stored"))
+	if err := store.PersistTurn(context.Background(), turn); err != nil {
+		t.Fatalf("PersistTurn failed: %v", err)
+	}
+	listed, err := store.ListTurns(context.Background(), geppettomodule.TurnStoreQuery{SessionID: "session-a", Phase: "final"})
+	if err != nil {
+		t.Fatalf("ListTurns failed: %v", err)
+	}
+	if len(listed) != 1 {
+		t.Fatalf("listed = %d, want 1", len(listed))
+	}
+	latest, err := store.LoadLatestTurn(context.Background(), geppettomodule.TurnStoreQuery{SessionID: "session-a", Phase: "final"})
+	if err != nil {
+		t.Fatalf("LoadLatestTurn failed: %v", err)
+	}
+	if latest == nil || latest.Turn == nil || latest.SessionID != "session-a" || latest.TurnID != "turn-a" {
+		t.Fatalf("unexpected latest: %#v", latest)
+	}
+}
+
+func assertSectionField(t *testing.T, sectionValues *values.SectionValues, key string, want any) {
+	t.Helper()
+	got, ok := sectionValues.GetField(key)
+	if !ok {
+		t.Fatalf("%s missing", key)
+	}
+	if got != want {
+		t.Fatalf("%s = %#v, want %#v", key, got, want)
 	}
 }
 

--- a/pkg/js/modules/geppetto/provider/provider_test.go
+++ b/pkg/js/modules/geppetto/provider/provider_test.go
@@ -16,7 +16,7 @@ import (
 	inferenceengine "github.com/go-go-golems/geppetto/pkg/inference/engine"
 	geppettomodule "github.com/go-go-golems/geppetto/pkg/js/modules/geppetto"
 	"github.com/go-go-golems/geppetto/pkg/turns"
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 	"github.com/go-go-golems/go-go-goja/pkg/jsevents"
 	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
 )
@@ -43,14 +43,6 @@ func (h *fakeHost) AssetResolver() providerapi.AssetResolver {
 	return nil
 }
 
-type fakeOptionsOnlyHost struct{}
-
-func (fakeOptionsOnlyHost) GeppettoOptions(context.Context, Config) (geppettomodule.Options, error) {
-	return geppettomodule.Options{}, nil
-}
-
-func (fakeOptionsOnlyHost) AssetResolver() providerapi.AssetResolver { return nil }
-
 type providerRecordingStore struct{}
 
 var _ geppettomodule.TurnStore = (*providerRecordingStore)(nil)
@@ -65,7 +57,7 @@ func (s *providerRecordingStore) LoadLatestTurn(context.Context, geppettomodule.
 func (s *providerRecordingStore) Close() error { return nil }
 
 func TestRegisterProvider(t *testing.T) {
-	registry := providerapi.NewRegistry()
+	registry := providerapi.NewProviderRegistry()
 	if err := Register(registry); err != nil {
 		t.Fatalf("register provider: %v", err)
 	}
@@ -80,12 +72,12 @@ func TestRegisterProvider(t *testing.T) {
 
 func TestProviderRequiresHostServices(t *testing.T) {
 	mod := resolveModule(t)
-	if _, err := mod.New(providerapi.ModuleContext{}); err == nil {
+	if _, err := mod.NewModuleFactory(providerapi.ModuleSetupContext{}); err == nil {
 		t.Fatalf("expected missing host services error")
 	}
 }
 
-func TestProviderLoadsProfileRegistriesWhenAllowed(t *testing.T) {
+func TestProviderLoadsDefaultProfileRegistries(t *testing.T) {
 	profilePath := filepath.Join(t.TempDir(), "profiles.yaml")
 	if err := os.WriteFile(profilePath, []byte(`slug: xgoja
 profiles:
@@ -102,21 +94,20 @@ profiles:
 	}
 	mod := resolveModule(t)
 	host := &fakeHost{}
-	loader, err := mod.New(providerapi.ModuleContext{
+	loader, err := mod.NewModuleFactory(providerapi.ModuleSetupContext{
 		Name: geppettomodule.ModuleName,
 		As:   geppettomodule.ModuleName,
 		Host: host,
 		Config: json.RawMessage(`{
-			"profileRegistries": [` + strconv.Quote(profilePath) + `],
-			"defaultProfile": "assistant",
-			"allowRegistryLoad": true
+			"defaultProfileRegistries": [` + strconv.Quote(profilePath) + `],
+			"defaultProfile": "assistant"
 		}`),
 	})
 	if err != nil {
 		t.Fatalf("create loader: %v", err)
 	}
-	if got := len(host.seen.ProfileRegistries); got != 1 {
-		t.Fatalf("host saw %d profileRegistries", got)
+	if got := len(host.seen.DefaultProfileRegistries); got != 1 {
+		t.Fatalf("host saw %d defaultProfileRegistries", got)
 	}
 
 	vm := goja.New()
@@ -151,7 +142,7 @@ profiles:
 func TestProviderIgnoresRemovedLegacyRegistryField(t *testing.T) {
 	mod := resolveModule(t)
 	host := &fakeHost{}
-	_, err := mod.New(providerapi.ModuleContext{
+	_, err := mod.NewModuleFactory(providerapi.ModuleSetupContext{
 		Name:   geppettomodule.ModuleName,
 		As:     geppettomodule.ModuleName,
 		Host:   host,
@@ -160,57 +151,15 @@ func TestProviderIgnoresRemovedLegacyRegistryField(t *testing.T) {
 	if err != nil {
 		t.Fatalf("legacy registry field should be ignored by provider decode: %v", err)
 	}
-	if len(host.seen.ProfileRegistries) != 0 {
-		t.Fatalf("legacy registry populated profileRegistries: %#v", host.seen.ProfileRegistries)
+	if len(host.seen.DefaultProfileRegistries) != 0 {
+		t.Fatalf("legacy registry populated defaultProfileRegistries: %#v", host.seen.DefaultProfileRegistries)
 	}
 }
 
-func TestProviderRejectsProfileRegistriesUnlessAllowed(t *testing.T) {
+func TestProviderIgnoresRemovedLegacyStorageFields(t *testing.T) {
 	mod := resolveModule(t)
-	_, err := mod.New(providerapi.ModuleContext{
-		Name:   geppettomodule.ModuleName,
-		As:     geppettomodule.ModuleName,
-		Host:   &fakeHost{},
-		Config: json.RawMessage(`{"profileRegistries": ["profiles.yaml"]}`),
-	})
-	if err == nil {
-		t.Fatalf("expected allowRegistryLoad error")
-	}
-}
-
-func TestProviderTurnsConfigRequiresEnableStorage(t *testing.T) {
-	mod := resolveModule(t)
-	_, err := mod.New(providerapi.ModuleContext{
-		Context: context.Background(),
-		Name:    geppettomodule.ModuleName,
-		As:      geppettomodule.ModuleName,
-		Host:    &fakeHost{},
-		Config:  json.RawMessage(`{"turns":{"dsn":"file:test.sqlite"}}`),
-	})
-	if err == nil {
-		t.Fatalf("expected enableStorage error")
-	}
-}
-
-func TestProviderEnableStorageRequiresStorageHost(t *testing.T) {
-	mod := resolveModule(t)
-	_, err := mod.New(providerapi.ModuleContext{
-		Context: context.Background(),
-		Name:    geppettomodule.ModuleName,
-		As:      geppettomodule.ModuleName,
-		Host:    fakeOptionsOnlyHost{},
-		Config:  json.RawMessage(`{"enableStorage":true}`),
-	})
-	if err == nil {
-		t.Fatalf("expected storage host capability error")
-	}
-}
-
-func TestProviderEnableStorageInstallsDefaultTurnStore(t *testing.T) {
-	mod := resolveModule(t)
-	store := &providerRecordingStore{}
-	host := &fakeHost{storage: geppettomodule.StorageOptions{Default: store}}
-	loader, err := mod.New(providerapi.ModuleContext{
+	host := &fakeHost{}
+	loader, err := mod.NewModuleFactory(providerapi.ModuleSetupContext{
 		Context: context.Background(),
 		Name:    geppettomodule.ModuleName,
 		As:      geppettomodule.ModuleName,
@@ -218,25 +167,22 @@ func TestProviderEnableStorageInstallsDefaultTurnStore(t *testing.T) {
 		Config:  json.RawMessage(`{"enableStorage":true,"turns":{"default":true,"phase":"final"}}`),
 	})
 	if err != nil {
-		t.Fatalf("create loader with storage: %v", err)
+		t.Fatalf("legacy storage fields should be ignored by provider decode: %v", err)
 	}
 	if loader == nil {
 		t.Fatalf("loader is nil")
 	}
-	if !host.storageSeen {
-		t.Fatalf("storage host was not invoked")
-	}
-	if host.seen.Turns == nil || !host.seen.Turns.Default || host.seen.Turns.Phase != "final" {
-		t.Fatalf("host saw storage config %+v", host.seen)
+	if host.storageSeen {
+		t.Fatalf("storage host should not be invoked by provider config")
 	}
 }
 
-type providerRuntimeModuleSpec struct{}
+type providerRuntimeModuleRegistrar struct{}
 
-func (providerRuntimeModuleSpec) ID() string { return "geppetto-provider-test" }
+func (providerRuntimeModuleRegistrar) ID() string { return "geppetto-provider-test" }
 
-func (providerRuntimeModuleSpec) RegisterRuntimeModule(ctx *gojengine.RuntimeModuleContext, reg *require.Registry) error {
-	registry := providerapi.NewRegistry()
+func (providerRuntimeModuleRegistrar) RegisterRuntimeModule(ctx *gojengine.RuntimeModuleRegistrationContext, reg *require.Registry) error {
+	registry := providerapi.NewProviderRegistry()
 	if err := Register(registry); err != nil {
 		return err
 	}
@@ -255,7 +201,7 @@ func (providerRuntimeModuleSpec) RegisterRuntimeModule(ctx *gojengine.RuntimeMod
 			return manager, ok && manager != nil
 		},
 	}}
-	loader, err := mod.New(providerapi.ModuleContext{
+	loader, err := mod.NewModuleFactory(providerapi.ModuleSetupContext{
 		Context: context.Background(),
 		Name:    geppettomodule.ModuleName,
 		As:      geppettomodule.ModuleName,
@@ -282,12 +228,12 @@ func (e *providerEventEngine) RunInference(ctx context.Context, t *turns.Turn) (
 }
 
 func TestProviderRuntimeSupportsEventEmitterRunAsync(t *testing.T) {
-	factory, err := gojengine.NewBuilder(
+	factory, err := gojengine.NewRuntimeFactoryBuilder(
 		gojengine.WithDataOnlyDefaultRegistryModules(true),
 	).
 		UseModuleMiddleware(gojengine.Pipeline()).
 		WithRuntimeInitializers(jsevents.Install()).
-		WithModules(providerRuntimeModuleSpec{}).
+		WithModules(providerRuntimeModuleRegistrar{}).
 		Build()
 	if err != nil {
 		t.Fatalf("failed creating runtime factory: %v", err)
@@ -352,7 +298,7 @@ func TestProviderRuntimeSupportsEventEmitterRunAsync(t *testing.T) {
 func TestModuleLoaderInstallsGeppettoExports(t *testing.T) {
 	mod := resolveModule(t)
 	host := &fakeHost{}
-	loader, err := mod.New(providerapi.ModuleContext{
+	loader, err := mod.NewModuleFactory(providerapi.ModuleSetupContext{
 		Name:   geppettomodule.ModuleName,
 		As:     geppettomodule.ModuleName,
 		Host:   host,
@@ -361,8 +307,8 @@ func TestModuleLoaderInstallsGeppettoExports(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create loader: %v", err)
 	}
-	if host.seen.Profile != "test-profile" || !host.seen.AllowNetwork {
-		t.Fatalf("host saw config %+v", host.seen)
+	if host.seen.DefaultProfile != "" || len(host.seen.DefaultProfileRegistries) != 0 {
+		t.Fatalf("removed legacy config fields should be ignored, host saw %+v", host.seen)
 	}
 
 	vm := goja.New()
@@ -394,7 +340,7 @@ func TestModuleLoaderInstallsGeppettoExports(t *testing.T) {
 
 func resolveModule(t *testing.T) providerapi.Module {
 	t.Helper()
-	registry := providerapi.NewRegistry()
+	registry := providerapi.NewProviderRegistry()
 	if err := Register(registry); err != nil {
 		t.Fatalf("register provider: %v", err)
 	}

--- a/pkg/js/modules/geppetto/provider/provider_test.go
+++ b/pkg/js/modules/geppetto/provider/provider_test.go
@@ -159,8 +159,8 @@ func TestProviderIgnoresRemovedLegacyStorageFields(t *testing.T) {
 }
 
 func TestProviderMapsGlazedFlagsToXGojaConfig(t *testing.T) {
-	cap := capability{}
-	sections, err := cap.GlazedConfigSections(providerapi.SectionRequest{})
+	providerCapability := capability{}
+	sections, err := providerCapability.GlazedConfigSections(providerapi.SectionRequest{})
 	if err != nil {
 		t.Fatalf("GlazedConfigSections failed: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestProviderMapsGlazedFlagsToXGojaConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("xgojaConfigSection failed: %v", err)
 	}
-	out, err := cap.XGojaConfigFromGlazed(context.Background(), providerapi.XGojaConfigRequest{
+	out, err := providerCapability.XGojaConfigFromGlazed(context.Background(), providerapi.XGojaConfigRequest{
 		ConfigSection: configSection,
 		GlazedValues:  values.New(values.WithSectionValues(configSectionSlug, glazedSection)),
 	})

--- a/pkg/js/modules/geppetto/provider/provider_test.go
+++ b/pkg/js/modules/geppetto/provider/provider_test.go
@@ -201,6 +201,32 @@ func TestProviderMapsGlazedFlagsToXGojaConfig(t *testing.T) {
 	}
 }
 
+func TestProviderRegistersSQLiteTurnStoreCloser(t *testing.T) {
+	mod := resolveModule(t)
+	closers := []func(context.Context) error{}
+	_, err := mod.NewModuleFactory(providerapi.ModuleSetupContext{
+		Context: context.Background(),
+		Name:    geppettomodule.ModuleName,
+		As:      geppettomodule.ModuleName,
+		Config: json.RawMessage(`{
+			"turnsDB": ` + strconv.Quote(filepath.Join(t.TempDir(), "turns.db")) + `
+		}`),
+		AddCloser: func(fn func(context.Context) error) error {
+			closers = append(closers, fn)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewModuleFactory: %v", err)
+	}
+	if len(closers) != 1 {
+		t.Fatalf("closers = %d, want 1", len(closers))
+	}
+	if err := closers[0](context.Background()); err != nil {
+		t.Fatalf("closer: %v", err)
+	}
+}
+
 func TestSQLiteTurnStorePersistsAndReadsTurns(t *testing.T) {
 	store, err := openSQLiteTurnStore("", filepath.Join(t.TempDir(), "turns.db"))
 	if err != nil {

--- a/pkg/js/modules/geppetto/provider/sqlite_turn_store.go
+++ b/pkg/js/modules/geppetto/provider/sqlite_turn_store.go
@@ -1,0 +1,251 @@
+package provider
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	geppettomodule "github.com/go-go-golems/geppetto/pkg/js/modules/geppetto"
+	"github.com/go-go-golems/geppetto/pkg/turns"
+	"github.com/go-go-golems/geppetto/pkg/turns/serde"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+const sqliteTurnStoreSchema = `
+CREATE TABLE IF NOT EXISTS geppetto_turns (
+	conv_id TEXT NOT NULL,
+	session_id TEXT NOT NULL,
+	turn_id TEXT NOT NULL,
+	phase TEXT NOT NULL,
+	runtime_key TEXT NOT NULL DEFAULT '',
+	inference_id TEXT NOT NULL DEFAULT '',
+	created_at_ms INTEGER NOT NULL,
+	payload TEXT NOT NULL,
+	PRIMARY KEY (conv_id, session_id, turn_id, phase)
+);
+CREATE INDEX IF NOT EXISTS geppetto_turns_by_session ON geppetto_turns(session_id, phase, created_at_ms DESC);
+CREATE INDEX IF NOT EXISTS geppetto_turns_by_conv ON geppetto_turns(conv_id, phase, created_at_ms DESC);
+`
+
+type sqliteTurnStore struct {
+	db *sql.DB
+}
+
+var _ geppettomodule.TurnStore = (*sqliteTurnStore)(nil)
+
+func openSQLiteTurnStore(turnsDSN, turnsDB string) (*sqliteTurnStore, error) {
+	dsn := strings.TrimSpace(turnsDSN)
+	if dsn == "" {
+		path := strings.TrimSpace(turnsDB)
+		if path == "" {
+			return nil, nil
+		}
+		if dir := filepath.Dir(path); dir != "" && dir != "." {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				return nil, fmt.Errorf("geppetto provider create turns db dir: %w", err)
+			}
+		}
+		dsn = sqliteTurnStoreDSNForFile(path)
+	}
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("geppetto provider open turns sqlite: %w", err)
+	}
+	store := &sqliteTurnStore{db: db}
+	if err := store.migrate(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return store, nil
+}
+
+func sqliteTurnStoreDSNForFile(path string) string {
+	return fmt.Sprintf("file:%s?_busy_timeout=5000&_journal_mode=WAL", path)
+}
+
+func (s *sqliteTurnStore) migrate() error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("geppetto provider turns sqlite store is nil")
+	}
+	if _, err := s.db.Exec(sqliteTurnStoreSchema); err != nil {
+		return fmt.Errorf("geppetto provider migrate turns sqlite: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteTurnStore) PersistTurn(ctx context.Context, t *turns.Turn) error {
+	if s == nil || s.db == nil || t == nil {
+		return nil
+	}
+	sessionID := turnSessionID(t)
+	if sessionID == "" {
+		return fmt.Errorf("geppetto provider turns sqlite store: sessionID is empty")
+	}
+	turnID := strings.TrimSpace(t.ID)
+	if turnID == "" {
+		turnID = "turn"
+	}
+	payload, err := serde.ToYAML(t, serde.Options{})
+	if err != nil {
+		return fmt.Errorf("geppetto provider turns sqlite store serialize turn: %w", err)
+	}
+	createdAtMs := time.Now().UnixMilli()
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO geppetto_turns (conv_id, session_id, turn_id, phase, runtime_key, inference_id, created_at_ms, payload)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(conv_id, session_id, turn_id, phase) DO UPDATE SET
+	runtime_key=excluded.runtime_key,
+	inference_id=excluded.inference_id,
+	created_at_ms=excluded.created_at_ms,
+	payload=excluded.payload
+`, sessionID, sessionID, turnID, "final", turnRuntimeKey(t), turnInferenceID(t), createdAtMs, string(payload))
+	if err != nil {
+		return fmt.Errorf("geppetto provider turns sqlite store persist turn: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteTurnStore) ListTurns(ctx context.Context, q geppettomodule.TurnStoreQuery) ([]geppettomodule.TurnStoreSnapshot, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("geppetto provider turns sqlite store is nil")
+	}
+	where := []string{"1=1"}
+	args := []any{}
+	if convID := strings.TrimSpace(q.ConvID); convID != "" {
+		where = append(where, "conv_id = ?")
+		args = append(args, convID)
+	}
+	if sessionID := strings.TrimSpace(q.SessionID); sessionID != "" {
+		where = append(where, "session_id = ?")
+		args = append(args, sessionID)
+	}
+	if phase := strings.TrimSpace(q.Phase); phase != "" {
+		where = append(where, "phase = ?")
+		args = append(args, phase)
+	}
+	if q.SinceMs > 0 {
+		where = append(where, "created_at_ms >= ?")
+		args = append(args, q.SinceMs)
+	}
+	limit := q.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	args = append(args, limit)
+	rows, err := s.db.QueryContext(ctx, `
+SELECT conv_id, session_id, turn_id, phase, runtime_key, inference_id, created_at_ms, payload
+FROM geppetto_turns
+WHERE `+strings.Join(where, " AND ")+`
+ORDER BY created_at_ms DESC
+LIMIT ?`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("geppetto provider turns sqlite store list turns: %w", err)
+	}
+	defer rows.Close()
+	out := []geppettomodule.TurnStoreSnapshot{}
+	for rows.Next() {
+		snapshot, err := scanTurnSnapshot(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, snapshot)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *sqliteTurnStore) LoadLatestTurn(ctx context.Context, q geppettomodule.TurnStoreQuery) (*geppettomodule.TurnStoreSnapshot, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("geppetto provider turns sqlite store is nil")
+	}
+	convID := strings.TrimSpace(q.ConvID)
+	if convID == "" {
+		convID = strings.TrimSpace(q.SessionID)
+	}
+	if convID == "" {
+		return nil, fmt.Errorf("geppetto provider turns sqlite store: convId or sessionId required")
+	}
+	phase := strings.TrimSpace(q.Phase)
+	if phase == "" {
+		phase = "final"
+	}
+	row := s.db.QueryRowContext(ctx, `
+SELECT conv_id, session_id, turn_id, phase, runtime_key, inference_id, created_at_ms, payload
+FROM geppetto_turns
+WHERE conv_id = ? AND phase = ?
+ORDER BY created_at_ms DESC
+LIMIT 1`, convID, phase)
+	snapshot, err := scanTurnSnapshot(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &snapshot, nil
+}
+
+func (s *sqliteTurnStore) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanTurnSnapshot(row rowScanner) (geppettomodule.TurnStoreSnapshot, error) {
+	var snapshot geppettomodule.TurnStoreSnapshot
+	var payload string
+	if err := row.Scan(&snapshot.ConvID, &snapshot.SessionID, &snapshot.TurnID, &snapshot.Phase, &snapshot.RuntimeKey, &snapshot.InferenceID, &snapshot.CreatedAtMs, &payload); err != nil {
+		return geppettomodule.TurnStoreSnapshot{}, err
+	}
+	if strings.TrimSpace(payload) != "" {
+		decoded, err := serde.FromYAML([]byte(payload))
+		if err != nil {
+			return geppettomodule.TurnStoreSnapshot{}, fmt.Errorf("geppetto provider turns sqlite store decode turn: %w", err)
+		}
+		snapshot.Turn = decoded
+	}
+	return snapshot, nil
+}
+
+func turnSessionID(t *turns.Turn) string {
+	if t == nil {
+		return ""
+	}
+	if v, ok, err := turns.KeyTurnMetaSessionID.Get(t.Metadata); err == nil && ok {
+		return strings.TrimSpace(v)
+	}
+	return ""
+}
+
+func turnRuntimeKey(t *turns.Turn) string {
+	if t == nil {
+		return ""
+	}
+	if v, ok, err := turns.KeyTurnMetaRuntime.Get(t.Metadata); err == nil && ok {
+		if s, ok := v.(string); ok {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
+}
+
+func turnInferenceID(t *turns.Turn) string {
+	if t == nil {
+		return ""
+	}
+	if v, ok, err := turns.KeyTurnMetaInferenceID.Get(t.Metadata); err == nil && ok {
+		return strings.TrimSpace(v)
+	}
+	return ""
+}

--- a/pkg/js/modules/geppetto/provider/sqlite_turn_store.go
+++ b/pkg/js/modules/geppetto/provider/sqlite_turn_store.go
@@ -113,35 +113,23 @@ func (s *sqliteTurnStore) ListTurns(ctx context.Context, q geppettomodule.TurnSt
 	if s == nil || s.db == nil {
 		return nil, fmt.Errorf("geppetto provider turns sqlite store is nil")
 	}
-	where := []string{"1=1"}
-	args := []any{}
-	if convID := strings.TrimSpace(q.ConvID); convID != "" {
-		where = append(where, "conv_id = ?")
-		args = append(args, convID)
-	}
-	if sessionID := strings.TrimSpace(q.SessionID); sessionID != "" {
-		where = append(where, "session_id = ?")
-		args = append(args, sessionID)
-	}
-	if phase := strings.TrimSpace(q.Phase); phase != "" {
-		where = append(where, "phase = ?")
-		args = append(args, phase)
-	}
-	if q.SinceMs > 0 {
-		where = append(where, "created_at_ms >= ?")
-		args = append(args, q.SinceMs)
-	}
+	convID := strings.TrimSpace(q.ConvID)
+	sessionID := strings.TrimSpace(q.SessionID)
+	phase := strings.TrimSpace(q.Phase)
+	sinceMs := q.SinceMs
 	limit := q.Limit
 	if limit <= 0 {
 		limit = 100
 	}
-	args = append(args, limit)
 	rows, err := s.db.QueryContext(ctx, `
 SELECT conv_id, session_id, turn_id, phase, runtime_key, inference_id, created_at_ms, payload
 FROM geppetto_turns
-WHERE `+strings.Join(where, " AND ")+`
+WHERE (? = '' OR conv_id = ?)
+  AND (? = '' OR session_id = ?)
+  AND (? = '' OR phase = ?)
+  AND (? <= 0 OR created_at_ms >= ?)
 ORDER BY created_at_ms DESC
-LIMIT ?`, args...)
+LIMIT ?`, convID, convID, sessionID, sessionID, phase, phase, sinceMs, sinceMs, limit)
 	if err != nil {
 		return nil, fmt.Errorf("geppetto provider turns sqlite store list turns: %w", err)
 	}

--- a/pkg/js/modules/geppetto/provider/sqlite_turn_store.go
+++ b/pkg/js/modules/geppetto/provider/sqlite_turn_store.go
@@ -145,7 +145,7 @@ LIMIT ?`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("geppetto provider turns sqlite store list turns: %w", err)
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	out := []geppettomodule.TurnStoreSnapshot{}
 	for rows.Next() {
 		snapshot, err := scanTurnSnapshot(rows)

--- a/pkg/js/modules/geppetto/provider/sqlite_turn_store.go
+++ b/pkg/js/modules/geppetto/provider/sqlite_turn_store.go
@@ -153,10 +153,8 @@ func (s *sqliteTurnStore) LoadLatestTurn(ctx context.Context, q geppettomodule.T
 		return nil, fmt.Errorf("geppetto provider turns sqlite store is nil")
 	}
 	convID := strings.TrimSpace(q.ConvID)
-	if convID == "" {
-		convID = strings.TrimSpace(q.SessionID)
-	}
-	if convID == "" {
+	sessionID := strings.TrimSpace(q.SessionID)
+	if convID == "" && sessionID == "" {
 		return nil, fmt.Errorf("geppetto provider turns sqlite store: convId or sessionId required")
 	}
 	phase := strings.TrimSpace(q.Phase)
@@ -166,9 +164,11 @@ func (s *sqliteTurnStore) LoadLatestTurn(ctx context.Context, q geppettomodule.T
 	row := s.db.QueryRowContext(ctx, `
 SELECT conv_id, session_id, turn_id, phase, runtime_key, inference_id, created_at_ms, payload
 FROM geppetto_turns
-WHERE conv_id = ? AND phase = ?
+WHERE (? = '' OR conv_id = ?)
+  AND (? = '' OR session_id = ?)
+  AND phase = ?
 ORDER BY created_at_ms DESC
-LIMIT 1`, convID, phase)
+LIMIT 1`, convID, convID, sessionID, sessionID, phase)
 	snapshot, err := scanTurnSnapshot(row)
 	if err == sql.ErrNoRows {
 		return nil, nil

--- a/pkg/js/runtime/runtime.go
+++ b/pkg/js/runtime/runtime.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/dop251/goja_nodejs/require"
 	gp "github.com/go-go-golems/geppetto/pkg/js/modules/geppetto"
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 	"github.com/go-go-golems/go-go-goja/pkg/jsevents"
 	"github.com/rs/zerolog"
 	zlog "github.com/rs/zerolog/log"
@@ -36,7 +36,7 @@ type geppettoModuleSpec struct {
 
 func (s geppettoModuleSpec) ID() string { return "geppetto" }
 
-func (s geppettoModuleSpec) RegisterRuntimeModule(ctx *gojengine.RuntimeModuleContext, reg *require.Registry) error {
+func (s geppettoModuleSpec) RegisterRuntimeModule(ctx *gojengine.RuntimeModuleRegistrationContext, reg *require.Registry) error {
 	if ctx == nil {
 		return fmt.Errorf("runtime module context is nil")
 	}
@@ -66,7 +66,7 @@ func NewRuntime(ctx context.Context, opts Options) (*gojengine.Runtime, error) {
 	if len(opts.RequireOptions) > 0 {
 		builderOpts = append(builderOpts, gojengine.WithRequireOptions(opts.RequireOptions...))
 	}
-	builder := gojengine.NewBuilder(builderOpts...).WithModules(geppettoModuleSpec{opts: opts.ModuleOptions})
+	builder := gojengine.NewRuntimeFactoryBuilder(builderOpts...).WithModules(geppettoModuleSpec{opts: opts.ModuleOptions})
 	if opts.IncludeDefaultModules {
 		builder = builder.UseModuleMiddleware(gojengine.Pipeline())
 	}

--- a/pkg/js/runtime/runtime_test.go
+++ b/pkg/js/runtime/runtime_test.go
@@ -10,19 +10,19 @@ import (
 
 	"github.com/dop251/goja"
 	gp "github.com/go-go-golems/geppetto/pkg/js/modules/geppetto"
-	gojengine "github.com/go-go-golems/go-go-goja/engine"
+	gojengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 	"github.com/go-go-golems/go-go-goja/pkg/jsevents"
 	"github.com/rs/zerolog"
 )
 
 type runtimeInitFunc struct {
 	id string
-	fn func(ctx *gojengine.RuntimeContext) error
+	fn func(ctx *gojengine.RuntimeInitializationContext) error
 }
 
 func (f runtimeInitFunc) ID() string { return f.id }
 
-func (f runtimeInitFunc) InitRuntime(ctx *gojengine.RuntimeContext) error {
+func (f runtimeInitFunc) InitRuntime(ctx *gojengine.RuntimeInitializationContext) error {
 	if f.fn == nil {
 		return nil
 	}
@@ -95,7 +95,7 @@ func TestNewRuntime_SkipsNilRuntimeInitializers(t *testing.T) {
 			nil,
 			runtimeInitFunc{
 				id: "real-init",
-				fn: func(ctx *gojengine.RuntimeContext) error {
+				fn: func(ctx *gojengine.RuntimeInitializationContext) error {
 					initCalls.Add(1)
 					return ctx.VM.Set("runtimeInitWorked", true)
 				},
@@ -182,7 +182,7 @@ func TestNewRuntime_RegistersGeppettoAndCustomBindings(t *testing.T) {
 		RuntimeInitializers: []gojengine.RuntimeInitializer{
 			runtimeInitFunc{
 				id: "pinocchio-like-bindings",
-				fn: func(ctx *gojengine.RuntimeContext) error {
+				fn: func(ctx *gojengine.RuntimeInitializationContext) error {
 					return ctx.VM.Set("registerSemReducer", func(call goja.FunctionCall) goja.Value {
 						reducerCalls.Add(1)
 						return goja.Undefined()


### PR DESCRIPTION
This PR introduces a significant refactoring of the Geppetto provider for `go-go-
goja`. The changes improve modularity, simplify configuration, and integrate with
the Glazed configuration system.

Key changes include:

- **Host Service Contributions**: A new mechanism allows host applications to
  contribute Geppetto options like tool registries, middleware factories, and
  event sinks. This replaces the previous rigid `HostServices` interface, making
  the provider more extensible. An example package demonstrating this pattern has
  been added.

- **Glazed Integration**: The provider now implements the `GlazedConfigSections`
  capability. This allows its configuration (e.g., profile registries, turn
  store path) to be exposed as standard command-line flags in applications
  built with the Glazed framework.

- **Built-in SQLite Turn Store**: A new, self-contained SQLite implementation
  for the turn store is included. This simplifies persistence setup, which can
  now be enabled directly via configuration (`turnsDB` or `turnsDSN`) without
  requiring the host to provide a custom implementation.

- **Configuration Cleanup**: The provider's configuration has been streamlined.
  Legacy fields such as `allowRegistryLoad`, `enableStorage`, and the nested
  `turns` object have been removed in favor of the new, more direct
  configuration model.

- **Dependency Update**: The `go-go-goja` dependency has been updated to v0.8.0,
  and the codebase has been adapted to its new APIs.