### PR TITLE
Feat: Add embeddings JS API

### DIFF
--- a/examples/js/geppetto/hardcut/06_embeddings_with_registry_profile.js
+++ b/examples/js/geppetto/hardcut/06_embeddings_with_registry_profile.js
@@ -1,6 +1,16 @@
 const gp = require("geppetto");
-if (typeof gp.embeddings !== "function") {
-  console.log(JSON.stringify({ skipped: true, reason: "gp.embeddings hard-cut wrapper is not implemented yet" }, null, 2));
-} else {
-  throw new Error("Update this example once gp.embeddings() is implemented.");
+
+const settings = gp.inferenceProfiles
+  .load(globalThis.GEPPETTO_PHASE123_PROFILE)
+  .resolve("assistant");
+const embedder = gp.embeddings(settings);
+const model = embedder.model();
+
+if (model.name !== "text-embedding-3-small") {
+  throw new Error(`unexpected embedding model name: ${model.name}`);
 }
+if (model.dimensions !== 4) {
+  throw new Error(`unexpected embedding dimensions: ${model.dimensions}`);
+}
+
+JSON.stringify({ ok: true, model }, null, 2);

--- a/examples/js/geppetto/profiles/50-hardcut-phase123.yaml
+++ b/examples/js/geppetto/profiles/50-hardcut-phase123.yaml
@@ -12,6 +12,10 @@ profiles:
         engine: gpt-4o-mini
         temperature: 0.2
         max_response_tokens: 128
+      embeddings:
+        type: openai
+        engine: text-embedding-3-small
+        dimensions: 4
       model_info:
         id: gpt-4o-mini
         name: GPT-4o Mini

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/dop251/goja_nodejs v0.0.0-20250409162600-f7acab6894b0
 	github.com/go-go-golems/glazed v1.3.6
 	github.com/go-go-golems/go-emrichen v0.0.11
-	github.com/go-go-golems/go-go-goja v0.8.0
+	github.com/go-go-golems/go-go-goja v0.8.3
 	github.com/go-go-golems/logcopter v0.1.0
 	github.com/go-go-golems/sanitize v0.0.2
 	github.com/google/generative-ai-go v0.20.1
@@ -101,6 +101,7 @@ require (
 	github.com/tiendc/go-deepcopy v1.7.1 // indirect
 	github.com/tree-sitter-grammars/tree-sitter-yaml v0.7.2 // indirect
 	github.com/tree-sitter/go-tree-sitter v0.25.0 // indirect
+	github.com/tree-sitter/tree-sitter-javascript v0.25.0 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/xuri/efp v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/go-go-golems/glazed v1.3.6 h1:33jWLP0nE9cDapB8oG/Z6UeqdNszI/OB3OogkhA
 github.com/go-go-golems/glazed v1.3.6/go.mod h1:Q+GuLpSK6OHfDJBbrA4RFOkpYPw++2jj5FAquem8w8g=
 github.com/go-go-golems/go-emrichen v0.0.11 h1:LIN/5OrzczpNCTAGOEg6epPELgyVYV+2IJ01qilldag=
 github.com/go-go-golems/go-emrichen v0.0.11/go.mod h1:nBIzXZwbOD7l3UKmRnofLh09BPbqKRPaxM0BLpOso0g=
-github.com/go-go-golems/go-go-goja v0.8.0 h1:Cm93aODLyCe8RWC04vjYZKfDDsqJqeRMMIH2P4U/Muk=
-github.com/go-go-golems/go-go-goja v0.8.0/go.mod h1:nBJcgJrQ660gf88vyffcAKpBgXghGMn8KSMuErRt2jg=
+github.com/go-go-golems/go-go-goja v0.8.3 h1:VRx5WzDau2TO+14anbC5QUJu0oCI/hHaxXBSrZlcRxU=
+github.com/go-go-golems/go-go-goja v0.8.3/go.mod h1:nBJcgJrQ660gf88vyffcAKpBgXghGMn8KSMuErRt2jg=
 github.com/go-go-golems/logcopter v0.1.0 h1:CGBxAGudhoQOncJ6GEWDJ6c1g5LrU59/ewGlPFKBmdk=
 github.com/go-go-golems/logcopter v0.1.0/go.mod h1:HNCeqsUqxu+Jm5h05YlbN5+KFtK84D5ZnOimvVLyWH4=
 github.com/go-go-golems/sanitize v0.0.2 h1:a1wImzNrhRMyY/1ujqkc7JD2OwdwMxGkMeY4EXwWD/M=

--- a/pkg/doc/types/geppetto.d.ts
+++ b/pkg/doc/types/geppetto.d.ts
@@ -119,6 +119,19 @@ declare module "geppetto" {
 
     export function engine(): EngineBuilder;
 
+    export interface EmbeddingModel {
+        name: string;
+        dimensions: number;
+    }
+
+    export interface EmbeddingsProvider {
+        embed(text: string): number[];
+        embedBatch(texts: string[]): number[][];
+        model(): EmbeddingModel;
+    }
+
+    export function embeddings(settings: InferenceSettings): EmbeddingsProvider;
+
     export interface MessageBuilder {
         text(text: string): MessageBuilder;
         imageURL(url: string, options?: Record<string, any>): MessageBuilder;

--- a/pkg/embeddings/settings_factory.go
+++ b/pkg/embeddings/settings_factory.go
@@ -223,11 +223,22 @@ func NewSettingsFactoryFromInferenceSettings(s *settings.InferenceSettings) *Set
 	}
 
 	if s.API != nil {
-		// Copy relevant API keys and base URLs
+		// Copy top-level API keys and base URLs as defaults.
 		for apiType, key := range s.API.APIKeys {
 			config.APIKeys[apiType] = key
 		}
 		for apiType, url := range s.API.BaseUrls {
+			config.BaseURLs[apiType] = url
+		}
+	}
+
+	if s.Embeddings != nil {
+		// Embedding-local credentials and endpoints are more specific than the
+		// top-level API maps and should win when both are present.
+		for apiType, key := range s.Embeddings.APIKeys {
+			config.APIKeys[apiType] = key
+		}
+		for apiType, url := range s.Embeddings.BaseURLs {
 			config.BaseURLs[apiType] = url
 		}
 	}

--- a/pkg/embeddings/settings_factory_test.go
+++ b/pkg/embeddings/settings_factory_test.go
@@ -1,0 +1,74 @@
+package embeddings
+
+import (
+	"testing"
+
+	"github.com/go-go-golems/geppetto/pkg/embeddings/config"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
+)
+
+func TestNewSettingsFactoryFromInferenceSettingsCopiesEmbeddingLocalAPIMaps(t *testing.T) {
+	in := &settings.InferenceSettings{
+		API: &settings.APISettings{
+			APIKeys:  map[string]string{"openai-api-key": "top-level-key"},
+			BaseUrls: map[string]string{"ollama-base-url": "http://top-level.example:11434"},
+		},
+		Embeddings: &config.EmbeddingsConfig{
+			Type:       "openai",
+			Engine:     "text-embedding-3-small",
+			Dimensions: 1536,
+			APIKeys:    map[string]string{"openai-api-key": "embedding-key"},
+			BaseURLs:   map[string]string{"ollama-base-url": "http://embedding.example:11434"},
+		},
+	}
+
+	factory := NewSettingsFactoryFromInferenceSettings(in)
+	if factory.config.APIKeys["openai-api-key"] != "embedding-key" {
+		t.Fatalf("openai api key = %q, want embedding-local key", factory.config.APIKeys["openai-api-key"])
+	}
+	if factory.config.BaseURLs["ollama-base-url"] != "http://embedding.example:11434" {
+		t.Fatalf("ollama base url = %q, want embedding-local URL", factory.config.BaseURLs["ollama-base-url"])
+	}
+}
+
+func TestNewSettingsFactoryFromInferenceSettingsOpenAIUsesEmbeddingLocalAPIKey(t *testing.T) {
+	in := &settings.InferenceSettings{
+		Embeddings: &config.EmbeddingsConfig{
+			Type:       "openai",
+			Engine:     "text-embedding-3-small",
+			Dimensions: 1536,
+			APIKeys:    map[string]string{"openai-api-key": "embedding-key"},
+		},
+	}
+
+	provider, err := NewSettingsFactoryFromInferenceSettings(in).NewProvider()
+	if err != nil {
+		t.Fatalf("NewProvider returned error: %v", err)
+	}
+	if _, ok := provider.(*OpenAIProvider); !ok {
+		t.Fatalf("provider = %T, want *OpenAIProvider", provider)
+	}
+}
+
+func TestNewSettingsFactoryFromInferenceSettingsOllamaUsesEmbeddingLocalBaseURL(t *testing.T) {
+	in := &settings.InferenceSettings{
+		Embeddings: &config.EmbeddingsConfig{
+			Type:       "ollama",
+			Engine:     "nomic-embed-text",
+			Dimensions: 768,
+			BaseURLs:   map[string]string{"ollama-base-url": "http://embedding.example:11434"},
+		},
+	}
+
+	provider, err := NewSettingsFactoryFromInferenceSettings(in).NewProvider()
+	if err != nil {
+		t.Fatalf("NewProvider returned error: %v", err)
+	}
+	ollamaProvider, ok := provider.(*OllamaProvider)
+	if !ok {
+		t.Fatalf("provider = %T, want *OllamaProvider", provider)
+	}
+	if ollamaProvider.baseURL != "http://embedding.example:11434" {
+		t.Fatalf("baseURL = %q, want embedding-local URL", ollamaProvider.baseURL)
+	}
+}

--- a/pkg/embeddings/settings_validation.go
+++ b/pkg/embeddings/settings_validation.go
@@ -37,8 +37,8 @@ func ValidateInferenceSettingsForEmbeddings(s *settings.InferenceSettings) error
 
 	switch providerType {
 	case openAIEmbeddingProvider:
-		if s.API == nil || strings.TrimSpace(s.API.APIKeys["openai-api-key"]) == "" {
-			return fmt.Errorf("selected OpenAI embedding profile has no openai-api-key; stack an OpenAI base profile or set inference_settings.api.api_keys.openai-api-key")
+		if strings.TrimSpace(openAIEmbeddingAPIKey(s)) == "" {
+			return fmt.Errorf("selected OpenAI embedding profile has no openai-api-key; stack an OpenAI base profile or set inference_settings.api.api_keys.openai-api-key or inference_settings.embeddings.api_keys.openai-api-key")
 		}
 	case ollamaEmbeddingProvider:
 		if s.Embeddings.Dimensions == 0 {
@@ -49,4 +49,19 @@ func ValidateInferenceSettingsForEmbeddings(s *settings.InferenceSettings) error
 	}
 
 	return nil
+}
+
+func openAIEmbeddingAPIKey(s *settings.InferenceSettings) string {
+	if s == nil {
+		return ""
+	}
+	if s.Embeddings != nil {
+		if key := s.Embeddings.APIKeys["openai-api-key"]; strings.TrimSpace(key) != "" {
+			return key
+		}
+	}
+	if s.API != nil {
+		return s.API.APIKeys["openai-api-key"]
+	}
+	return ""
 }

--- a/pkg/embeddings/settings_validation_test.go
+++ b/pkg/embeddings/settings_validation_test.go
@@ -68,6 +68,17 @@ func TestValidateInferenceSettingsForEmbeddings(t *testing.T) {
 			},
 		},
 		{
+			name: "openai complete with embedding-local key",
+			in: &settings.InferenceSettings{
+				Embeddings: &config.EmbeddingsConfig{
+					Type:       "openai",
+					Engine:     "text-embedding-3-small",
+					Dimensions: 1536,
+					APIKeys:    map[string]string{"openai-api-key": "test-key"},
+				},
+			},
+		},
+		{
 			name: "ollama complete",
 			in: &settings.InferenceSettings{
 				Embeddings: &config.EmbeddingsConfig{Type: "ollama", Engine: "nomic-embed-text", Dimensions: 768},

--- a/pkg/js/modules/geppetto/api_embeddings.go
+++ b/pkg/js/modules/geppetto/api_embeddings.go
@@ -1,0 +1,68 @@
+package geppetto
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dop251/goja"
+	"github.com/go-go-golems/geppetto/pkg/embeddings"
+)
+
+type embeddingsRef struct {
+	api      *moduleRuntime
+	provider embeddings.Provider
+}
+
+func (m *moduleRuntime) embeddingsBuilder(call goja.FunctionCall) goja.Value {
+	if len(call.Arguments) < 1 || goja.IsUndefined(call.Arguments[0]) || goja.IsNull(call.Arguments[0]) {
+		panic(m.vm.NewTypeError("embeddings(settings) requires a registry-resolved InferenceSettings wrapper"))
+	}
+	settingsRef, err := m.requireInferenceSettingsRef(call.Arguments[0])
+	if err != nil {
+		panic(m.vm.NewGoError(err))
+	}
+	if settingsRef.settings == nil {
+		panic(m.vm.NewGoError(fmt.Errorf("embeddings(settings) requires non-empty inference settings")))
+	}
+	provider, err := embeddings.NewSettingsFactoryFromInferenceSettings(settingsRef.settings).NewProvider()
+	if err != nil {
+		panic(m.vm.NewGoError(fmt.Errorf("embeddings(settings): %w", err)))
+	}
+	return m.newEmbeddingsObject(&embeddingsRef{api: m, provider: provider})
+}
+
+func (m *moduleRuntime) newEmbeddingsObject(ref *embeddingsRef) *goja.Object {
+	if ref == nil {
+		ref = &embeddingsRef{api: m}
+	}
+	ref.api = m
+	o := m.vm.NewObject()
+	m.attachRef(o, ref)
+	m.mustSet(o, "embed", func(text string) ([]float32, error) {
+		if ref.provider == nil {
+			return nil, fmt.Errorf("embeddings provider is not initialized")
+		}
+		return ref.provider.GenerateEmbedding(m.embeddingContext(), text)
+	})
+	m.mustSet(o, "embedBatch", func(texts []string) ([][]float32, error) {
+		if ref.provider == nil {
+			return nil, fmt.Errorf("embeddings provider is not initialized")
+		}
+		return ref.provider.GenerateBatchEmbeddings(m.embeddingContext(), texts)
+	})
+	m.mustSet(o, "model", func() map[string]any {
+		if ref.provider == nil {
+			return map[string]any{}
+		}
+		model := ref.provider.GetModel()
+		return map[string]any{"name": model.Name, "dimensions": model.Dimensions}
+	})
+	return o
+}
+
+func (m *moduleRuntime) embeddingContext() context.Context {
+	if m != nil && m.runtimeLifetimeContext != nil {
+		return m.runtimeLifetimeContext
+	}
+	return context.Background()
+}

--- a/pkg/js/modules/geppetto/api_embeddings_test.go
+++ b/pkg/js/modules/geppetto/api_embeddings_test.go
@@ -1,0 +1,47 @@
+package geppetto
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEmbeddingsBuilderFromRegistryProfileExposesModel(t *testing.T) {
+	profilePath := filepath.Join(t.TempDir(), "profiles.yaml")
+	if err := os.WriteFile(profilePath, []byte(`slug: embeddings-test
+profiles:
+  assistant:
+    inference_settings:
+      api:
+        api_keys:
+          openai-api-key: dummy-key
+      embeddings:
+        type: openai
+        engine: text-embedding-3-small
+        dimensions: 4
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile profiles.yaml: %v", err)
+	}
+	rt := newJSRuntime(t, Options{})
+	if err := rt.vm.Set("profilePath", profilePath); err != nil {
+		t.Fatalf("set profilePath: %v", err)
+	}
+	mustRunJS(t, rt, `
+		const gp = require("geppetto");
+		const settings = gp.inferenceProfiles.load(globalThis.profilePath).resolve("assistant");
+		const embedder = gp.embeddings(settings);
+		const model = embedder.model();
+		if (model.name !== "text-embedding-3-small") throw new Error("wrong model name: " + model.name);
+		if (model.dimensions !== 4) throw new Error("wrong model dims: " + model.dimensions);
+	`)
+}
+
+func TestEmbeddingsBuilderRejectsMissingSettings(t *testing.T) {
+	rt := newJSRuntime(t, Options{})
+	mustRunJS(t, rt, `
+		const gp = require("geppetto");
+		let ok = false;
+		try { gp.embeddings(); } catch (err) { ok = String(err).includes("requires"); }
+		if (!ok) throw new Error("expected embeddings() to reject missing settings");
+	`)
+}

--- a/pkg/js/modules/geppetto/api_embeddings_test.go
+++ b/pkg/js/modules/geppetto/api_embeddings_test.go
@@ -36,6 +36,35 @@ profiles:
 	`)
 }
 
+func TestEmbeddingsBuilderUsesEmbeddingLocalCredentials(t *testing.T) {
+	profilePath := filepath.Join(t.TempDir(), "profiles.yaml")
+	if err := os.WriteFile(profilePath, []byte(`slug: embeddings-local-credentials-test
+profiles:
+  assistant:
+    inference_settings:
+      embeddings:
+        type: openai
+        engine: text-embedding-3-small
+        dimensions: 4
+        api_keys:
+          openai-api-key: dummy-key
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile profiles.yaml: %v", err)
+	}
+	rt := newJSRuntime(t, Options{})
+	if err := rt.vm.Set("profilePath", profilePath); err != nil {
+		t.Fatalf("set profilePath: %v", err)
+	}
+	mustRunJS(t, rt, `
+		const gp = require("geppetto");
+		const settings = gp.inferenceProfiles.load(globalThis.profilePath).resolve("assistant");
+		const embedder = gp.embeddings(settings);
+		const model = embedder.model();
+		if (model.name !== "text-embedding-3-small") throw new Error("wrong model name: " + model.name);
+		if (model.dimensions !== 4) throw new Error("wrong model dims: " + model.dimensions);
+	`)
+}
+
 func TestEmbeddingsBuilderRejectsMissingSettings(t *testing.T) {
 	rt := newJSRuntime(t, Options{})
 	mustRunJS(t, rt, `

--- a/pkg/js/modules/geppetto/hardcut_contract_test.go
+++ b/pkg/js/modules/geppetto/hardcut_contract_test.go
@@ -39,6 +39,7 @@ func TestHardCutPublicSurfaceContract(t *testing.T) {
 			"inferenceProfiles",
 			"turnStores",
 			"engine",
+			"embeddings",
 			"tool",
 			"toolRegistry",
 			"schema",
@@ -61,7 +62,6 @@ func TestHardCutPublicSurfaceContract(t *testing.T) {
 			"schemas",
 			"middlewares",
 			"tools",
-			"embeddings",
 			"unsafe",
 			"events",
 		];

--- a/pkg/js/modules/geppetto/module.go
+++ b/pkg/js/modules/geppetto/module.go
@@ -182,6 +182,7 @@ func (m *moduleRuntime) installExports(exports *goja.Object) {
 	m.mustSet(inferenceProfilesObj, "default", m.inferenceProfilesDefault)
 	m.mustSet(exports, "inferenceProfiles", inferenceProfilesObj)
 	m.mustSet(exports, "engine", m.engineBuilder)
+	m.mustSet(exports, "embeddings", m.embeddingsBuilder)
 	m.mustSet(exports, "agent", m.agentBuilder)
 	m.installTurnStoresNamespace(exports)
 	m.mustSet(exports, "tool", m.toolBuilder)

--- a/pkg/js/modules/geppetto/module_hardcut_test.go
+++ b/pkg/js/modules/geppetto/module_hardcut_test.go
@@ -69,7 +69,7 @@ func TestHardCutPublicSurface(t *testing.T) {
 		const gp = require("geppetto");
 		function assert(cond, msg) { if (!cond) throw new Error(msg); }
 		function has(obj, key) { return Object.prototype.hasOwnProperty.call(obj, key); }
-		const required = ["version", "consts", "agent", "inferenceProfiles", "turnStores", "engine", "tool", "toolRegistry", "schema"];
+		const required = ["version", "consts", "agent", "inferenceProfiles", "turnStores", "engine", "embeddings", "tool", "toolRegistry", "schema"];
 		for (const key of required) assert(has(gp, key), "missing export: " + key);
 		const removed = ["chat", "inferenceSettings", "turn", "createBuilder", "createSession", "runInference", "profiles", "engines", "turns", "runner", "schemas", "middlewares", "tools", "events"];
 		for (const key of removed) assert(!has(gp, key), "legacy export should be absent: " + key);

--- a/pkg/js/modules/geppetto/spec/geppetto.d.ts.tmpl
+++ b/pkg/js/modules/geppetto/spec/geppetto.d.ts.tmpl
@@ -119,6 +119,19 @@ declare module "geppetto" {
 
     export function engine(): EngineBuilder;
 
+    export interface EmbeddingModel {
+        name: string;
+        dimensions: number;
+    }
+
+    export interface EmbeddingsProvider {
+        embed(text: string): number[];
+        embedBatch(texts: string[]): number[][];
+        model(): EmbeddingModel;
+    }
+
+    export function embeddings(settings: InferenceSettings): EmbeddingsProvider;
+
     export interface MessageBuilder {
         text(text: string): MessageBuilder;
         imageURL(url: string, options?: Record<string, any>): MessageBuilder;


### PR DESCRIPTION
This PR introduces a new `gp.embeddings()` function to the Geppetto JS module,
providing a straightforward way to generate text embeddings.

### Key Changes
- **New API:**
  - `gp.embeddings(settings)`: Creates an embedding provider instance from
    resolved `InferenceSettings`.
  - The returned provider object has the following methods:
    - `embed(text: string): number[]`: Generates an embedding for a single
      text.
    - `embedBatch(texts: string[]): number[][]`: Generates embeddings for
      multiple texts in a single call.
    - `model()`: Returns an object with the `name` and `dimensions` of the
      underlying embedding model.

- **Configuration:**
  - The embedding provider is configured via an `embeddings` section within an
    `inference_settings` block in a profile YAML file.

- **Supporting Changes:**
  - Implemented the Go backend for the new JS API.
  - Added comprehensive unit tests for the new functionality.
  - Updated TypeScript definitions (`geppetto.d.ts`) to include the new
    interfaces and functions.
  - Updated an example script to demonstrate the new API's usage.