### PR TITLE
Provider URL validation opt-in for local fake-provider testing

### DIFF
--- a/pkg/steps/ai/claude/api/completion.go
+++ b/pkg/steps/ai/claude/api/completion.go
@@ -50,10 +50,11 @@ type ErrorDetail struct {
 
 // Client represents the Claude API client.
 type Client struct {
-	httpClient *http.Client
-	apiKey     string
-	APIVersion string
-	BaseURL    string
+	httpClient         *http.Client
+	apiKey             string
+	APIVersion         string
+	BaseURL            string
+	outboundURLOptions security.OutboundURLOptions
 }
 
 const defaultAPIVersion = "2023-06-01"
@@ -79,6 +80,17 @@ func (c *Client) SetHTTPClient(httpClient *http.Client) {
 	c.httpClient = httpClient
 }
 
+func (c *Client) SetOutboundURLOptions(opts security.OutboundURLOptions) {
+	c.outboundURLOptions = opts
+}
+
+func (c *Client) outboundOptions() security.OutboundURLOptions {
+	if c == nil {
+		return security.OutboundURLOptions{}
+	}
+	return c.outboundURLOptions
+}
+
 // Helper function to set necessary headers
 func (c *Client) setHeaders(req *http.Request) {
 	req.Header.Set("x-api-key", c.apiKey)
@@ -88,9 +100,7 @@ func (c *Client) setHeaders(req *http.Request) {
 
 // Complete sends a completion request and returns the response.
 func (c *Client) Complete(req *Request) (*SuccessfulResponse, error) {
-	if err := security.ValidateOutboundURL(c.BaseURL, security.OutboundURLOptions{
-		AllowHTTP: false,
-	}); err != nil {
+	if err := security.ValidateOutboundURL(c.BaseURL, c.outboundOptions()); err != nil {
 		return nil, fmt.Errorf("invalid claude base URL: %w", err)
 	}
 
@@ -149,9 +159,7 @@ type Event struct {
 }
 
 func (c *Client) StreamComplete(req *Request) (<-chan Event, error) {
-	if err := security.ValidateOutboundURL(c.BaseURL, security.OutboundURLOptions{
-		AllowHTTP: false,
-	}); err != nil {
+	if err := security.ValidateOutboundURL(c.BaseURL, c.outboundOptions()); err != nil {
 		return nil, fmt.Errorf("invalid claude base URL: %w", err)
 	}
 

--- a/pkg/steps/ai/claude/api/messages.go
+++ b/pkg/steps/ai/claude/api/messages.go
@@ -168,9 +168,7 @@ func (u Usage) MarshalZerologObject(e *zerolog.Event) {
 // SendMessage sends a message request and returns the response.
 func (c *Client) SendMessage(ctx context.Context, req *MessageRequest) (*MessageResponse, error) {
 	url := strings.TrimSuffix(c.BaseURL, "/") + "/v1/messages"
-	if err := security.ValidateOutboundURL(url, security.OutboundURLOptions{
-		AllowHTTP: false,
-	}); err != nil {
+	if err := security.ValidateOutboundURL(url, c.outboundOptions()); err != nil {
 		return nil, fmt.Errorf("invalid claude messages URL: %w", err)
 	}
 
@@ -225,9 +223,7 @@ func (c *Client) StreamMessage(ctx context.Context, req *MessageRequest) (<-chan
 	}
 
 	url := strings.TrimSuffix(c.BaseURL, "/") + "/v1/messages"
-	if err := security.ValidateOutboundURL(url, security.OutboundURLOptions{
-		AllowHTTP: false,
-	}); err != nil {
+	if err := security.ValidateOutboundURL(url, c.outboundOptions()); err != nil {
 		return nil, fmt.Errorf("invalid claude messages URL: %w", err)
 	}
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(body))
@@ -283,9 +279,7 @@ func (c *Client) StreamMessage(ctx context.Context, req *MessageRequest) (<-chan
 
 func (c *Client) CountTokens(ctx context.Context, req *MessageCountTokensRequest) (*MessageCountTokensResponse, error) {
 	url := strings.TrimSuffix(c.BaseURL, "/") + "/v1/messages/count_tokens"
-	if err := security.ValidateOutboundURL(url, security.OutboundURLOptions{
-		AllowHTTP: false,
-	}); err != nil {
+	if err := security.ValidateOutboundURL(url, c.outboundOptions()); err != nil {
 		return nil, fmt.Errorf("invalid claude count tokens URL: %w", err)
 	}
 

--- a/pkg/steps/ai/claude/api/messages_test.go
+++ b/pkg/steps/ai/claude/api/messages_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+
+	"github.com/go-go-golems/geppetto/pkg/security"
 )
 
 const multipleContentTypesExpected = `{"role":"assistant","content":[{"type":"text","text":"Text"},{"type":"image","source":{"type":"base64","media_type":"image/jpeg","data":"base64data"}},{"type":"tool_use","id":"tool1","name":"calculator","input":{"operation":"add","numbers":[1,2]}}]}`
@@ -109,5 +111,25 @@ func TestMessageDeserialization(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestClientOutboundOptionsDefaultDeny(t *testing.T) {
+	client := NewClient("test-key", "http://127.0.0.1:9999")
+	err := security.ValidateOutboundURL(client.BaseURL, client.outboundOptions())
+	if err == nil {
+		t.Fatal("expected default outbound options to reject plain HTTP")
+	}
+}
+
+func TestClientOutboundOptionsCanAllowLocalHTTP(t *testing.T) {
+	client := NewClient("test-key", "http://127.0.0.1:9999")
+	client.SetOutboundURLOptions(security.OutboundURLOptions{
+		AllowHTTP:          true,
+		AllowLocalNetworks: true,
+	})
+
+	if err := security.ValidateOutboundURL(client.BaseURL, client.outboundOptions()); err != nil {
+		t.Fatalf("expected local HTTP to be allowed after opt-in: %v", err)
 	}
 }

--- a/pkg/steps/ai/claude/engine_claude.go
+++ b/pkg/steps/ai/claude/engine_claude.go
@@ -82,6 +82,7 @@ func (e *ClaudeEngine) RunInference(
 	}
 
 	client := api.NewClient(apiKey, baseURL)
+	client.SetOutboundURLOptions(settings.OutboundURLOptions(apiSettings, string(apiType)))
 	httpClient, err := settings.EnsureHTTPClient(clientSettings)
 	if err != nil {
 		return nil, err

--- a/pkg/steps/ai/claude/token_count.go
+++ b/pkg/steps/ai/claude/token_count.go
@@ -49,6 +49,7 @@ func (tc *TokenCounter) CountTurn(ctx context.Context, t *turns.Turn) (*tokencou
 	}
 
 	client := api.NewClient(apiKey, baseURL)
+	client.SetOutboundURLOptions(settings.OutboundURLOptions(tc.settings.API, "claude"))
 	if tc.settings.Client != nil && tc.settings.Client.HTTPClient != nil {
 		client.SetHTTPClient(tc.settings.Client.HTTPClient)
 	}

--- a/pkg/steps/ai/openai/chat_stream.go
+++ b/pkg/steps/ai/openai/chat_stream.go
@@ -65,9 +65,7 @@ func resolveChatStreamConfig(
 		return chatStreamConfig{}, errors.Errorf("no base URL for %s", apiType)
 	}
 	endpoint := strings.TrimRight(baseURL, "/") + "/chat/completions"
-	if err := security.ValidateOutboundURL(endpoint, security.OutboundURLOptions{
-		AllowHTTP: false,
-	}); err != nil {
+	if err := security.ValidateOutboundURL(endpoint, settings.OutboundURLOptions(apiSettings, string(apiType))); err != nil {
 		return chatStreamConfig{}, errors.Wrap(err, "invalid chat completion URL")
 	}
 	httpClient, err := settings.EnsureHTTPClient(clientSettings)

--- a/pkg/steps/ai/openai/chat_stream_test.go
+++ b/pkg/steps/ai/openai/chat_stream_test.go
@@ -6,6 +6,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
+	ai_types "github.com/go-go-golems/geppetto/pkg/steps/ai/types"
 )
 
 func TestOpenChatCompletionStream_404HintsWhenBaseURLLooksLikeChatEndpoint(t *testing.T) {
@@ -174,5 +177,35 @@ func TestNormalizeChatStreamEvent_NormalizesToolCalls(t *testing.T) {
 	}
 	if call.Function.Arguments != "{\"q\":\"cats\"}" {
 		t.Fatalf("unexpected tool call arguments: %q", call.Function.Arguments)
+	}
+}
+
+func TestResolveChatStreamConfigRejectsLocalHTTPByDefault(t *testing.T) {
+	apiSettings := settings.NewAPISettings()
+	apiSettings.APIKeys["openai-api-key"] = "test-key"
+	apiSettings.BaseUrls["openai-base-url"] = "http://127.0.0.1:9999/v1"
+
+	_, err := resolveChatStreamConfig(apiSettings, nil, ai_types.ApiTypeOpenAI)
+	if err == nil {
+		t.Fatal("expected local HTTP base URL to be rejected by default")
+	}
+	if !strings.Contains(err.Error(), "http scheme is not allowed") {
+		t.Fatalf("expected http rejection, got %v", err)
+	}
+}
+
+func TestResolveChatStreamConfigAllowsLocalHTTPWhenProfileOptsIn(t *testing.T) {
+	apiSettings := settings.NewAPISettings()
+	apiSettings.APIKeys["openai-api-key"] = "test-key"
+	apiSettings.BaseUrls["openai-base-url"] = "http://127.0.0.1:9999/v1"
+	apiSettings.AllowHTTP["openai"] = true
+	apiSettings.AllowLocalNetworks["openai"] = true
+
+	cfg, err := resolveChatStreamConfig(apiSettings, nil, ai_types.ApiTypeOpenAI)
+	if err != nil {
+		t.Fatalf("resolveChatStreamConfig: %v", err)
+	}
+	if got := cfg.endpoint; got != "http://127.0.0.1:9999/v1/chat/completions" {
+		t.Fatalf("endpoint = %q", got)
 	}
 }

--- a/pkg/steps/ai/openai_responses/engine.go
+++ b/pkg/steps/ai/openai_responses/engine.go
@@ -95,15 +95,14 @@ func (e *Engine) RunInference(ctx context.Context, t *turns.Turn) (*turns.Turn, 
 	if e.settings != nil && e.settings.API != nil {
 		apiKey = responsesAPIKey(e.settings.API)
 	}
-	url := responsesEndpoint(func() *settings.APISettings {
+	apiSettings := func() *settings.APISettings {
 		if e.settings == nil {
 			return nil
 		}
 		return e.settings.API
-	}(), "/responses")
-	if err := security.ValidateOutboundURL(url, security.OutboundURLOptions{
-		AllowHTTP: false,
-	}); err != nil {
+	}()
+	url := responsesEndpoint(apiSettings, "/responses")
+	if err := security.ValidateOutboundURL(url, responsesOutboundURLOptions(apiSettings)); err != nil {
 		return nil, errors.Wrap(err, "invalid responses URL")
 	}
 	httpClient, err := settings.EnsureHTTPClient(func() *settings.ClientSettings {

--- a/pkg/steps/ai/openai_responses/provider_settings.go
+++ b/pkg/steps/ai/openai_responses/provider_settings.go
@@ -3,6 +3,7 @@ package openai_responses
 import (
 	"strings"
 
+	"github.com/go-go-golems/geppetto/pkg/security"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/types"
 )
@@ -43,6 +44,15 @@ func responsesBaseURL(api *settings.APISettings) string {
 func responsesEndpoint(api *settings.APISettings, path string) string {
 	path = "/" + strings.TrimLeft(path, "/")
 	return strings.TrimRight(responsesBaseURL(api), "/") + path
+}
+
+func responsesOutboundURLOptions(api *settings.APISettings) security.OutboundURLOptions {
+	return settings.OutboundURLOptionsForKeys(
+		api,
+		string(types.ApiTypeOpenResponses),
+		string(types.ApiTypeOpenAIResponses),
+		string(types.ApiTypeOpenAI),
+	)
 }
 
 func responsesAPIType(s *settings.InferenceSettings) types.ApiType {

--- a/pkg/steps/ai/openai_responses/provider_settings_test.go
+++ b/pkg/steps/ai/openai_responses/provider_settings_test.go
@@ -103,3 +103,27 @@ func settingsWithAPIType(apiType string) *settings.InferenceSettings {
 	ret.Chat.ApiType = &v
 	return ret
 }
+
+func TestResponsesOutboundURLOptionsPrefersOpenResponsesAlias(t *testing.T) {
+	api := settings.NewAPISettings()
+	api.AllowHTTP["openai"] = false
+	api.AllowHTTP["open-responses"] = true
+	api.AllowLocalNetworks["openai"] = false
+	api.AllowLocalNetworks["open-responses"] = true
+
+	opts := responsesOutboundURLOptions(api)
+	if !opts.AllowHTTP || !opts.AllowLocalNetworks {
+		t.Fatalf("responses outbound options = %#v, want open-responses alias", opts)
+	}
+}
+
+func TestResponsesOutboundURLOptionsFallsBackToOpenAI(t *testing.T) {
+	api := settings.NewAPISettings()
+	api.AllowHTTP["openai"] = true
+	api.AllowLocalNetworks["openai"] = true
+
+	opts := responsesOutboundURLOptions(api)
+	if !opts.AllowHTTP || !opts.AllowLocalNetworks {
+		t.Fatalf("responses outbound options = %#v, want openai fallback", opts)
+	}
+}

--- a/pkg/steps/ai/openai_responses/token_count.go
+++ b/pkg/steps/ai/openai_responses/token_count.go
@@ -69,7 +69,7 @@ func (tc *TokenCounter) CountTurn(ctx context.Context, t *turns.Turn) (*tokencou
 	}
 
 	url := responsesEndpoint(tc.settings.API, "/responses/input_tokens")
-	if err := security.ValidateOutboundURL(url, security.OutboundURLOptions{AllowHTTP: false}); err != nil {
+	if err := security.ValidateOutboundURL(url, responsesOutboundURLOptions(tc.settings.API)); err != nil {
 		return nil, errors.Wrap(err, "invalid responses token count URL")
 	}
 

--- a/pkg/steps/ai/settings/outbound_url.go
+++ b/pkg/steps/ai/settings/outbound_url.go
@@ -1,0 +1,62 @@
+package settings
+
+import (
+	"strings"
+
+	"github.com/go-go-golems/geppetto/pkg/security"
+)
+
+// OutboundURLOptions returns provider URL validation options for a single API type.
+//
+// Defaults remain fail-closed: plain HTTP and local-network targets are rejected
+// unless the profile explicitly opts in under inference_settings.api.
+func OutboundURLOptions(api *APISettings, apiType string) security.OutboundURLOptions {
+	return OutboundURLOptionsForKeys(api, apiType)
+}
+
+// OutboundURLOptionsForKeys returns provider URL validation options using the
+// first matching provider key. It accepts several aliases because some provider
+// families (notably OpenAI Responses) support legacy and canonical API type
+// names while sharing one endpoint.
+//
+// The YAML shape is intentionally profile-owned and explicit:
+//
+//	api:
+//	  allow_http:
+//	    openai: true
+//	  allow_local_networks:
+//	    openai: true
+//
+// Suffix-style keys such as "openai-allow-http" are also accepted so CLI or
+// generated-map callers can use the same naming convention as api_keys and
+// base_urls.
+func OutboundURLOptionsForKeys(api *APISettings, apiTypes ...string) security.OutboundURLOptions {
+	if api == nil {
+		return security.OutboundURLOptions{}
+	}
+
+	return security.OutboundURLOptions{
+		AllowHTTP:          lookupOutboundBool(api.AllowHTTP, "allow-http", apiTypes...),
+		AllowLocalNetworks: lookupOutboundBool(api.AllowLocalNetworks, "allow-local-networks", apiTypes...),
+	}
+}
+
+func lookupOutboundBool(values map[string]bool, suffix string, apiTypes ...string) bool {
+	if len(values) == 0 {
+		return false
+	}
+
+	for _, apiType := range apiTypes {
+		apiType = strings.TrimSpace(apiType)
+		if apiType == "" {
+			continue
+		}
+		for _, key := range []string{apiType, apiType + "-" + suffix} {
+			if value, ok := values[key]; ok {
+				return value
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/steps/ai/settings/outbound_url_test.go
+++ b/pkg/steps/ai/settings/outbound_url_test.go
@@ -1,0 +1,73 @@
+package settings
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestOutboundURLOptionsDefaultDeny(t *testing.T) {
+	opts := OutboundURLOptions(NewAPISettings(), "openai")
+	if opts.AllowHTTP || opts.AllowLocalNetworks {
+		t.Fatalf("default outbound options = %#v, want deny", opts)
+	}
+}
+
+func TestOutboundURLOptionsUsesRawProviderKeys(t *testing.T) {
+	api := NewAPISettings()
+	api.AllowHTTP["openai"] = true
+	api.AllowLocalNetworks["openai"] = true
+
+	opts := OutboundURLOptions(api, "openai")
+	if !opts.AllowHTTP || !opts.AllowLocalNetworks {
+		t.Fatalf("outbound options = %#v, want both true", opts)
+	}
+}
+
+func TestOutboundURLOptionsUsesSuffixedProviderKeys(t *testing.T) {
+	api := NewAPISettings()
+	api.AllowHTTP["openai-allow-http"] = true
+	api.AllowLocalNetworks["openai-allow-local-networks"] = true
+
+	opts := OutboundURLOptions(api, "openai")
+	if !opts.AllowHTTP || !opts.AllowLocalNetworks {
+		t.Fatalf("outbound options = %#v, want both true", opts)
+	}
+}
+
+func TestInferenceSettingsUnmarshalOutboundURLOptions(t *testing.T) {
+	ss, err := NewInferenceSettings()
+	if err != nil {
+		t.Fatalf("NewInferenceSettings: %v", err)
+	}
+
+	input := `api:
+  allow_http:
+    openai: true
+  allow_local_networks:
+    openai: true
+chat:
+  api_type: openai
+  engine: gpt-4o-mini
+`
+	if err := yaml.NewDecoder(strings.NewReader(input)).Decode(ss); err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+
+	opts := OutboundURLOptions(ss.API, "openai")
+	if !opts.AllowHTTP || !opts.AllowLocalNetworks {
+		t.Fatalf("outbound options = %#v, want both true", opts)
+	}
+}
+
+func TestOutboundURLOptionsForKeysFallsBackAcrossAliases(t *testing.T) {
+	api := NewAPISettings()
+	api.AllowHTTP["openai"] = true
+	api.AllowLocalNetworks["openai"] = true
+
+	opts := OutboundURLOptionsForKeys(api, "open-responses", "openai-responses", "openai")
+	if !opts.AllowHTTP || !opts.AllowLocalNetworks {
+		t.Fatalf("outbound options = %#v, want fallback to openai", opts)
+	}
+}

--- a/pkg/steps/ai/settings/settings-inference.go
+++ b/pkg/steps/ai/settings/settings-inference.go
@@ -43,12 +43,23 @@ type factoryConfigFileWrapper struct {
 type APISettings struct {
 	APIKeys  map[string]string `yaml:"api_keys,omitempty" glazed:"*-api-key"`
 	BaseUrls map[string]string `yaml:"base_urls,omitempty" glazed:"*-base-url"`
+
+	// AllowHTTP permits plain HTTP provider URLs for explicitly opted-in API
+	// types. It is intentionally false by default; use only for local test
+	// providers or trusted local gateways.
+	AllowHTTP map[string]bool `yaml:"allow_http,omitempty"`
+	// AllowLocalNetworks permits loopback/private/link-local provider targets for
+	// explicitly opted-in API types. It is intentionally false by default; use
+	// only for local test providers or trusted local gateways.
+	AllowLocalNetworks map[string]bool `yaml:"allow_local_networks,omitempty"`
 }
 
 func NewAPISettings() *APISettings {
 	return &APISettings{
-		APIKeys:  map[string]string{},
-		BaseUrls: map[string]string{},
+		APIKeys:            map[string]string{},
+		BaseUrls:           map[string]string{},
+		AllowHTTP:          map[string]bool{},
+		AllowLocalNetworks: map[string]bool{},
 	}
 }
 

--- a/ttmp/2026/07/06/LLM-PROXY-BYOK-GEPETTO--geppetto-dependencies-ssrf-escape-hatch-for-local-testing-and-streaming-include-usage/README.md
+++ b/ttmp/2026/07/06/LLM-PROXY-BYOK-GEPETTO--geppetto-dependencies-ssrf-escape-hatch-for-local-testing-and-streaming-include-usage/README.md
@@ -1,0 +1,21 @@
+# Geppetto dependencies: SSRF escape hatch for local testing and streaming include_usage
+
+This is the document workspace for ticket LLM-PROXY-BYOK-GEPETTO.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket LLM-PROXY-BYOK-GEPETTO --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket LLM-PROXY-BYOK-GEPETTO --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket LLM-PROXY-BYOK-GEPETTO --field Status --value review`

--- a/ttmp/2026/07/06/LLM-PROXY-BYOK-GEPETTO--geppetto-dependencies-ssrf-escape-hatch-for-local-testing-and-streaming-include-usage/changelog.md
+++ b/ttmp/2026/07/06/LLM-PROXY-BYOK-GEPETTO--geppetto-dependencies-ssrf-escape-hatch-for-local-testing-and-streaming-include-usage/changelog.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 2026-07-06
+
+- Initial workspace created
+
+
+## 2026-07-06
+
+Step 2: implemented profile-owned outbound URL validation opt-ins for OpenAI Chat, OpenAI Responses, and Claude; defaults remain fail-closed; full go test ./... and pre-commit lint passed (commit ece5bb07).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-05/llm-proxy-byok/geppetto/pkg/steps/ai/claude/api/completion.go — Claude API client carries outbound URL options
+- /home/manuel/workspaces/2026-07-05/llm-proxy-byok/geppetto/pkg/steps/ai/openai/chat_stream.go — OpenAI-compatible Chat validates provider URL with profile-owned outbound options
+- /home/manuel/workspaces/2026-07-05/llm-proxy-byok/geppetto/pkg/steps/ai/openai_responses/provider_settings.go — Responses alias-aware outbound option resolution
+- /home/manuel/workspaces/2026-07-05/llm-proxy-byok/geppetto/pkg/steps/ai/settings/outbound_url.go — New helper mapping profile API settings to security.OutboundURLOptions
+- /home/manuel/workspaces/2026-07-05/llm-proxy-byok/geppetto/pkg/steps/ai/settings/settings-inference.go — APISettings now exposes allow_http and allow_local_networks maps
+

--- a/ttmp/2026/07/06/LLM-PROXY-BYOK-GEPETTO--geppetto-dependencies-ssrf-escape-hatch-for-local-testing-and-streaming-include-usage/design-doc/01-geppetto-dependencies-ssrf-escape-hatch-and-streaming-include-usage.md
+++ b/ttmp/2026/07/06/LLM-PROXY-BYOK-GEPETTO--geppetto-dependencies-ssrf-escape-hatch-for-local-testing-and-streaming-include-usage/design-doc/01-geppetto-dependencies-ssrf-escape-hatch-and-streaming-include-usage.md
@@ -1,0 +1,127 @@
+---
+Title: 'Geppetto dependencies: SSRF escape hatch and streaming include_usage'
+Ticket: LLM-PROXY-BYOK-GEPETTO
+Status: active
+Topics:
+    - byok
+    - geppetto
+    - llm-proxy
+    - security
+    - inference
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: /home/manuel/workspaces/2026-07-05/llm-proxy-byok/geppetto/pkg/security/outbound_url.go
+      Note: ValidateOutboundURL + OutboundURLOptions — the SSRF guard primitive
+    - Path: /home/manuel/workspaces/2026-07-05/llm-proxy-byok/geppetto/pkg/steps/ai/claude/api/completion.go
+      Note: Hard-codes AllowHTTP: false at the Claude provider call sites (lines 91, 152)
+    - Path: /home/manuel/workspaces/2026-07-05/llm-proxy-byok/geppetto/pkg/steps/ai/openai_responses/engine.go
+      Note: Hard-codes AllowHTTP: false at the OpenAI Responses call site (line 104)
+    - Path: /home/manuel/workspaces/2026-07-05/llm-proxy-byok/geppetto/pkg/embeddings/ollama.go
+      Note: Already opts into AllowHTTP+AllowLocalNetworks — proves the mechanism is reachable
+    - Path: /home/manuel/workspaces/2026-07-05/llm-proxy-byok/llm-proxy/pkg/runtime/chat_service.go
+      Note: Streaming goroutine that owns result.Usage — include_usage plumbing point
+ExternalSources: []
+Summary: Two geppetto-side blockers for the BYOK effort: (1) the SSRF guard hard-codes AllowHTTP:false on every LLM provider path with no per-profile escape hatch, blocking local plain-HTTP fake providers in tests; (2) stream_options.include_usage is unsupported, so streaming clients cannot observe usage on the wire.
+LastUpdated: 2026-07-06T11:30:00-04:00
+WhatFor: Capture the geppetto dependencies that block local-provider testing and on-wire streaming usage, with concrete fix proposals for both geppetto and llm-proxy.
+WhenToUse: Read when unblocking local-provider smoke tests or implementing stream_options.include_usage.
+---
+
+# Geppetto dependencies: SSRF escape hatch and streaming include_usage
+
+## Executive Summary
+
+Two geppetto-side concerns block or limit the BYOK effort and were discovered during the LLM-PROXY-BYOK implementation (diary Steps 3 and 5). This ticket tracks resolving both:
+
+1. **SSRF escape hatch for local testing.** Geppetto's `security.ValidateOutboundURL` is well-designed — it takes an `OutboundURLOptions{AllowHTTP, AllowLocalNetworks}` struct — but every LLM provider call site hard-codes `AllowHTTP: false` with no way to override it per profile or per provider. This makes it impossible to point a profile at a local plain-HTTP fake provider for smoke testing. (The Ollama embeddings provider already opts into `AllowHTTP: true, AllowLocalNetworks: true`, proving the mechanism is reachable — it is just not exposed for LLM providers.)
+2. **`stream_options.include_usage`.** Streaming responses carry no usage object on the wire. The authoritative token counts exist only in the `InferenceResult` returned by `geppettoengine.RunInferenceWithResult`. The OpenAI streaming API defines `stream_options.include_usage` to emit a final SSE frame carrying `usage`; llm-proxy does not implement it, so streaming BYOK consumers cannot observe their own spend on the wire (they can only read it via the control-plane usage API after the fact).
+
+## Problem Statement
+
+### 1. SSRF guard blocks local-provider testing
+
+During LLM-PROXY-BYOK Phase 2, the planned tmux smoke test against a local plain-HTTP fake provider failed:
+
+```
+invalid chat completion URL: http scheme is not allowed
+```
+
+Root cause: every LLM provider path in geppetto calls `security.ValidateOutboundURL(url, security.OutboundURLOptions{AllowHTTP: false})` with a hard-coded literal. There is no env var, flag, or profile setting to relax this. The relevant call sites:
+
+- `geppetto/pkg/steps/ai/claude/api/completion.go:91` and `:152` — `AllowHTTP: false`
+- `geppetto/pkg/steps/ai/openai_responses/engine.go:104` — `AllowHTTP: false`
+- `geppetto/pkg/steps/ai/openai_responses/token_count.go:72` — `AllowHTTP: false`
+
+Contrast with `geppetto/pkg/embeddings/ollama.go:52`, which legitimately sets `AllowHTTP: true, AllowLocalNetworks: true` because Ollama runs locally. The primitive supports the opt-in; the LLM providers just never wire it up.
+
+**Impact:** the only way to test the full HTTP → middleware → service → engine → metering chain against a fake upstream is an in-process fake engine implementing `EngineWithResult` (which is what `pkg/byok/integration_test.go` does). That is excellent for CI but does not exercise the real HTTP client path, the real SSE parser, or the real provider URL handling. A local HTTP fake provider remains valuable for integration and operator smoke testing.
+
+### 2. `stream_options.include_usage` unsupported
+
+The OpenAI Chat Completions streaming API supports `stream_options: { include_usage: true }`, which causes the server to emit a final SSE chunk whose `usage` field is populated. llm-proxy currently ignores this option. The proxy's SSE chunks have no `usage` field, and the authoritative numbers exist only in the `InferenceResult` returned inside the streaming goroutine after the stream completes (`pkg/runtime/chat_service.go`).
+
+**Impact:** BYOK consumers that stream cannot observe their own token usage on the wire. They must poll the control-plane `/api/usage` endpoint after the fact. This is a documented gap in the LLM-PROXY-BYOK diary (Step 3, "What should be done in the future") and the PROJ note's open questions.
+
+## Proposed Solution
+
+### 1. SSRF escape hatch — profile-level opt-in
+
+Thread `OutboundURLOptions` from profile settings so a profile can opt into `AllowHTTP` and/or `AllowLocalNetworks`. This mirrors how the Ollama embeddings provider already works and keeps the default secure (deny HTTP + local networks).
+
+**Geppetto side:**
+- Add optional fields to the provider/connection settings struct that feeds `ValidateOutboundURL`, e.g. `AllowHTTP bool` and `AllowLocalNetworks bool` on the relevant `ClientSettings`/`API` settings, defaulting to `false`.
+- Replace the hard-coded `security.OutboundURLOptions{AllowHTTP: false}` literals at the LLM provider call sites with a value derived from those settings.
+- Keep the default `false` so production behavior is unchanged unless a profile explicitly opts in.
+
+**llm-proxy side:**
+- Expose the two booleans as profile YAML fields (e.g. under `api:` or a new `security:` block) so a dev profile can point at `http://127.0.0.1:PORT`.
+- Document the dev-only nature loudly; this must never be the default for a profile that resolves a real provider key.
+
+**Alternative / complement — in-process fake engine:**
+- The in-process fake `EngineWithResult` pattern (`pkg/byok/integration_test.go`) remains the preferred CI approach because it is deterministic and needs no port. This ticket should also document that pattern as the canonical test seam so future contributors do not re-derive it.
+
+### 2. `stream_options.include_usage` — emit a final usage frame
+
+**llm-proxy side (primary):**
+- In the streaming handlers (`chat_service.go`, `completion_service.go`), inspect the request for `stream_options.include_usage` (and the legacy `include_usage` if relevant).
+- After the upstream stream completes and `result.Usage` is available (the same point where `meter.Recorder` is called), emit one final SSE chunk carrying the `usage` object, then the `data: [DONE]` terminator.
+- The usage object must be mapped to the OpenAI wire shape (prompt_tokens, completion_tokens, total_tokens, and cached token fields where applicable), reusing the same mapping the meter uses to avoid drift.
+
+**Geppetto side (verify only):**
+- Confirm `RunInferenceWithResult` reliably returns `result.Usage` for streaming completions across all engines (it does for the engines llm-proxy uses today). No geppetto change is expected unless an engine fails to populate usage.
+
+## Design Decisions
+
+- **Profile-level opt-in over a global dev flag.** A global `--allow-http-providers` flag is too broad: it would relax the guard for every profile. Per-profile opt-in matches the existing Ollama precedent and keeps blast radius small.
+- **Default remains deny.** The hard-coded `false` is the correct production default. The escape hatch is strictly additive for dev/test profiles.
+- **include_usage is llm-proxy's responsibility.** The usage data already reaches llm-proxy via `result.Usage`; the gap is purely that llm-proxy does not serialize it into a final SSE frame. No geppetto streaming change is required.
+- **Reuse the meter's usage mapping.** The ledger and the on-wire usage frame must agree, so both should derive from the same `turns.InferenceUsage` → wire-usage helper.
+
+## Alternatives Considered
+
+- **Global env var `GEPPETTO_ALLOW_HTTP=true`.** Rejected: too broad, and it would silently weaken security for every profile in the process.
+- **HTTPS test server with a trusted self-signed cert.** Considered for testing. Rejected as the primary path: it adds cert-management overhead to every smoke loop and does not help operators who legitimately want to point a profile at a local gateway. Viable as an additional option but not a substitute for the opt-in.
+- **Skip on-wire usage; rely on the control-plane usage API.** Rejected: streaming clients (especially third-party sites in Phase 4) should be able to observe their own spend without a second round-trip to a different plane.
+
+## Implementation Plan
+
+1. **Geppetto: thread OutboundURLOptions from settings.** Add `AllowHTTP`/`AllowLocalNetworks` to the provider settings structs; replace the hard-coded literals at the Claude, OpenAI Responses, and OpenAI Chat call sites. Default false. Add unit tests asserting the opt-in is honored and the default still denies.
+2. **llm-proxy: expose profile security fields.** Add YAML fields; wire them into the settings that reach the engine. Add a dev profile in `examples/` pointing at `http://127.0.0.1`.
+3. **llm-proxy: implement `stream_options.include_usage`.** Parse the request option; after stream completion, emit a final usage SSE chunk then `[DONE]`. Add an integration test asserting the final frame carries usage matching the ledger row.
+4. **Document the in-process fake-engine test seam** in this ticket's reference docs so the canonical CI pattern is discoverable.
+5. **Operator smoke:** stand up a local plain-HTTP fake provider and drive the full HTTP path with a dev profile, confirming the SSRF opt-in works end to end.
+
+## Open Questions
+
+- Should the `AllowLocalNetworks` opt-in be separately gated from `AllowHTTP`, or combined into a single `dev: true` profile flag? (Lean: keep them separate to match the existing `OutboundURLOptions` shape.)
+- Should `include_usage` also be emitted for the OpenAI Responses API streaming shape, or only Chat Completions? (Lean: both, where the upstream API defines it.)
+- Does any geppetto engine fail to populate `result.Usage` for streaming? (Verify during implementation; none known today.)
+
+## References
+
+- LLM-PROXY-BYOK diary Step 3 (SSRF blocker) and Step 5 (include_usage future work)
+- PROJ note open questions: `stream_options.include_usage` support
+- Geppetto: `pkg/security/outbound_url.go`, `pkg/steps/ai/claude/api/completion.go`, `pkg/steps/ai/openai_responses/engine.go`, `pkg/embeddings/ollama.go`
+- llm-proxy: `pkg/runtime/chat_service.go`, `pkg/byok/meter/meter.go`, `pkg/byok/integration_test.go`

--- a/ttmp/2026/07/06/LLM-PROXY-BYOK-GEPETTO--geppetto-dependencies-ssrf-escape-hatch-for-local-testing-and-streaming-include-usage/index.md
+++ b/ttmp/2026/07/06/LLM-PROXY-BYOK-GEPETTO--geppetto-dependencies-ssrf-escape-hatch-for-local-testing-and-streaming-include-usage/index.md
@@ -1,0 +1,84 @@
+---
+Title: 'Geppetto dependencies: SSRF escape hatch for local testing and streaming include_usage'
+Ticket: LLM-PROXY-BYOK-GEPETTO
+Status: active
+Topics:
+    - byok
+    - geppetto
+    - llm-proxy
+    - security
+    - inference
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: pkg/security/outbound_url.go
+      Note: ValidateOutboundURL + OutboundURLOptions — the SSRF guard primitive
+    - Path: pkg/steps/ai/claude/api/completion.go
+      Note: Claude API client carries outbound URL options
+    - Path: pkg/steps/ai/openai/chat_stream.go
+      Note: OpenAI-compatible Chat URL validation uses profile-owned outbound options
+    - Path: pkg/steps/ai/openai_responses/provider_settings.go
+      Note: Responses alias-aware outbound option resolution
+    - Path: pkg/steps/ai/settings/outbound_url.go
+      Note: New helper mapping profile API settings to security.OutboundURLOptions
+    - Path: pkg/steps/ai/settings/settings-inference.go
+      Note: APISettings exposes allow_http and allow_local_networks profile maps
+ExternalSources: []
+Summary: 'Geppetto-side dependencies for BYOK: expose a secure local-provider testing escape hatch around outbound URL validation and implement on-wire streaming usage support via stream_options.include_usage.'
+LastUpdated: 2026-07-06T11:45:00-04:00
+WhatFor: Track geppetto changes that unblock local fake-provider smoke tests and streaming usage visibility for llm-proxy BYOK.
+WhenToUse: Read before implementing the Geppetto SSRF escape hatch or llm-proxy include_usage plumbing.
+---
+
+
+
+
+
+
+
+
+
+
+
+# Geppetto dependencies: SSRF escape hatch for local testing and streaming include_usage
+
+## Overview
+
+This ticket was moved from the llm-proxy docmgr workspace into the Geppetto repo because the first implementation step belongs in Geppetto: provider URL validation already supports `OutboundURLOptions`, but LLM provider call sites hard-code `AllowHTTP: false` and expose no profile-level test escape hatch.
+
+The second workstream, `stream_options.include_usage`, is cross-repo: Geppetto must continue returning authoritative `result.Usage`; llm-proxy must serialize it into a final SSE frame when requested.
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- byok
+- geppetto
+- llm-proxy
+- security
+- inference
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/07/06/LLM-PROXY-BYOK-GEPETTO--geppetto-dependencies-ssrf-escape-hatch-for-local-testing-and-streaming-include-usage/reference/01-investigation-diary.md
+++ b/ttmp/2026/07/06/LLM-PROXY-BYOK-GEPETTO--geppetto-dependencies-ssrf-escape-hatch-for-local-testing-and-streaming-include-usage/reference/01-investigation-diary.md
@@ -1,0 +1,156 @@
+---
+Title: Investigation diary
+Ticket: LLM-PROXY-BYOK-GEPETTO
+Status: active
+Topics:
+    - byok
+    - geppetto
+    - llm-proxy
+    - security
+    - inference
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: Chronological diary for the geppetto-dependencies ticket, starting from the assessment of the LLM-PROXY-BYOK implementation and the two geppetto-side blockers it surfaced.
+LastUpdated: 2026-07-06T11:35:00-04:00
+WhatFor: Preserve the investigation trail so future sessions can resume the geppetto SSRF escape hatch and include_usage work without re-deriving context.
+WhenToUse: Read before resuming work on this ticket; append an entry per work session.
+---
+
+# Investigation diary
+
+## Goal
+
+Track the geppetto-side dependencies that block or limit the BYOK effort: the SSRF guard that prevents local-provider testing, and the missing `stream_options.include_usage` streaming support.
+
+## Step 1: Ticket creation from the BYOK assessment
+
+This ticket was created during a post-implementation assessment of the LLM-PROXY-BYOK work. The assessment reviewed the byok-host prior-art tickets, the llm-proxy implementation diaries (Steps 1–6), the PROJ note, and the current code state (builds clean, tests green, 0 TODOs, ~3,800 LOC, branch `task/llm-proxy-byok` local-only). Two geppetto-side concerns were identified as worth their own ticket because they span both the geppetto and llm-proxy repos and are not pure llm-proxy changes.
+
+### Prompt Context
+
+**User prompt (verbatim):** "create a geppetto ticket to address the issues with using geppetto packaging to test, and for include_usage maybe?"
+
+**Assistant interpretation:** Create a docmgr ticket (in the llm-proxy workspace) tracking the geppetto-side blockers: the SSRF guard that blocks local plain-HTTP fake providers in tests, and the missing `stream_options.include_usage` streaming support.
+
+**Inferred user intent:** Separate the geppetto-cross-cutting concerns from the llm-proxy-internal hardening so each can be scoped and picked up independently.
+
+### What I did
+- Verified the geppetto SSRF guard source: `pkg/security/outbound_url.go` defines `ValidateOutboundURL(rawURL, OutboundURLOptions{AllowHTTP, AllowLocalNetworks})` — the primitive is well-designed and supports opt-in.
+- Confirmed every LLM provider call site hard-codes `AllowHTTP: false`: `pkg/steps/ai/claude/api/completion.go:91,:152`, `pkg/steps/ai/openai_responses/engine.go:104`, `pkg/steps/ai/openai_responses/token_count.go:72`.
+- Confirmed `pkg/embeddings/ollama.go:52` already opts into `AllowHTTP: true, AllowLocalNetworks: true` — proving the mechanism is reachable, just not exposed for LLM providers.
+- Created ticket `LLM-PROXY-BYOK-GEPETTO` with design doc and this diary.
+- Wrote the design doc covering both issues with file/line-anchored evidence, proposed profile-level opt-in for the SSRF hatch, and the llm-proxy-side `include_usage` implementation plan.
+
+### Why
+- These two concerns are not pure llm-proxy changes: the SSRF hatch requires a geppetto change (threading `OutboundURLOptions` from settings), and `include_usage` spans the geppetto streaming result and the llm-proxy SSE frame. They deserve a focused ticket rather than being buried in a generic hardening list.
+
+### What worked
+- The geppetto source confirmed the diagnosis from the LLM-PROXY-BYOK diary Step 3 verbatim: the primitive supports opt-in, the callers just hard-code `false`.
+
+### What didn't work
+- N/A. This was a ticket-creation and design-writing step.
+
+### What I learned
+- The Ollama embeddings provider is the existing precedent for opting into local HTTP — the fix is "do what Ollama does, but make it profile-configurable for LLM providers."
+
+### What was tricky to build
+- Scoping the `include_usage` work correctly: the usage data already reaches llm-proxy via `result.Usage`, so the gap is purely llm-proxy's SSE frame emission, not a geppetto streaming change. Getting that boundary right keeps the geppetto side of this ticket small (verify only).
+
+### What warrants a second pair of eyes
+- Whether the SSRF opt-in should be two separate booleans (`AllowHTTP`, `AllowLocalNetworks`) matching the existing struct, or a single `dev: true` profile flag. The design doc leans separate to match the primitive.
+
+### What should be done in the future
+- Implement the geppetto-side settings threading (Step 1 of the design doc plan).
+- Consider filing a geppetto GitHub issue for the SSRF escape hatch if the geppetto maintainers want to track it upstream (the glazed issues were filed; geppetto was kept as a docmgr ticket per the user's request).
+
+### Code review instructions
+- Start with the design doc: `design-doc/01-geppetto-dependencies-ssrf-escape-hatch-and-streaming-include-usage.md`.
+- Verify the call-site evidence: `rg -n "AllowHTTP" geppetto/pkg/`.
+
+### Technical details
+- Geppetto repo: `/home/manuel/workspaces/2026-07-05/llm-proxy-byok/geppetto` (remote `go-go-golems/geppetto`).
+- llm-proxy streaming plumbing point: `pkg/runtime/chat_service.go` (the goroutine that owns `result.Usage`).
+
+## Step 2: Implement profile-owned outbound URL validation opt-ins
+
+The first Geppetto-side blocker is implemented. Provider URL validation still denies plain HTTP and local-network targets by default, but a profile can now explicitly opt in through `inference_settings.api.allow_http` and `inference_settings.api.allow_local_networks`. The opt-in is keyed by provider/API type and supports both raw provider keys (for YAML readability, e.g. `openai: true`) and suffixed keys (for compatibility with Geppetto's existing `openai-base-url` / `openai-api-key` naming pattern).
+
+The change removes the hard-coded `AllowHTTP: false` literals from OpenAI-compatible Chat Completions, OpenAI Responses, and Claude provider paths. This unblocks local fake-provider testing without weakening the default SSRF posture.
+
+### Prompt Context
+
+**User prompt (verbatim):** "push and PR. Then work on GEPETTO changes (move that ticket to geppetto/)"
+
+**Assistant interpretation:** Push the llm-proxy BYOK branch and open a PR, move the Geppetto follow-up ticket from the llm-proxy docmgr workspace into the Geppetto repo, then implement the Geppetto-side changes starting with the outbound URL validation escape hatch.
+
+**Inferred user intent:** Keep follow-up ownership in the correct repo and turn the assessment ticket into concrete Geppetto code, not just planning.
+
+**Commit (code):** ece5bb07 — "security: make provider URL validation opt-in configurable"
+
+### What I did
+- Moved `LLM-PROXY-BYOK-GEPETTO` from `llm-proxy/ttmp` into `geppetto/ttmp` and added the missing `byok` vocabulary topic.
+- Added `APISettings.AllowHTTP` and `APISettings.AllowLocalNetworks` maps.
+- Added `settings.OutboundURLOptions` / `OutboundURLOptionsForKeys` helper functions.
+- Threaded the helper through:
+  - `pkg/steps/ai/openai/chat_stream.go`
+  - `pkg/steps/ai/openai_responses/engine.go`
+  - `pkg/steps/ai/openai_responses/token_count.go`
+  - `pkg/steps/ai/claude/engine_claude.go`
+  - `pkg/steps/ai/claude/token_count.go`
+  - `pkg/steps/ai/claude/api/{completion.go,messages.go}` via `Client.SetOutboundURLOptions`.
+- Added tests for default-deny behavior, YAML decoding, suffixed/raw provider keys, Responses alias fallback, OpenAI Chat local HTTP opt-in, and Claude client options.
+- Ran focused tests and then full pre-commit validation.
+
+### Why
+- The BYOK llm-proxy integration needs a way to test the real provider HTTP path against local fake providers without globally weakening SSRF protections.
+- A profile-level opt-in keeps production defaults secure and scopes any relaxation to the profile that explicitly asks for it.
+
+### What worked
+- `GOWORK=off go test ./...` passed.
+- Geppetto's pre-commit hook passed: full tests plus lint/glazed-lint vet tooling.
+- The existing `OutboundURLOptions` primitive was sufficient; no changes to `pkg/security/outbound_url.go` were needed.
+
+### What didn't work
+- The first `git commit` attempt timed out because the pre-commit hook runs the full repository test/lint suite and exceeded the initial 120-second command timeout. I re-ran the same commit with a longer timeout; the hook completed successfully and the commit landed.
+- A focused test run initially failed because I removed the `security` import from `openai/chat_stream.go`, but the file still calls `security.ValidateOutboundURL`. Restored the import and re-ran the focused tests successfully.
+
+### What I learned
+- OpenAI Responses needs alias-aware option resolution just like its API key and base URL resolution. `responsesOutboundURLOptions` now checks `open-responses`, `openai-responses`, then `openai`.
+- The cleanest YAML shape is provider-keyed maps:
+  - `api.allow_http.openai: true`
+  - `api.allow_local_networks.openai: true`
+  while still accepting suffixed keys like `openai-allow-http` for naming consistency.
+
+### What was tricky to build
+- The tricky boundary was not the security primitive; it was threading the option into all provider paths without accidentally broadening defaults. Claude wraps URL validation inside an API client, so the engine and token counter now set `Client.SetOutboundURLOptions(...)` immediately after constructing the client. OpenAI Responses has multiple aliases, so it needed a small package-local helper rather than a single API type lookup.
+
+### What warrants a second pair of eyes
+- Whether maps keyed by provider/API type are the right long-term config shape, or whether the project eventually wants a nested structure under each base URL. The current shape matches existing `api_keys` / `base_urls` conventions.
+- Whether CLI flag support should be added later via wildcard `glazed` maps. This implementation focuses on profile YAML support because the immediate need is local-provider test profiles.
+
+### What should be done in the future
+- Add an operator smoke with a local plain-HTTP fake provider and a profile that opts into `allow_http` and `allow_local_networks`.
+- Continue with `stream_options.include_usage` after the SSRF/local-test path is proven end-to-end.
+
+### Code review instructions
+- Start with `pkg/steps/ai/settings/outbound_url.go` and `pkg/steps/ai/settings/settings-inference.go`.
+- Then review call sites in OpenAI Chat, OpenAI Responses, and Claude.
+- Validate with:
+  - `GOWORK=off go test ./pkg/steps/ai/settings ./pkg/steps/ai/openai ./pkg/steps/ai/openai_responses ./pkg/steps/ai/claude/... ./pkg/security`
+  - `GOWORK=off go test ./...`
+
+### Technical details
+- YAML example:
+  ```yaml
+  api:
+    base_urls:
+      openai-base-url: http://127.0.0.1:9999/v1
+    allow_http:
+      openai: true
+    allow_local_networks:
+      openai: true
+  ```
+- Responses alias order: `open-responses`, `openai-responses`, `openai`.

--- a/ttmp/2026/07/06/LLM-PROXY-BYOK-GEPETTO--geppetto-dependencies-ssrf-escape-hatch-for-local-testing-and-streaming-include-usage/tasks.md
+++ b/ttmp/2026/07/06/LLM-PROXY-BYOK-GEPETTO--geppetto-dependencies-ssrf-escape-hatch-for-local-testing-and-streaming-include-usage/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+## TODO
+
+- [x] Geppetto: add `AllowHTTP`/`AllowLocalNetworks` to provider settings structs (default false); replace hard-coded `AllowHTTP: false` at Claude (`completion.go:91,:152`), OpenAI Responses (`engine.go:104`, `token_count.go:72`), and OpenAI Chat call sites; unit tests asserting opt-in honored + default denies
+- [ ] llm-proxy: expose `allow_http`/`allow_local_networks` profile YAML fields; wire into settings reaching the engine; add a dev profile in `examples/` pointing at `http://127.0.0.1`
+- [ ] llm-proxy: implement `stream_options.include_usage` — after stream completion emit a final SSE chunk carrying `usage` (mapped via the same helper as the meter) then `[DONE]`; integration test asserting the final frame matches the ledger row
+- [ ] Document the in-process fake-engine test seam (`pkg/byok/integration_test.go`) as the canonical CI pattern in a reference doc
+- [ ] Operator smoke: stand up a local plain-HTTP fake provider, drive the full HTTP path with the dev profile, confirm the SSRF opt-in works e2e
+- [ ] Verify no geppetto engine fails to populate `result.Usage` for streaming (confirm during include_usage implementation)

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -129,6 +129,8 @@ topics:
       description: OpenAI-compatible llm-proxy service and related request/response mapping work
     - slug: multimodal
       description: Multimodal input/output support such as image content in LLM turns
+    - slug: byok
+      description: Bring-your-own-key credential brokering and delegated provider credentials
 docTypes:
     - slug: index
       description: Ticket index


### PR DESCRIPTION
## Summary

Adds profile-owned outbound URL validation opt-ins for provider HTTP calls while preserving secure defaults.

Motivation: llm-proxy BYOK needs to smoke-test real Geppetto provider packaging against local fake providers. Geppetto already has a secure `ValidateOutboundURL` primitive with `AllowHTTP` / `AllowLocalNetworks`, but the LLM provider paths hard-coded `AllowHTTP: false`, making local `http://127.0.0.1` fake providers impossible.

## Changes

- Add `APISettings.AllowHTTP` and `APISettings.AllowLocalNetworks` maps:
  ```yaml
  api:
    base_urls:
      openai-base-url: http://127.0.0.1:9999/v1
    allow_http:
      openai: true
    allow_local_networks:
      openai: true
  ```
- Add `settings.OutboundURLOptions` / `OutboundURLOptionsForKeys` helpers.
- Thread profile-owned outbound options through:
  - OpenAI-compatible Chat Completions (`pkg/steps/ai/openai/chat_stream.go`)
  - OpenAI Responses inference + token counting (`pkg/steps/ai/openai_responses/...`)
  - Claude Messages/Completions/token counting (`pkg/steps/ai/claude/...`)
- Keep defaults fail-closed: HTTP and local-network targets remain rejected unless a profile explicitly opts in.
- Add tests for default-deny, YAML decoding, suffixed/raw provider keys, Responses alias fallback, OpenAI Chat local HTTP opt-in, and Claude client options.
- Move the BYOK Geppetto follow-up docmgr ticket into this repo and check off the implemented SSRF/local-test task.

## Validation

Pre-commit and pre-push hooks passed:

- `go test ./...`
- repo lint (`golangci-lint`, `geppetto-lint`, `glazed-lint`)
- `gosec` — 0 issues
- `govulncheck` — no called vulnerabilities

Focused validation also passed:

```sh
GOWORK=off go test ./pkg/steps/ai/settings ./pkg/steps/ai/openai ./pkg/steps/ai/openai_responses ./pkg/steps/ai/claude/... ./pkg/security
```

## Follow-ups

Tracked in `LLM-PROXY-BYOK-GEPETTO`:

- add llm-proxy dev profile / operator smoke against a local plain-HTTP fake provider
- document in-process fake-engine test seam
- implement `stream_options.include_usage` final SSE usage frame on the llm-proxy side