### PR TITLE
Feat(geppetto): Set runtime owner from module context

### DIFF
--- a/pkg/js/modules/geppetto/provider/provider.go
+++ b/pkg/js/modules/geppetto/provider/provider.go
@@ -60,12 +60,16 @@ func Register(registry *providerapi.ProviderRegistry) error {
 				if err != nil {
 					return nil, fmt.Errorf("geppetto provider config: %w", err)
 				}
+
 				opts := geppettomodule.Options{}
 				if host, ok := ctx.Host.(HostServices); ok && host != nil {
 					opts, err = host.GeppettoOptions(ctx.Context, cfg)
 					if err != nil {
 						return nil, fmt.Errorf("geppetto provider host options: %w", err)
 					}
+				}
+				if opts.RuntimeOwner == nil {
+					opts.RuntimeOwner = ctx.RuntimeOwner
 				}
 				if err := applyHostOptionsContributions(ctx.Context, ctx.Host, cfg, &opts); err != nil {
 					return nil, err

--- a/pkg/js/modules/geppetto/provider/provider_test.go
+++ b/pkg/js/modules/geppetto/provider/provider_test.go
@@ -52,7 +52,10 @@ func TestRegisterProvider(t *testing.T) {
 
 func TestProviderWorksWithoutHostServices(t *testing.T) {
 	mod := resolveModule(t)
-	loader, err := mod.NewModuleFactory(providerapi.ModuleSetupContext{})
+	loader, err := mod.NewModuleFactory(providerapi.ModuleSetupContext{
+		Name: geppettomodule.ModuleName,
+		As:   geppettomodule.ModuleName,
+	})
 	if err != nil {
 		t.Fatalf("expected provider to work without host services: %v", err)
 	}


### PR DESCRIPTION
- The `geppetto` provider now uses the `RuntimeOwner` from the
  `ModuleSetupContext` as a fallback if one is not already provided by the
  host services.