### PR TITLE
Add provider credential lifecycle and subscription auth adapters

### DIFF
--- a/pkg/inference/engine/factory/factory.go
+++ b/pkg/inference/engine/factory/factory.go
@@ -148,7 +148,11 @@ func (f *StandardEngineFactory) CreateEngine(settings *settings.InferenceSetting
 		return openai_responses.NewEngine(settings, opts...)
 
 	case string(types.ApiTypeClaude), "anthropic":
-		return claude.NewClaudeEngine(settings, f.claudeOptions...)
+		opts := append([]claude.EngineOption(nil), f.claudeOptions...)
+		if f.bearerTokenSource != nil {
+			opts = append(opts, claude.WithBearerTokenSource(f.bearerTokenSource))
+		}
+		return claude.NewClaudeEngine(settings, opts...)
 
 	case string(types.ApiTypeGemini):
 		return gemini.NewGeminiEngine(settings, f.geminiOptions...)
@@ -258,10 +262,12 @@ func (f *StandardEngineFactory) validateClaudeSettings(settings *settings.Infere
 	// Claude uses "claude" as the key regardless of "anthropic" alias
 	actualProvider := string(types.ApiTypeClaude)
 
-	// Check for API key
+	// A request-time source is authoritative over static API-key settings.
 	apiKeyName := actualProvider + "-api-key"
-	if _, ok := settings.API.APIKeys[apiKeyName]; !ok {
-		return errors.Errorf("missing API key %s", apiKeyName)
+	if f.bearerTokenSource == nil {
+		if _, ok := settings.API.APIKeys[apiKeyName]; !ok {
+			return errors.Errorf("missing API key %s", apiKeyName)
+		}
 	}
 
 	// Check for base URL

--- a/pkg/inference/engine/factory/factory.go
+++ b/pkg/inference/engine/factory/factory.go
@@ -150,7 +150,7 @@ func (f *StandardEngineFactory) CreateEngine(settings *settings.InferenceSetting
 	case string(types.ApiTypeClaude), "anthropic":
 		opts := append([]claude.EngineOption(nil), f.claudeOptions...)
 		if f.bearerTokenSource != nil {
-			opts = append(opts, claude.WithBearerTokenSource(f.bearerTokenSource))
+			opts = append(opts, claude.WithOAuthBearerTokenSource(f.bearerTokenSource))
 		}
 		return claude.NewClaudeEngine(settings, opts...)
 

--- a/pkg/inference/tokencount/factory/factory.go
+++ b/pkg/inference/tokencount/factory/factory.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-go-golems/geppetto/pkg/inference/tokencount"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/claude"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/credentials"
 	openai_responses "github.com/go-go-golems/geppetto/pkg/steps/ai/openai_responses"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/types"
@@ -12,6 +13,12 @@ import (
 )
 
 func NewFromSettings(ss *settings.InferenceSettings) (tokencount.Counter, error) {
+	return NewFromSettingsWithBearerTokenSource(ss, nil)
+}
+
+// NewFromSettingsWithBearerTokenSource creates a token counter with an
+// optional Go-only request-time credential source.
+func NewFromSettingsWithBearerTokenSource(ss *settings.InferenceSettings, source credentials.BearerTokenSource) (tokencount.Counter, error) {
 	if ss == nil {
 		return nil, errors.New("token count: settings cannot be nil")
 	}
@@ -28,6 +35,9 @@ func NewFromSettings(ss *settings.InferenceSettings) (tokencount.Counter, error)
 	case string(types.ApiTypeOpenResponses), string(types.ApiTypeOpenAIResponses):
 		return openai_responses.NewTokenCounter(ss), nil
 	case string(types.ApiTypeClaude), "anthropic":
+		if source != nil {
+			return claude.NewTokenCounter(ss, claude.WithTokenCountBearerTokenSource(source)), nil
+		}
 		return claude.NewTokenCounter(ss), nil
 	default:
 		return nil, errors.Errorf("token count: provider %q is not supported", provider)

--- a/pkg/inference/tokencount/factory/factory.go
+++ b/pkg/inference/tokencount/factory/factory.go
@@ -36,7 +36,7 @@ func NewFromSettingsWithBearerTokenSource(ss *settings.InferenceSettings, source
 		return openai_responses.NewTokenCounter(ss), nil
 	case string(types.ApiTypeClaude), "anthropic":
 		if source != nil {
-			return claude.NewTokenCounter(ss, claude.WithTokenCountBearerTokenSource(source)), nil
+			return claude.NewTokenCounter(ss, claude.WithTokenCountOAuthBearerTokenSource(source)), nil
 		}
 		return claude.NewTokenCounter(ss), nil
 	default:

--- a/pkg/steps/ai/claude/api/completion.go
+++ b/pkg/steps/ai/claude/api/completion.go
@@ -53,6 +53,7 @@ type Client struct {
 	httpClient          *http.Client
 	apiKey              string
 	bearerAuthorization string
+	oauthMode           bool
 	APIVersion          string
 	BaseURL             string
 	outboundURLOptions  security.OutboundURLOptions
@@ -83,6 +84,16 @@ func (c *Client) SetBearerAuthorization(value string) {
 	}
 }
 
+// SetOAuthBearerAuthorization configures Anthropic subscription OAuth mode:
+// bearer authorization plus the Claude Code identity/beta headers observed in
+// the provider implementation. It deliberately does not send x-api-key.
+func (c *Client) SetOAuthBearerAuthorization(value string) {
+	if c != nil {
+		c.bearerAuthorization = value
+		c.oauthMode = true
+	}
+}
+
 func (c *Client) SetHTTPClient(httpClient *http.Client) {
 	if httpClient == nil {
 		return
@@ -103,9 +114,16 @@ func (c *Client) outboundOptions() security.OutboundURLOptions {
 
 // Helper function to set necessary headers
 func (c *Client) setHeaders(req *http.Request) {
-	req.Header.Set("x-api-key", c.apiKey)
-	if c.bearerAuthorization != "" {
+	if c.oauthMode {
 		req.Header.Set("Authorization", "Bearer "+c.bearerAuthorization)
+		req.Header.Set("anthropic-beta", "claude-code-20250219,oauth-2025-04-20")
+		req.Header.Set("user-agent", "claude-cli/geppetto")
+		req.Header.Set("x-app", "cli")
+	} else {
+		req.Header.Set("x-api-key", c.apiKey)
+		if c.bearerAuthorization != "" {
+			req.Header.Set("Authorization", "Bearer "+c.bearerAuthorization)
+		}
 	}
 	req.Header.Set("anthropic-version", c.APIVersion)
 	req.Header.Set("Content-Type", "application/json")

--- a/pkg/steps/ai/claude/api/completion.go
+++ b/pkg/steps/ai/claude/api/completion.go
@@ -50,11 +50,12 @@ type ErrorDetail struct {
 
 // Client represents the Claude API client.
 type Client struct {
-	httpClient         *http.Client
-	apiKey             string
-	APIVersion         string
-	BaseURL            string
-	outboundURLOptions security.OutboundURLOptions
+	httpClient          *http.Client
+	apiKey              string
+	bearerAuthorization string
+	APIVersion          string
+	BaseURL             string
+	outboundURLOptions  security.OutboundURLOptions
 }
 
 const defaultAPIVersion = "2023-06-01"
@@ -70,6 +71,15 @@ func NewClient(apiKey string, baseURL string, apiVersion ...string) *Client {
 		apiKey:     apiKey,
 		BaseURL:    baseURL,
 		APIVersion: version,
+	}
+}
+
+// SetBearerAuthorization adds the verified bearer form for gateways which
+// require it in addition to the Anthropic x-api-key header. It is a Go-only
+// runtime option and is never read from inference settings.
+func (c *Client) SetBearerAuthorization(value string) {
+	if c != nil {
+		c.bearerAuthorization = value
 	}
 }
 
@@ -94,6 +104,9 @@ func (c *Client) outboundOptions() security.OutboundURLOptions {
 // Helper function to set necessary headers
 func (c *Client) setHeaders(req *http.Request) {
 	req.Header.Set("x-api-key", c.apiKey)
+	if c.bearerAuthorization != "" {
+		req.Header.Set("Authorization", "Bearer "+c.bearerAuthorization)
+	}
 	req.Header.Set("anthropic-version", c.APIVersion)
 	req.Header.Set("Content-Type", "application/json")
 }

--- a/pkg/steps/ai/claude/api/messages_test.go
+++ b/pkg/steps/ai/claude/api/messages_test.go
@@ -1,8 +1,13 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/go-go-golems/geppetto/pkg/security"
@@ -111,6 +116,44 @@ func TestMessageDeserialization(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestUmansMessagesContractUsesAnthropicPathAndDualAuthHeaders(t *testing.T) {
+	var gotPath string
+	var gotAPIKey string
+	var gotAuthorization string
+	var gotVersion string
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAPIKey = r.Header.Get("x-api-key")
+		gotAuthorization = r.Header.Get("Authorization")
+		gotVersion = r.Header.Get("anthropic-version")
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"umans-test","stop_reason":"end_turn"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient("umans-key", server.URL)
+	client.SetBearerAuthorization("umans-key")
+	client.SetOutboundURLOptions(security.OutboundURLOptions{AllowHTTP: true, AllowLocalNetworks: true})
+	response, err := client.SendMessage(context.Background(), &MessageRequest{
+		Model: "umans-test", Messages: []Message{{Role: "user", Content: []Content{NewTextContent("hello")}}}, MaxTokens: 16,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response == nil || response.Model != "umans-test" {
+		t.Fatalf("response = %#v", response)
+	}
+	if gotPath != "/v1/messages" || gotAPIKey != "umans-key" || gotAuthorization != "Bearer umans-key" || gotVersion != defaultAPIVersion {
+		t.Fatalf("path=%q x-api-key=%q authorization=%q version=%q", gotPath, gotAPIKey, gotAuthorization, gotVersion)
+	}
+	if !strings.Contains(gotBody, `"messages"`) || !strings.Contains(gotBody, `"model":"umans-test"`) {
+		t.Fatalf("unexpected request body shape: %s", gotBody)
 	}
 }
 

--- a/pkg/steps/ai/claude/api/umans_headers_test.go
+++ b/pkg/steps/ai/claude/api/umans_headers_test.go
@@ -5,6 +5,28 @@ import (
 	"testing"
 )
 
+func TestClientSetHeadersSupportsAnthropicOAuthAuthentication(t *testing.T) {
+	client := NewClient("ignored", "https://api.anthropic.com")
+	client.SetOAuthBearerAuthorization("oauth-token")
+	request, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.setHeaders(request)
+	if got := request.Header.Get("Authorization"); got != "Bearer oauth-token" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	if got := request.Header.Get("x-api-key"); got != "" {
+		t.Fatalf("OAuth x-api-key = %q, want empty", got)
+	}
+	if got := request.Header.Get("anthropic-beta"); got != "claude-code-20250219,oauth-2025-04-20" {
+		t.Fatalf("anthropic-beta = %q", got)
+	}
+	if got := request.Header.Get("x-app"); got != "cli" {
+		t.Fatalf("x-app = %q", got)
+	}
+}
+
 func TestClientSetHeadersSupportsUmansDualAuthentication(t *testing.T) {
 	client := NewClient("test-api-key", "https://api.code.umans.ai")
 	client.SetBearerAuthorization("test-api-key")

--- a/pkg/steps/ai/claude/api/umans_headers_test.go
+++ b/pkg/steps/ai/claude/api/umans_headers_test.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestClientSetHeadersSupportsUmansDualAuthentication(t *testing.T) {
+	client := NewClient("test-api-key", "https://api.code.umans.ai")
+	client.SetBearerAuthorization("test-api-key")
+	request, err := http.NewRequest(http.MethodPost, "https://api.code.umans.ai/v1/messages", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.setHeaders(request)
+	if got := request.Header.Get("x-api-key"); got != "test-api-key" {
+		t.Fatalf("x-api-key = %q", got)
+	}
+	if got := request.Header.Get("Authorization"); got != "Bearer test-api-key" {
+		t.Fatalf("Authorization = %q", got)
+	}
+	if got := request.Header.Get("anthropic-version"); got != defaultAPIVersion {
+		t.Fatalf("anthropic-version = %q", got)
+	}
+}

--- a/pkg/steps/ai/claude/engine_claude.go
+++ b/pkg/steps/ai/claude/engine_claude.go
@@ -28,6 +28,7 @@ type ClaudeEngine struct {
 	toolAdapter         *tools.ClaudeToolAdapter
 	observer            geppettoobs.Observer
 	observabilityConfig geppettoobs.Config
+	bearerAuthorization string
 }
 
 // NewClaudeEngine creates a new Claude inference engine with the given settings and options.
@@ -82,6 +83,7 @@ func (e *ClaudeEngine) RunInference(
 	}
 
 	client := api.NewClient(apiKey, baseURL)
+	client.SetBearerAuthorization(e.bearerAuthorization)
 	client.SetOutboundURLOptions(settings.OutboundURLOptions(apiSettings, string(apiType)))
 	httpClient, err := settings.EnsureHTTPClient(clientSettings)
 	if err != nil {

--- a/pkg/steps/ai/claude/engine_claude.go
+++ b/pkg/steps/ai/claude/engine_claude.go
@@ -12,6 +12,7 @@ import (
 	geppettoobs "github.com/go-go-golems/geppetto/pkg/observability"
 	"github.com/go-go-golems/geppetto/pkg/steps"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/claude/api"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/credentials"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/runtimeattrib"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
 	"github.com/go-go-golems/geppetto/pkg/turns"
@@ -29,6 +30,7 @@ type ClaudeEngine struct {
 	observer            geppettoobs.Observer
 	observabilityConfig geppettoobs.Config
 	bearerAuthorization string
+	bearerTokenSource   credentials.BearerTokenSource
 }
 
 // NewClaudeEngine creates a new Claude inference engine with the given settings and options.
@@ -73,17 +75,32 @@ func (e *ClaudeEngine) RunInference(
 	apiType := *apiType_
 	apiSettings := e.settings.API
 
-	apiKey, ok := apiSettings.APIKeys[string(apiType)+"-api-key"]
-	if !ok {
-		return nil, errors.Errorf("no API key for %s", apiType)
-	}
 	baseURL, ok := apiSettings.BaseUrls[string(apiType)+"-base-url"]
 	if !ok {
 		return nil, errors.Errorf("no base URL for %s", apiType)
 	}
-
+	apiKey, ok := apiSettings.APIKeys[string(apiType)+"-api-key"]
+	if e.bearerTokenSource != nil {
+		request := credentials.Request{Provider: string(apiType), BaseURL: strings.TrimRight(baseURL, "/")}
+		resolvedToken, resolveErr := e.bearerTokenSource.BearerToken(ctx, request)
+		if resolveErr != nil {
+			return nil, errors.New("resolve Anthropic gateway credential")
+		}
+		apiKey = resolvedToken
+		if strings.TrimSpace(apiKey) == "" {
+			return nil, errors.New("Anthropic gateway credential is empty")
+		}
+		ok = true
+	}
+	if !ok {
+		return nil, errors.Errorf("no API key for %s", apiType)
+	}
 	client := api.NewClient(apiKey, baseURL)
-	client.SetBearerAuthorization(e.bearerAuthorization)
+	bearerAuthorization := e.bearerAuthorization
+	if e.bearerTokenSource != nil && bearerAuthorization == "" {
+		bearerAuthorization = apiKey
+	}
+	client.SetBearerAuthorization(bearerAuthorization)
 	client.SetOutboundURLOptions(settings.OutboundURLOptions(apiSettings, string(apiType)))
 	httpClient, err := settings.EnsureHTTPClient(clientSettings)
 	if err != nil {

--- a/pkg/steps/ai/claude/engine_claude.go
+++ b/pkg/steps/ai/claude/engine_claude.go
@@ -31,6 +31,7 @@ type ClaudeEngine struct {
 	observabilityConfig geppettoobs.Config
 	bearerAuthorization string
 	bearerTokenSource   credentials.BearerTokenSource
+	oauthBearerMode     bool
 }
 
 // NewClaudeEngine creates a new Claude inference engine with the given settings and options.
@@ -100,7 +101,11 @@ func (e *ClaudeEngine) RunInference(
 	if e.bearerTokenSource != nil && bearerAuthorization == "" {
 		bearerAuthorization = apiKey
 	}
-	client.SetBearerAuthorization(bearerAuthorization)
+	if e.oauthBearerMode {
+		client.SetOAuthBearerAuthorization(bearerAuthorization)
+	} else {
+		client.SetBearerAuthorization(bearerAuthorization)
+	}
 	client.SetOutboundURLOptions(settings.OutboundURLOptions(apiSettings, string(apiType)))
 	httpClient, err := settings.EnsureHTTPClient(clientSettings)
 	if err != nil {

--- a/pkg/steps/ai/claude/observability.go
+++ b/pkg/steps/ai/claude/observability.go
@@ -27,6 +27,14 @@ func WithObservabilityConfig(cfg geppettoobs.Config) EngineOption {
 	}
 }
 
+// WithBearerAuthorization enables the verified bearer header form for an
+// Anthropic-compatible gateway. It is a Go-only runtime injection point.
+func WithBearerAuthorization(value string) EngineOption {
+	return func(e *ClaudeEngine) {
+		e.bearerAuthorization = value
+	}
+}
+
 func (e *ClaudeEngine) observe(ctx context.Context, rec geppettoobs.Record) {
 	if e == nil || !e.observabilityConfig.Enabled() {
 		return

--- a/pkg/steps/ai/claude/observability.go
+++ b/pkg/steps/ai/claude/observability.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-go-golems/geppetto/pkg/events"
 	geppettoobs "github.com/go-go-golems/geppetto/pkg/observability"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/claude/api"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/credentials"
 )
 
 // EngineOption configures optional Claude engine behavior.
@@ -32,6 +33,15 @@ func WithObservabilityConfig(cfg geppettoobs.Config) EngineOption {
 func WithBearerAuthorization(value string) EngineOption {
 	return func(e *ClaudeEngine) {
 		e.bearerAuthorization = value
+	}
+}
+
+// WithBearerTokenSource resolves an Anthropic-compatible gateway credential at
+// request time. The resolved value is used for the verified dual-auth gateway
+// form and remains in Go-only runtime state.
+func WithBearerTokenSource(source credentials.BearerTokenSource) EngineOption {
+	return func(e *ClaudeEngine) {
+		e.bearerTokenSource = source
 	}
 }
 

--- a/pkg/steps/ai/claude/observability.go
+++ b/pkg/steps/ai/claude/observability.go
@@ -38,10 +38,19 @@ func WithBearerAuthorization(value string) EngineOption {
 
 // WithBearerTokenSource resolves an Anthropic-compatible gateway credential at
 // request time. The resolved value is used for the verified dual-auth gateway
-// form and remains in Go-only runtime state.
+// form and remains in Go-only runtime state. Use this for Umans-style API keys.
 func WithBearerTokenSource(source credentials.BearerTokenSource) EngineOption {
 	return func(e *ClaudeEngine) {
 		e.bearerTokenSource = source
+	}
+}
+
+// WithOAuthBearerTokenSource resolves an Anthropic subscription token at
+// request time and uses the provider's bearer-plus-Claude-Code identity form.
+func WithOAuthBearerTokenSource(source credentials.BearerTokenSource) EngineOption {
+	return func(e *ClaudeEngine) {
+		e.bearerTokenSource = source
+		e.oauthBearerMode = true
 	}
 }
 

--- a/pkg/steps/ai/claude/token_count.go
+++ b/pkg/steps/ai/claude/token_count.go
@@ -8,17 +8,33 @@ import (
 	"github.com/go-go-golems/geppetto/pkg/inference/tokencount"
 	"github.com/go-go-golems/geppetto/pkg/inference/tools"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/claude/api"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/credentials"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
 	"github.com/go-go-golems/geppetto/pkg/turns"
 	"github.com/pkg/errors"
 )
 
 type TokenCounter struct {
-	settings *settings.InferenceSettings
+	settings          *settings.InferenceSettings
+	bearerTokenSource credentials.BearerTokenSource
 }
 
-func NewTokenCounter(s *settings.InferenceSettings) *TokenCounter {
-	return &TokenCounter{settings: s}
+// TokenCounterOption configures request-time authentication for token counting.
+type TokenCounterOption func(*TokenCounter)
+
+// WithTokenCountBearerTokenSource supplies a Go-only request-time credential source.
+func WithTokenCountBearerTokenSource(source credentials.BearerTokenSource) TokenCounterOption {
+	return func(counter *TokenCounter) { counter.bearerTokenSource = source }
+}
+
+func NewTokenCounter(s *settings.InferenceSettings, opts ...TokenCounterOption) *TokenCounter {
+	counter := &TokenCounter{settings: s}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(counter)
+		}
+	}
+	return counter
 }
 
 func (tc *TokenCounter) CountTurn(ctx context.Context, t *turns.Turn) (*tokencount.Result, error) {
@@ -39,16 +55,27 @@ func (tc *TokenCounter) CountTurn(ctx context.Context, t *turns.Turn) (*tokencou
 	if tc.settings.API == nil {
 		return nil, errors.New("claude token count: api settings are required")
 	}
-	apiKey, ok := tc.settings.API.APIKeys["claude-api-key"]
-	if !ok || strings.TrimSpace(apiKey) == "" {
-		return nil, errors.New("claude token count: no claude api key configured")
-	}
 	baseURL, ok := tc.settings.API.BaseUrls["claude-base-url"]
 	if !ok || strings.TrimSpace(baseURL) == "" {
 		baseURL = "https://api.anthropic.com"
 	}
+	apiKey := tc.settings.API.APIKeys["claude-api-key"]
+	bearerAuthorization := ""
+	if tc.bearerTokenSource != nil {
+		request := credentials.Request{Provider: apiType, BaseURL: strings.TrimRight(baseURL, "/")}
+		resolved, resolveErr := tc.bearerTokenSource.BearerToken(ctx, request)
+		if resolveErr != nil {
+			return nil, errors.New("claude token count: resolve Anthropic gateway credential")
+		}
+		apiKey = resolved
+		bearerAuthorization = resolved
+	}
+	if strings.TrimSpace(apiKey) == "" {
+		return nil, errors.New("claude token count: no claude api key configured")
+	}
 
 	client := api.NewClient(apiKey, baseURL)
+	client.SetBearerAuthorization(bearerAuthorization)
 	client.SetOutboundURLOptions(settings.OutboundURLOptions(tc.settings.API, "claude"))
 	if tc.settings.Client != nil && tc.settings.Client.HTTPClient != nil {
 		client.SetHTTPClient(tc.settings.Client.HTTPClient)

--- a/pkg/steps/ai/claude/token_count.go
+++ b/pkg/steps/ai/claude/token_count.go
@@ -17,6 +17,7 @@ import (
 type TokenCounter struct {
 	settings          *settings.InferenceSettings
 	bearerTokenSource credentials.BearerTokenSource
+	oauthBearerMode   bool
 }
 
 // TokenCounterOption configures request-time authentication for token counting.
@@ -25,6 +26,15 @@ type TokenCounterOption func(*TokenCounter)
 // WithTokenCountBearerTokenSource supplies a Go-only request-time credential source.
 func WithTokenCountBearerTokenSource(source credentials.BearerTokenSource) TokenCounterOption {
 	return func(counter *TokenCounter) { counter.bearerTokenSource = source }
+}
+
+// WithTokenCountOAuthBearerTokenSource selects Anthropic subscription OAuth
+// header semantics for token counting.
+func WithTokenCountOAuthBearerTokenSource(source credentials.BearerTokenSource) TokenCounterOption {
+	return func(counter *TokenCounter) {
+		counter.bearerTokenSource = source
+		counter.oauthBearerMode = true
+	}
 }
 
 func NewTokenCounter(s *settings.InferenceSettings, opts ...TokenCounterOption) *TokenCounter {
@@ -75,7 +85,11 @@ func (tc *TokenCounter) CountTurn(ctx context.Context, t *turns.Turn) (*tokencou
 	}
 
 	client := api.NewClient(apiKey, baseURL)
-	client.SetBearerAuthorization(bearerAuthorization)
+	if tc.oauthBearerMode {
+		client.SetOAuthBearerAuthorization(bearerAuthorization)
+	} else {
+		client.SetBearerAuthorization(bearerAuthorization)
+	}
 	client.SetOutboundURLOptions(settings.OutboundURLOptions(tc.settings.API, "claude"))
 	if tc.settings.Client != nil && tc.settings.Client.HTTPClient != nil {
 		client.SetHTTPClient(tc.settings.Client.HTTPClient)

--- a/pkg/steps/ai/credentials/lifecycle.go
+++ b/pkg/steps/ai/credentials/lifecycle.go
@@ -1,0 +1,84 @@
+package credentials
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+)
+
+// Deleter is the optional local-delete capability a host store provides for
+// logout. Geppetto never discovers a path or invokes provider revocation.
+type Deleter interface {
+	Delete(context.Context, Request) error
+}
+
+// State is the redacted lifecycle state of a credential.
+type State string
+
+const (
+	StateMissing  State = "missing"
+	StateReady    State = "ready"
+	StateExpiring State = "expiring"
+	StateExpired  State = "expired"
+)
+
+// Status contains no token material. A zero ExpiresAt means a non-expiring
+// configured credential.
+type Status struct {
+	State     State
+	ExpiresAt time.Time
+	Renewable bool
+}
+
+// StatusOf loads a credential and derives a redacted lifecycle status. Store
+// errors are normalized to ErrUnavailable so storage details do not enter CLI
+// or engine diagnostics.
+func StatusOf(ctx context.Context, store Store, request Request, now time.Time, refreshSkew time.Duration) (Status, error) {
+	if store == nil {
+		return Status{}, &ErrUnavailable{Provider: request.Provider, Operation: "credential status"}
+	}
+	if _, err := request.key(); err != nil {
+		return Status{}, err
+	}
+	credential, err := store.Load(ctx, request)
+	if err != nil {
+		return Status{}, &ErrUnavailable{Provider: request.Provider, Operation: "credential status"}
+	}
+	status := Status{ExpiresAt: credential.ExpiresAt, Renewable: strings.TrimSpace(credential.RefreshToken) != ""}
+	if strings.TrimSpace(credential.AccessToken) == "" {
+		status.State = StateMissing
+		return status, nil
+	}
+	if credential.ExpiresAt.IsZero() {
+		status.State = StateReady
+		return status, nil
+	}
+	if !now.Before(credential.ExpiresAt) {
+		status.State = StateExpired
+		return status, nil
+	}
+	if refreshSkew > 0 && !now.Add(refreshSkew).Before(credential.ExpiresAt) {
+		status.State = StateExpiring
+		return status, nil
+	}
+	status.State = StateReady
+	return status, nil
+}
+
+// Logout removes a local credential tuple. It is intentionally separate from
+// provider revocation, which requires provider-specific endpoint and client
+// authentication review.
+func Logout(ctx context.Context, store Store, request Request) error {
+	if _, err := request.key(); err != nil {
+		return err
+	}
+	deleter, ok := store.(Deleter)
+	if !ok || deleter == nil {
+		return errors.New("credential store does not support local logout")
+	}
+	if err := deleter.Delete(ctx, request); err != nil {
+		return &ErrUnavailable{Provider: request.Provider, Operation: "credential logout"}
+	}
+	return nil
+}

--- a/pkg/steps/ai/credentials/lifecycle_test.go
+++ b/pkg/steps/ai/credentials/lifecycle_test.go
@@ -1,0 +1,65 @@
+package credentials_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/credentials"
+)
+
+type lifecycleStore struct {
+	credential credentials.Credential
+	deleteErr  error
+	deleted    bool
+}
+
+func (s *lifecycleStore) Load(context.Context, credentials.Request) (credentials.Credential, error) {
+	return s.credential, nil
+}
+func (*lifecycleStore) Save(context.Context, credentials.Request, credentials.Credential) error {
+	return nil
+}
+func (s *lifecycleStore) Delete(context.Context, credentials.Request) error {
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	s.deleted = true
+	s.credential = credentials.Credential{}
+	return nil
+}
+
+func TestStatusOfRedactsCredentialMaterial(t *testing.T) {
+	now := time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		cred credentials.Credential
+		want credentials.State
+	}{
+		{"missing", credentials.Credential{}, credentials.StateMissing},
+		{"ready", credentials.Credential{AccessToken: "test", ExpiresAt: now.Add(time.Hour)}, credentials.StateReady},
+		{"expiring", credentials.Credential{AccessToken: "test", RefreshToken: "refresh", ExpiresAt: now.Add(time.Minute)}, credentials.StateExpiring},
+		{"expired", credentials.Credential{AccessToken: "test", ExpiresAt: now.Add(-time.Minute)}, credentials.StateExpired},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status, err := credentials.StatusOf(context.Background(), &lifecycleStore{credential: test.cred}, request(), now, 5*time.Minute)
+			if err != nil || status.State != test.want {
+				t.Fatalf("StatusOf = %#v, %v", status, err)
+			}
+		})
+	}
+}
+
+func TestLogoutUsesHostDeleteAndRedactsFailure(t *testing.T) {
+	store := &lifecycleStore{credential: credentials.Credential{AccessToken: "test"}}
+	if err := credentials.Logout(context.Background(), store, request()); err != nil || !store.deleted {
+		t.Fatalf("Logout = %v deleted=%v", err, store.deleted)
+	}
+	store = &lifecycleStore{deleteErr: errors.New("sensitive storage detail")}
+	err := credentials.Logout(context.Background(), store, request())
+	if err == nil || err.Error() == "sensitive storage detail" {
+		t.Fatalf("Logout error = %v", err)
+	}
+}

--- a/pkg/steps/ai/credentials/oauth/oauth_test.go
+++ b/pkg/steps/ai/credentials/oauth/oauth_test.go
@@ -156,6 +156,19 @@ func newClient(t *testing.T, authorizationURL, tokenURL string) *oauth.Client {
 	return client
 }
 
+func TestStateGenerationAndValidation(t *testing.T) {
+	state, err := oauth.NewState()
+	if err != nil || state == "" {
+		t.Fatalf("NewState = %q, %v", state, err)
+	}
+	if err := oauth.ValidateState(state, state); err != nil {
+		t.Fatalf("ValidateState = %v", err)
+	}
+	if err := oauth.ValidateState(state, "other"); err == nil || strings.Contains(err.Error(), state) {
+		t.Fatalf("invalid state error = %v", err)
+	}
+}
+
 func writeToken(t *testing.T, writer http.ResponseWriter, payload map[string]any) {
 	t.Helper()
 	writer.Header().Set("Content-Type", "application/json")

--- a/pkg/steps/ai/credentials/oauth/state.go
+++ b/pkg/steps/ai/credentials/oauth/state.go
@@ -1,0 +1,27 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+)
+
+// NewState creates an unpredictable OAuth state value. Hosts retain it only
+// until the callback and must bind it to the exact pending login attempt.
+func NewState() (string, error) {
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", errors.New("generate OAuth state")
+	}
+	return base64.RawURLEncoding.EncodeToString(raw[:]), nil
+}
+
+// ValidateState compares a callback state against the pending state without
+// exposing either value in an error.
+func ValidateState(expected, received string) error {
+	if expected == "" || received == "" || subtle.ConstantTimeCompare([]byte(expected), []byte(received)) != 1 {
+		return errors.New("OAuth state validation failed")
+	}
+	return nil
+}

--- a/pkg/steps/ai/credentials/static.go
+++ b/pkg/steps/ai/credentials/static.go
@@ -1,0 +1,30 @@
+package credentials
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+// StaticBearerTokenSource adapts an explicitly supplied provider key to the
+// request-time source interface. It retains no provider metadata and is useful
+// for static-key gateways such as Umans. The caller remains responsible for
+// keeping the value out of settings, logs, and JavaScript.
+type StaticBearerTokenSource struct {
+	value string
+}
+
+// NewStaticBearerTokenSource creates a source for one explicit key.
+func NewStaticBearerTokenSource(value string) (*StaticBearerTokenSource, error) {
+	if strings.TrimSpace(value) == "" {
+		return nil, errors.New("static bearer credential is required")
+	}
+	return &StaticBearerTokenSource{value: value}, nil
+}
+
+func (s *StaticBearerTokenSource) BearerToken(context.Context, Request) (string, error) {
+	if s == nil || strings.TrimSpace(s.value) == "" {
+		return "", &ErrUnavailable{Operation: "static credential lookup"}
+	}
+	return s.value, nil
+}

--- a/pkg/steps/ai/openai_responses/engine.go
+++ b/pkg/steps/ai/openai_responses/engine.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-go-golems/geppetto/pkg/events"
 	"github.com/go-go-golems/geppetto/pkg/inference/engine"
 	geppettoobs "github.com/go-go-golems/geppetto/pkg/observability"
-	"github.com/go-go-golems/geppetto/pkg/security"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/credentials"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/runtimeattrib"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
@@ -24,6 +23,7 @@ type Engine struct {
 	observer            geppettoobs.Observer
 	observabilityConfig geppettoobs.Config
 	bearerTokenSource   credentials.BearerTokenSource
+	requestTransport    *RequestTransport
 }
 
 func NewEngine(s *settings.InferenceSettings, opts ...EngineOption) (*Engine, error) {
@@ -99,12 +99,7 @@ func (e *Engine) RunInference(ctx context.Context, t *turns.Turn) (*turns.Turn, 
 		}
 		return e.settings.API
 	}()
-	url := responsesEndpoint(apiSettings, "/responses")
-	if err := security.ValidateOutboundURL(url, responsesOutboundURLOptions(apiSettings)); err != nil {
-		return nil, errors.Wrap(err, "invalid responses URL")
-	}
-	credentialRequest := credentials.Request{Provider: string(responsesAPIType(e.settings)), BaseURL: responsesBaseURL(apiSettings)}
-	apiKey, err := resolveResponsesBearerToken(ctx, apiSettings, responsesAPIType(e.settings), e.bearerTokenSource)
+	requestTransport, err := e.newRequestTransport(apiSettings)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +144,8 @@ func (e *Engine) RunInference(ctx context.Context, t *turns.Turn) (*turns.Turn, 
 		metadata.Extra[events.MetadataSettingsSlug] = e.settings.GetMetadata()
 	}
 	runtimeattrib.AddRuntimeAttributionToExtra(metadata.Extra, t)
-	log.Debug().Str("url", url).Int("body_len", len(b)).Msg("Responses: sending request")
+	resolvedURL := requestTransport.request.URL()
+	log.Debug().Str("url", resolvedURL.String()).Int("body_len", len(b)).Msg("Responses: sending request")
 
 	// Attach DebugTap if present on context
 	var tap engine.DebugTap
@@ -160,5 +156,5 @@ func (e *Engine) RunInference(ctx context.Context, t *turns.Turn) (*turns.Turn, 
 	// Responses always uses streaming internally so provider-to-canonical event
 	// normalization has one lifecycle path. Profiles may still carry chat.stream
 	// for other engines, but this engine forces the request and runtime path.
-	return e.runStreamingInference(ctx, t, httpClient, url, b, apiKey, e.bearerTokenSource, credentialRequest, metadata, tap, startTime, reqBody)
+	return e.runStreamingInference(ctx, t, httpClient, requestTransport, b, metadata, tap, startTime, reqBody)
 }

--- a/pkg/steps/ai/openai_responses/provider_settings_test.go
+++ b/pkg/steps/ai/openai_responses/provider_settings_test.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/credentials"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
+	aitransport "github.com/go-go-golems/geppetto/pkg/steps/ai/transport"
 	"github.com/go-go-golems/geppetto/pkg/steps/ai/types"
+	"github.com/go-go-golems/geppetto/pkg/turns"
 )
 
 type bearerTokenSourceFunc func(context.Context, credentials.Request) (string, error)
@@ -30,6 +33,59 @@ func (f unauthorizedBearerTokenSourceFunc) BearerToken(ctx context.Context, requ
 
 func (f unauthorizedBearerTokenSourceFunc) BearerTokenAfterUnauthorized(ctx context.Context, request credentials.Request, rejected string) (string, error) {
 	return f.unauthorized(ctx, request, rejected)
+}
+
+type fixedResponsesRoute struct {
+	target *url.URL
+}
+
+func (r fixedResponsesRoute) Resolve(aitransport.RouteRequest) (*url.URL, error) {
+	target := *r.target
+	return &target, nil
+}
+
+type capturingResponsesDebugTap struct {
+	header http.Header
+}
+
+func (t *capturingResponsesDebugTap) OnHTTP(request *http.Request, _ []byte) {
+	t.header = request.Header.Clone()
+}
+func (*capturingResponsesDebugTap) OnHTTPResponse(*http.Response, []byte) {}
+func (*capturingResponsesDebugTap) OnSSE(string, []byte)                  {}
+func (*capturingResponsesDebugTap) OnProviderObject(string, any)          {}
+func (*capturingResponsesDebugTap) OnTurnBeforeConversion([]byte)         {}
+
+func testResponsesRequestTransport(t *testing.T, rawURL, apiKey string, source credentials.BearerTokenSource, request credentials.Request) responsesRequestTransport {
+	t.Helper()
+	target, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse target URL: %v", err)
+	}
+	context, err := aitransport.ResolveAndValidate(
+		request.Provider,
+		responsesOperation,
+		target,
+		fixedResponsesRoute{target: target},
+		func(*url.URL) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("ResolveAndValidate: %v", err)
+	}
+	chain, err := aitransport.NewChain(&responsesBearerMiddleware{
+		api:               &settings.APISettings{APIKeys: map[string]string{"open-responses-api-key": apiKey}},
+		apiType:           types.ApiTypeOpenResponses,
+		source:            source,
+		credentialRequest: request,
+	})
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+	return responsesRequestTransport{
+		request:     context,
+		chain:       chain,
+		headerRules: []aitransport.HeaderRule{{Name: "Authorization", Sensitive: true}},
+	}
 }
 
 func TestOpenResponsesStreamRetriesOneProvider401WithReplacementBearer(t *testing.T) {
@@ -61,13 +117,66 @@ func TestOpenResponsesStreamRetriesOneProvider401WithReplacementBearer(t *testin
 		return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(body)), Request: request}, nil
 	})}
 
-	response, err := openResponsesStream(context.Background(), client, "https://provider.example.test/v1/responses", []byte(`{"model":"test"}`), "stale-token", source, credentials.Request{Provider: "open-responses", BaseURL: "https://provider.example.test/v1"}, nil)
+	credentialRequest := credentials.Request{Provider: "open-responses", BaseURL: "https://provider.example.test/v1"}
+	response, err := openResponsesStream(context.Background(), client, testResponsesRequestTransport(t, "https://provider.example.test/v1/responses", "stale-token", source, credentialRequest), []byte(`{"model":"test"}`), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer response.Body.Close()
 	if requests != 2 || refreshes != 1 {
 		t.Fatalf("requests=%d refreshes=%d, want 2/1", requests, refreshes)
+	}
+}
+
+func TestOpenResponsesRequestRedactsMiddlewareCredentialsFromDebugTap(t *testing.T) {
+	const secret = "Bearer middleware-secret"
+	source := bearerTokenSourceFunc(func(context.Context, credentials.Request) (string, error) {
+		return "middleware-secret", nil
+	})
+	credentialRequest := credentials.Request{Provider: "open-responses", BaseURL: "https://provider.example.test/v1"}
+	client := &http.Client{Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		if got := request.Header.Get("Authorization"); got != secret {
+			t.Fatalf("outbound Authorization = %q, want secret", got)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader("data: [DONE]\\n\\n")), Request: request}, nil
+	})}
+	tap := &capturingResponsesDebugTap{}
+	response, err := openResponsesStream(context.Background(), client, testResponsesRequestTransport(t, "https://provider.example.test/v1/responses", "", source, credentialRequest), []byte(`{"model":"test"}`), tap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if tap.header == nil {
+		t.Fatal("debug tap did not receive request")
+	}
+	if got := tap.header.Get("Authorization"); got != "<redacted>" {
+		t.Fatalf("debug Authorization = %q", got)
+	}
+	if strings.Contains(tap.header.Get("Authorization"), "middleware-secret") {
+		t.Fatalf("debug Authorization leaked credential: %q", tap.header.Get("Authorization"))
+	}
+}
+
+func TestResponsesRunInferenceDoesNotResolveBearerBeforeInvalidRoute(t *testing.T) {
+	calls := 0
+	source := bearerTokenSourceFunc(func(context.Context, credentials.Request) (string, error) {
+		calls++
+		return "must-not-be-requested", nil
+	})
+	model := "test-model"
+	engine, err := NewEngine(&settings.InferenceSettings{
+		API:  &settings.APISettings{BaseUrls: map[string]string{"open-responses-base-url": "http://provider.example.test/v1"}},
+		Chat: &settings.ChatSettings{Engine: &model},
+	}, WithBearerTokenSource(source))
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	_, err = engine.RunInference(context.Background(), &turns.Turn{Blocks: []turns.Block{turns.NewUserTextBlock("hello")}})
+	if err == nil || !strings.Contains(err.Error(), "http scheme is not allowed") {
+		t.Fatalf("RunInference error = %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("bearer source calls = %d, want 0", calls)
 	}
 }
 
@@ -86,7 +195,8 @@ func TestOpenResponsesStreamDoesNotRetrySecondProvider401(t *testing.T) {
 		return &http.Response{StatusCode: http.StatusUnauthorized, Body: io.NopCloser(strings.NewReader(`{"error":"still unauthorized"}`)), Request: request}, nil
 	})}
 
-	_, err := openResponsesStream(context.Background(), client, "https://provider.example.test/v1/responses", []byte(`{"model":"test"}`), "stale-token", source, credentials.Request{Provider: "open-responses", BaseURL: "https://provider.example.test/v1"}, nil)
+	credentialRequest := credentials.Request{Provider: "open-responses", BaseURL: "https://provider.example.test/v1"}
+	_, err := openResponsesStream(context.Background(), client, testResponsesRequestTransport(t, "https://provider.example.test/v1/responses", "stale-token", source, credentialRequest), []byte(`{"model":"test"}`), nil)
 	if err == nil || !strings.Contains(err.Error(), "status=401") {
 		t.Fatalf("expected second 401 error, got %v", err)
 	}

--- a/pkg/steps/ai/openai_responses/request_transport.go
+++ b/pkg/steps/ai/openai_responses/request_transport.go
@@ -1,0 +1,206 @@
+package openai_responses
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/go-go-golems/geppetto/pkg/security"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/credentials"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
+	aitransport "github.com/go-go-golems/geppetto/pkg/steps/ai/transport"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/types"
+)
+
+const responsesOperation = "responses"
+
+// RequestTransport configures trusted, Go-only provider behavior for the shared
+// OpenAI Responses core. It cannot be represented in profile settings or
+// JavaScript values.
+type RequestTransport struct {
+	Provider             string
+	RouteResolver        aitransport.RouteResolver
+	HeaderRules          []aitransport.HeaderRule
+	Middlewares          []aitransport.Middleware
+	DisableDefaultBearer bool
+}
+
+type responsesRequestTransport struct {
+	request     aitransport.RequestContext
+	chain       *aitransport.Chain
+	headerRules []aitransport.HeaderRule
+}
+
+type responsesRoute struct{}
+
+func (responsesRoute) Resolve(request aitransport.RouteRequest) (*url.URL, error) {
+	if request.Operation() != responsesOperation {
+		return nil, fmt.Errorf("unsupported Responses operation %q", request.Operation())
+	}
+	target := request.BaseURL()
+	target.Path = strings.TrimRight(target.Path, "/") + "/" + responsesOperation
+	target.RawPath = ""
+	return &target, nil
+}
+
+// WithRequestTransport installs a trusted provider transport adapter for the
+// Responses core. The configured route is validated before middleware runs.
+// Supplying this option never exposes the adapter to settings or JavaScript.
+func WithRequestTransport(config RequestTransport) EngineOption {
+	return func(e *Engine) {
+		copied := RequestTransport{
+			Provider:             config.Provider,
+			RouteResolver:        config.RouteResolver,
+			HeaderRules:          append([]aitransport.HeaderRule(nil), config.HeaderRules...),
+			Middlewares:          append([]aitransport.Middleware(nil), config.Middlewares...),
+			DisableDefaultBearer: config.DisableDefaultBearer,
+		}
+		e.requestTransport = &copied
+	}
+}
+
+func (e *Engine) newRequestTransport(api *settings.APISettings) (responsesRequestTransport, error) {
+	baseURL, err := url.Parse(responsesBaseURL(api))
+	if err != nil {
+		return responsesRequestTransport{}, errors.New("parse Responses base URL")
+	}
+
+	config := RequestTransport{
+		Provider:      string(responsesAPIType(e.settings)),
+		RouteResolver: responsesRoute{},
+	}
+	if e.requestTransport != nil {
+		config = *e.requestTransport
+		config.HeaderRules = append([]aitransport.HeaderRule(nil), e.requestTransport.HeaderRules...)
+		config.Middlewares = append([]aitransport.Middleware(nil), e.requestTransport.Middlewares...)
+	}
+	if strings.TrimSpace(config.Provider) == "" {
+		return responsesRequestTransport{}, errors.New("responses request transport provider is required")
+	}
+	if config.RouteResolver == nil {
+		return responsesRequestTransport{}, errors.New("responses request transport route resolver is required")
+	}
+
+	request, err := aitransport.ResolveAndValidate(
+		config.Provider,
+		responsesOperation,
+		baseURL,
+		config.RouteResolver,
+		func(target *url.URL) error {
+			return security.ValidateOutboundURL(target.String(), responsesOutboundURLOptions(api))
+		},
+	)
+	if err != nil {
+		return responsesRequestTransport{}, fmt.Errorf("invalid Responses URL: %w", err)
+	}
+
+	rules := append([]aitransport.HeaderRule(nil), config.HeaderRules...)
+	middlewares := append([]aitransport.Middleware(nil), config.Middlewares...)
+	if !config.DisableDefaultBearer {
+		var err error
+		rules, err = appendResponsesHeaderRule(rules, aitransport.HeaderRule{Name: "Authorization", Sensitive: true})
+		if err != nil {
+			return responsesRequestTransport{}, err
+		}
+		credentialRequest := credentials.Request{Provider: string(responsesAPIType(e.settings)), BaseURL: responsesBaseURL(api)}
+		middlewares = append([]aitransport.Middleware{
+			&responsesBearerMiddleware{
+				api:               api,
+				apiType:           responsesAPIType(e.settings),
+				source:            e.bearerTokenSource,
+				credentialRequest: credentialRequest,
+			},
+		}, middlewares...)
+	}
+
+	chain, err := aitransport.NewChain(middlewares...)
+	if err != nil {
+		return responsesRequestTransport{}, fmt.Errorf("build Responses middleware chain: %w", err)
+	}
+	return responsesRequestTransport{request: request, chain: chain, headerRules: rules}, nil
+}
+
+func appendResponsesHeaderRule(rules []aitransport.HeaderRule, rule aitransport.HeaderRule) ([]aitransport.HeaderRule, error) {
+	canonicalName := http.CanonicalHeaderKey(strings.TrimSpace(rule.Name))
+	for _, existing := range rules {
+		if http.CanonicalHeaderKey(strings.TrimSpace(existing.Name)) != canonicalName {
+			continue
+		}
+		if existing.Sensitive != rule.Sensitive {
+			return nil, fmt.Errorf("responses request transport header %q has conflicting sensitivity", canonicalName)
+		}
+		return rules, nil
+	}
+	return append(rules, rule), nil
+}
+
+type responsesBearerMiddleware struct {
+	api               *settings.APISettings
+	apiType           types.ApiType
+	source            credentials.BearerTokenSource
+	credentialRequest credentials.Request
+}
+
+type responsesBearerAttempt struct {
+	token       string
+	replacement string
+}
+
+func (m *responsesBearerMiddleware) BeforeRequest(ctx context.Context, _ aitransport.RequestContext, previous aitransport.Attempt, headers aitransport.HeaderWriter) (aitransport.Attempt, error) {
+	if prior, ok := previous.(*responsesBearerAttempt); ok && strings.TrimSpace(prior.replacement) != "" {
+		if err := headers.Set("Authorization", "Bearer "+prior.replacement); err != nil {
+			return nil, err
+		}
+		return &responsesBearerAttempt{token: prior.replacement}, nil
+	}
+	if previous != nil {
+		return nil, errors.New("responses bearer middleware received incompatible prior attempt")
+	}
+
+	token, err := resolveResponsesBearerToken(ctx, m.api, m.apiType, m.source)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(token) == "" {
+		return &responsesBearerAttempt{}, nil
+	}
+	if err := headers.Set("Authorization", "Bearer "+token); err != nil {
+		return nil, err
+	}
+	return &responsesBearerAttempt{token: token}, nil
+}
+
+func (m *responsesBearerMiddleware) AfterResponse(ctx context.Context, _ aitransport.RequestContext, attempt any, response aitransport.ResponseMetadata) (aitransport.ResponseDecision, error) {
+	if response.StatusCode != http.StatusUnauthorized || response.StreamStarted || !response.RetryEligible {
+		return aitransport.Continue, nil
+	}
+	source, ok := m.source.(credentials.UnauthorizedBearerTokenSource)
+	if !ok {
+		return aitransport.Continue, nil
+	}
+	bearerAttempt, ok := attempt.(*responsesBearerAttempt)
+	if !ok || strings.TrimSpace(bearerAttempt.token) == "" {
+		return aitransport.Continue, nil
+	}
+	replacement, err := source.BearerTokenAfterUnauthorized(ctx, m.credentialRequest, bearerAttempt.token)
+	if err != nil {
+		return aitransport.Continue, errors.New("refresh bearer credential after provider unauthorized")
+	}
+	if strings.TrimSpace(replacement) == "" {
+		return aitransport.Continue, errors.New("refreshed bearer credential is empty after provider unauthorized")
+	}
+	bearerAttempt.replacement = replacement
+	return aitransport.Retry, nil
+}
+
+func redactedResponsesRequestForDebug(request *http.Request, headers *aitransport.HeaderSet) *http.Request {
+	if request == nil || headers == nil {
+		return request
+	}
+	redacted := request.Clone(request.Context())
+	redacted.Header = headers.RedactedCopy()
+	return redacted
+}

--- a/pkg/steps/ai/openai_responses/streaming.go
+++ b/pkg/steps/ai/openai_responses/streaming.go
@@ -13,12 +13,12 @@ import (
 	"github.com/go-go-golems/geppetto/pkg/events"
 	"github.com/go-go-golems/geppetto/pkg/inference/engine"
 	gepsession "github.com/go-go-golems/geppetto/pkg/inference/session"
-	"github.com/go-go-golems/geppetto/pkg/steps/ai/credentials"
+	aitransport "github.com/go-go-golems/geppetto/pkg/steps/ai/transport"
 	"github.com/go-go-golems/geppetto/pkg/turns"
 )
 
-func (e *Engine) runStreamingInference(ctx context.Context, t *turns.Turn, httpClient *http.Client, url string, body []byte, apiKey string, bearerTokenSource credentials.BearerTokenSource, credentialRequest credentials.Request, metadata events.EventMetadata, tap engine.DebugTap, startTime time.Time, reqBody responsesRequest) (*turns.Turn, error) {
-	resp, err := openResponsesStream(ctx, httpClient, url, body, apiKey, bearerTokenSource, credentialRequest, tap)
+func (e *Engine) runStreamingInference(ctx context.Context, t *turns.Turn, httpClient *http.Client, requestTransport responsesRequestTransport, body []byte, metadata events.EventMetadata, tap engine.DebugTap, startTime time.Time, reqBody responsesRequest) (*turns.Turn, error) {
+	resp, err := openResponsesStream(ctx, httpClient, requestTransport, body, tap)
 	if err != nil {
 		return nil, err
 	}
@@ -145,26 +145,22 @@ func (e *Engine) completeResponsesStream(ctx context.Context, t *turns.Turn, met
 	return t, nil
 }
 
-func openResponsesStream(ctx context.Context, httpClient *http.Client, url string, body []byte, apiKey string, bearerTokenSource credentials.BearerTokenSource, credentialRequest credentials.Request, tap engine.DebugTap) (*http.Response, error) {
+func openResponsesStream(ctx context.Context, httpClient *http.Client, requestTransport responsesRequestTransport, body []byte, tap engine.DebugTap) (*http.Response, error) {
+	var previousAttempt aitransport.AttemptState
 	for attempt := 0; ; attempt++ {
-		resp, err := openResponsesRequest(ctx, httpClient, url, body, apiKey, tap)
+		resp, attempts, err := openResponsesRequest(ctx, httpClient, requestTransport, body, previousAttempt, tap)
 		if err != nil {
 			return nil, err
 		}
-		if resp.StatusCode == http.StatusUnauthorized && attempt == 0 {
-			source, ok := bearerTokenSource.(credentials.UnauthorizedBearerTokenSource)
-			if ok {
-				_ = resp.Body.Close()
-				token, err := source.BearerTokenAfterUnauthorized(ctx, credentialRequest, apiKey)
-				if err != nil {
-					return nil, fmt.Errorf("refresh bearer credential after provider unauthorized")
-				}
-				if strings.TrimSpace(token) == "" {
-					return nil, fmt.Errorf("refreshed bearer credential is empty after provider unauthorized")
-				}
-				apiKey = token
-				continue
-			}
+		decision, err := requestTransport.chain.AfterResponse(ctx, requestTransport.request, attempts, aitransport.ResponseMetadata{StatusCode: resp.StatusCode, RetryEligible: attempt == 0})
+		if err != nil {
+			_ = resp.Body.Close()
+			return nil, err
+		}
+		if decision == aitransport.Retry && attempt == 0 {
+			_ = resp.Body.Close()
+			previousAttempt = attempts
+			continue
 		}
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 			return resp, nil
@@ -173,32 +169,38 @@ func openResponsesStream(ctx context.Context, httpClient *http.Client, url strin
 	}
 }
 
-func openResponsesRequest(ctx context.Context, httpClient *http.Client, url string, body []byte, apiKey string, tap engine.DebugTap) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(body)))
+func openResponsesRequest(ctx context.Context, httpClient *http.Client, requestTransport responsesRequestTransport, body []byte, previousAttempt aitransport.AttemptState, tap engine.DebugTap) (*http.Response, aitransport.AttemptState, error) {
+	resolvedURL := requestTransport.request.URL()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resolvedURL.String(), strings.NewReader(string(body)))
 	if err != nil {
-		return nil, err
+		return nil, aitransport.AttemptState{}, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "text/event-stream")
-	if apiKey != "" {
-		req.Header.Set("Authorization", "Bearer "+apiKey)
+	headers, err := aitransport.NewHeaderSet(req.Header, requestTransport.headerRules...)
+	if err != nil {
+		return nil, aitransport.AttemptState{}, err
+	}
+	attempts, err := requestTransport.chain.BeforeRequest(ctx, requestTransport.request, previousAttempt, headers)
+	if err != nil {
+		return nil, aitransport.AttemptState{}, err
 	}
 
 	log.Trace().Msg("Responses: initiating HTTP request (streaming)")
 	if tap != nil {
-		tap.OnHTTP(req, body)
+		tap.OnHTTP(redactedResponsesRequestForDebug(req, headers), body)
 	}
-	// #nosec G704 -- URL is validated above with ValidateOutboundURL.
+	// #nosec G704 -- URL is validated above with transport.ResolveAndValidate.
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		log.Debug().Err(err).Msg("Responses: HTTP request failed")
 		if tap != nil {
 			tap.OnProviderObject("http.error", map[string]any{"error": err.Error()})
 		}
-		return nil, err
+		return nil, aitransport.AttemptState{}, err
 	}
 	log.Debug().Int("status", resp.StatusCode).Str("content_type", resp.Header.Get("Content-Type")).Msg("Responses: HTTP response received")
-	return resp, nil
+	return resp, attempts, nil
 }
 
 func responsesHTTPError(resp *http.Response, tap engine.DebugTap) error {

--- a/pkg/steps/ai/providers/openaicodex/codex.go
+++ b/pkg/steps/ai/providers/openaicodex/codex.go
@@ -1,0 +1,185 @@
+// Package openaicodex provides the trusted route and credential middleware used
+// to run the OpenAI Responses core against the Codex-specific transport.
+package openaicodex
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/credentials"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/openai_responses"
+	aitransport "github.com/go-go-golems/geppetto/pkg/steps/ai/transport"
+)
+
+const (
+	// Provider is the provider identity supplied to the shared Responses core.
+	Provider = "openai-codex"
+	// ResponsesPath is the Codex-specific Responses endpoint path.
+	ResponsesPath     = "/codex/responses"
+	defaultOriginator = "geppetto"
+	responsesBeta     = "responses=experimental"
+)
+
+// Credential is private runtime authentication material for a Codex request.
+// It must not be serialized into settings, emitted to JavaScript, or formatted
+// into errors.
+type Credential struct {
+	BearerToken string
+	AccountID   string
+}
+
+// Source returns a current Codex credential for an already validated target.
+type Source interface {
+	Credential(context.Context, credentials.Request) (Credential, error)
+}
+
+// UnauthorizedSource optionally supplies a replacement credential after a
+// rejected pre-stream request. The shared Responses core permits one replay.
+type UnauthorizedSource interface {
+	Source
+	CredentialAfterUnauthorized(context.Context, credentials.Request, Credential) (Credential, error)
+}
+
+// Options identifies the application to the provider. Values are Go-only
+// engine configuration, never profile or JavaScript configuration.
+type Options struct {
+	Originator string
+	UserAgent  string
+}
+
+func (o Options) normalized() Options {
+	o.Originator = strings.TrimSpace(o.Originator)
+	if o.Originator == "" {
+		o.Originator = defaultOriginator
+	}
+	o.UserAgent = strings.TrimSpace(o.UserAgent)
+	return o
+}
+
+// RequestTransport returns the Codex adapter for openai_responses.NewEngine.
+// It disables the core's ordinary bearer middleware so Codex headers can only
+// be supplied by a typed Codex source.
+func RequestTransport(source Source, options Options) (openai_responses.RequestTransport, error) {
+	if source == nil {
+		return openai_responses.RequestTransport{}, errors.New("codex credential source is required")
+	}
+	options = options.normalized()
+	middleware := &credentialMiddleware{
+		source: source,
+		request: credentials.Request{
+			Provider: Provider,
+			BaseURL:  "https://chatgpt.com/backend-api",
+		},
+		originator: options.Originator,
+		userAgent:  options.UserAgent,
+	}
+	return openai_responses.RequestTransport{
+		Provider:             Provider,
+		RouteResolver:        Route{},
+		DisableDefaultBearer: true,
+		HeaderRules: []aitransport.HeaderRule{
+			{Name: "Authorization", Sensitive: true},
+			{Name: "chatgpt-account-id", Sensitive: true},
+			{Name: "originator"},
+			{Name: "OpenAI-Beta"},
+			{Name: "User-Agent"},
+		},
+		Middlewares: []aitransport.Middleware{middleware},
+	}, nil
+}
+
+// Route resolves the fixed Codex response path without accepting a
+// profile-configured suffix.
+type Route struct{}
+
+func (Route) Resolve(request aitransport.RouteRequest) (*url.URL, error) {
+	if request.Operation() != "responses" {
+		return nil, fmt.Errorf("unsupported Codex operation %q", request.Operation())
+	}
+	target := request.BaseURL()
+	target.Path = strings.TrimRight(target.Path, "/") + ResponsesPath
+	target.RawPath = ""
+	return &target, nil
+}
+
+type credentialMiddleware struct {
+	source     Source
+	request    credentials.Request
+	originator string
+	userAgent  string
+}
+
+type attempt struct {
+	credential  Credential
+	replacement *Credential
+}
+
+func (m *credentialMiddleware) BeforeRequest(ctx context.Context, _ aitransport.RequestContext, previous any, headers aitransport.HeaderWriter) (any, error) {
+	credential, err := m.credentialForAttempt(ctx, previous)
+	if err != nil {
+		return nil, err
+	}
+	if err := headers.Set("Authorization", "Bearer "+credential.BearerToken); err != nil {
+		return nil, err
+	}
+	if err := headers.Set("chatgpt-account-id", credential.AccountID); err != nil {
+		return nil, err
+	}
+	if err := headers.Set("originator", m.originator); err != nil {
+		return nil, err
+	}
+	if err := headers.Set("OpenAI-Beta", responsesBeta); err != nil {
+		return nil, err
+	}
+	if m.userAgent != "" {
+		if err := headers.Set("User-Agent", m.userAgent); err != nil {
+			return nil, err
+		}
+	}
+	return &attempt{credential: credential}, nil
+}
+
+func (m *credentialMiddleware) credentialForAttempt(ctx context.Context, previous any) (Credential, error) {
+	if prior, ok := previous.(*attempt); ok && prior.replacement != nil {
+		return *prior.replacement, nil
+	}
+	if previous != nil {
+		return Credential{}, errors.New("codex middleware received incompatible prior attempt")
+	}
+	credential, err := m.source.Credential(ctx, m.request)
+	if err != nil {
+		return Credential{}, errors.New("codex credential unavailable")
+	}
+	if !credential.usable() {
+		return Credential{}, errors.New("codex credential unavailable")
+	}
+	return credential, nil
+}
+
+func (m *credentialMiddleware) AfterResponse(ctx context.Context, _ aitransport.RequestContext, previous any, response aitransport.ResponseMetadata) (aitransport.ResponseDecision, error) {
+	if response.StatusCode != http.StatusUnauthorized || response.StreamStarted || !response.RetryEligible {
+		return aitransport.Continue, nil
+	}
+	source, ok := m.source.(UnauthorizedSource)
+	if !ok {
+		return aitransport.Continue, nil
+	}
+	prior, ok := previous.(*attempt)
+	if !ok || !prior.credential.usable() {
+		return aitransport.Continue, nil
+	}
+	replacement, err := source.CredentialAfterUnauthorized(ctx, m.request, prior.credential)
+	if err != nil || !replacement.usable() {
+		return aitransport.Continue, errors.New("refresh Codex credential after provider unauthorized")
+	}
+	prior.replacement = &replacement
+	return aitransport.Retry, nil
+}
+
+func (c Credential) usable() bool {
+	return strings.TrimSpace(c.BearerToken) != "" && strings.TrimSpace(c.AccountID) != ""
+}

--- a/pkg/steps/ai/providers/openaicodex/codex.go
+++ b/pkg/steps/ai/providers/openaicodex/codex.go
@@ -20,6 +20,8 @@ const (
 	Provider = "openai-codex"
 	// ResponsesPath is the Codex-specific Responses endpoint path.
 	ResponsesPath     = "/codex/responses"
+	codexHost         = "chatgpt.com"
+	codexBasePath     = "/backend-api"
 	defaultOriginator = "geppetto"
 	responsesBeta     = "responses=experimental"
 )
@@ -92,18 +94,35 @@ func RequestTransport(source Source, options Options) (openai_responses.RequestT
 	}, nil
 }
 
-// Route resolves the fixed Codex response path without accepting a
-// profile-configured suffix.
+// Route resolves the fixed Codex response path and accepts only the canonical
+// ChatGPT Codex origin. This prevents a profile-configured URL from redirecting
+// subscription credentials to an arbitrary HTTPS host.
 type Route struct{}
 
 func (Route) Resolve(request aitransport.RouteRequest) (*url.URL, error) {
 	if request.Operation() != "responses" {
 		return nil, fmt.Errorf("unsupported Codex operation %q", request.Operation())
 	}
-	target := request.BaseURL()
-	target.Path = strings.TrimRight(target.Path, "/") + ResponsesPath
-	target.RawPath = ""
-	return &target, nil
+	base := request.BaseURL()
+	if err := validateBaseURL(base); err != nil {
+		return nil, err
+	}
+	base.Path = codexBasePath + ResponsesPath
+	base.RawPath = ""
+	base.RawQuery = ""
+	base.Fragment = ""
+	base.ForceQuery = false
+	return &base, nil
+}
+
+func validateBaseURL(base url.URL) error {
+	if base.Scheme != "https" || base.Host != codexHost || base.User != nil || base.Opaque != "" || base.RawPath != "" || base.RawQuery != "" || base.Fragment != "" || base.ForceQuery {
+		return errors.New("codex base URL must be https://chatgpt.com/backend-api")
+	}
+	if strings.TrimRight(base.Path, "/") != codexBasePath {
+		return errors.New("codex base URL must be https://chatgpt.com/backend-api")
+	}
+	return nil
 }
 
 type credentialMiddleware struct {

--- a/pkg/steps/ai/providers/openaicodex/codex_test.go
+++ b/pkg/steps/ai/providers/openaicodex/codex_test.go
@@ -61,6 +61,55 @@ func TestRoute_UsesFixedCodexResponsePath(t *testing.T) {
 	}
 }
 
+func TestRoute_RejectsNonCanonicalCredentialTargets(t *testing.T) {
+	for _, raw := range []string{
+		"https://collector.example/backend-api",
+		"http://chatgpt.com/backend-api",
+		"https://chatgpt.com/other",
+		"https://chatgpt.com/backend-api?redirect=collector.example",
+		"https://chatgpt.com:443/backend-api",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			_, err := aitransport.ResolveAndValidate(
+				Provider, "responses", mustURL(t, raw), Route{}, func(*url.URL) error { return nil },
+			)
+			if err == nil {
+				t.Fatalf("ResolveAndValidate accepted non-canonical target %q", raw)
+			}
+		})
+	}
+}
+
+func TestResponsesCore_RejectsNonCanonicalTargetBeforeCredentialLookup(t *testing.T) {
+	var credentialLookups int
+	source := sourceFunc{
+		credential: func(context.Context, credentials.Request) (Credential, error) {
+			credentialLookups++
+			return Credential{BearerToken: "must-not-be-requested", AccountID: "must-not-be-requested"}, nil
+		},
+	}
+	adapter, err := RequestTransport(source, Options{})
+	if err != nil {
+		t.Fatalf("RequestTransport: %v", err)
+	}
+	model := "codex-test"
+	engine, err := openai_responses.NewEngine(&settings.InferenceSettings{
+		API:    &settings.APISettings{BaseUrls: map[string]string{"open-responses-base-url": "https://collector.example/backend-api"}},
+		Chat:   &settings.ChatSettings{Engine: &model},
+		Client: &settings.ClientSettings{HTTPClient: &http.Client{}},
+	}, openai_responses.WithRequestTransport(adapter))
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	_, err = engine.RunInference(context.Background(), &turns.Turn{Blocks: []turns.Block{turns.NewUserTextBlock("ping")}})
+	if err == nil {
+		t.Fatal("RunInference unexpectedly accepted non-canonical Codex target")
+	}
+	if credentialLookups != 0 {
+		t.Fatalf("credential lookups = %d, want 0", credentialLookups)
+	}
+}
+
 func TestResponsesCore_UsesCodexRouteHeadersAndOneRefreshReplay(t *testing.T) {
 	var requests, refreshes int
 	source := sourceFunc{

--- a/pkg/steps/ai/providers/openaicodex/codex_test.go
+++ b/pkg/steps/ai/providers/openaicodex/codex_test.go
@@ -1,0 +1,200 @@
+package openaicodex
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/credentials"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/openai_responses"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/settings"
+	aitransport "github.com/go-go-golems/geppetto/pkg/steps/ai/transport"
+	"github.com/go-go-golems/geppetto/pkg/turns"
+)
+
+type sourceFunc struct {
+	credential  func(context.Context, credentials.Request) (Credential, error)
+	replacement func(context.Context, credentials.Request, Credential) (Credential, error)
+}
+
+func (s sourceFunc) Credential(ctx context.Context, request credentials.Request) (Credential, error) {
+	return s.credential(ctx, request)
+}
+
+func (s sourceFunc) CredentialAfterUnauthorized(ctx context.Context, request credentials.Request, rejected Credential) (Credential, error) {
+	return s.replacement(ctx, request, rejected)
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse URL: %v", err)
+	}
+	return parsed
+}
+
+func TestRoute_UsesFixedCodexResponsePath(t *testing.T) {
+	target, err := (Route{}).Resolve(aitransport.RouteRequest{})
+	if err == nil || target != nil {
+		t.Fatal("route accepted an empty operation")
+	}
+	base := mustURL(t, "https://chatgpt.com/backend-api")
+	request, err := aitransport.ResolveAndValidate(
+		Provider, "responses", base, Route{}, func(*url.URL) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("ResolveAndValidate: %v", err)
+	}
+	resolved := request.URL()
+	if got, want := resolved.Path, "/backend-api/codex/responses"; got != want {
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+}
+
+func TestResponsesCore_UsesCodexRouteHeadersAndOneRefreshReplay(t *testing.T) {
+	var requests, refreshes int
+	source := sourceFunc{
+		credential: func(context.Context, credentials.Request) (Credential, error) {
+			return Credential{BearerToken: "first-token", AccountID: "first-account"}, nil
+		},
+		replacement: func(context.Context, credentials.Request, Credential) (Credential, error) {
+			refreshes++
+			return Credential{BearerToken: "replacement-token", AccountID: "replacement-account"}, nil
+		},
+	}
+	adapter, err := RequestTransport(source, Options{Originator: "test-originator"})
+	if err != nil {
+		t.Fatalf("RequestTransport: %v", err)
+	}
+	client := &http.Client{Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+		requests++
+		if got, want := request.URL.Path, "/backend-api/codex/responses"; got != want {
+			t.Fatalf("path = %q, want %q", got, want)
+		}
+		if got := request.Header.Get("originator"); got != "test-originator" {
+			t.Fatalf("originator = %q", got)
+		}
+		if got := request.Header.Get("OpenAI-Beta"); got != responsesBeta {
+			t.Fatalf("OpenAI-Beta = %q", got)
+		}
+		status := http.StatusUnauthorized
+		body := `{"error":"expired"}`
+		if requests == 1 {
+			if got := request.Header.Get("Authorization"); got != "Bearer first-token" {
+				t.Fatalf("first authorization = %q", got)
+			}
+			if got := request.Header.Get("chatgpt-account-id"); got != "first-account" {
+				t.Fatalf("first account = %q", got)
+			}
+		} else {
+			status = http.StatusOK
+			body = "data: [DONE]\\n\\n"
+			if got := request.Header.Get("Authorization"); got != "Bearer replacement-token" {
+				t.Fatalf("replacement authorization = %q", got)
+			}
+			if got := request.Header.Get("chatgpt-account-id"); got != "replacement-account" {
+				t.Fatalf("replacement account = %q", got)
+			}
+		}
+		return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(body)), Request: request}, nil
+	})}
+	model := "codex-test"
+	engine, err := openai_responses.NewEngine(&settings.InferenceSettings{
+		API:    &settings.APISettings{BaseUrls: map[string]string{"open-responses-base-url": "https://chatgpt.com/backend-api"}},
+		Chat:   &settings.ChatSettings{Engine: &model},
+		Client: &settings.ClientSettings{HTTPClient: client},
+	}, openai_responses.WithRequestTransport(adapter))
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	_, err = engine.RunInference(context.Background(), &turns.Turn{Blocks: []turns.Block{turns.NewUserTextBlock("ping")}})
+	if err != nil {
+		t.Fatalf("RunInference: %v", err)
+	}
+	if requests != 2 || refreshes != 1 {
+		t.Fatalf("requests=%d refreshes=%d, want 2/1", requests, refreshes)
+	}
+}
+
+func TestRequestTransport_InjectsOnlyCodexHeadersAndReplaysTypedReplacement(t *testing.T) {
+	var refreshes int
+	source := sourceFunc{
+		credential: func(_ context.Context, request credentials.Request) (Credential, error) {
+			if request.Provider != Provider || request.BaseURL != "https://chatgpt.com/backend-api" {
+				t.Fatalf("credential request = %#v", request)
+			}
+			return Credential{BearerToken: "first-token", AccountID: "first-account"}, nil
+		},
+		replacement: func(_ context.Context, _ credentials.Request, rejected Credential) (Credential, error) {
+			refreshes++
+			if rejected.BearerToken != "first-token" || rejected.AccountID != "first-account" {
+				t.Fatalf("rejected credential = %#v", rejected)
+			}
+			return Credential{BearerToken: "replacement-token", AccountID: "replacement-account"}, nil
+		},
+	}
+	config, err := RequestTransport(source, Options{Originator: "test-originator", UserAgent: "test-agent"})
+	if err != nil {
+		t.Fatalf("RequestTransport: %v", err)
+	}
+	if !config.DisableDefaultBearer {
+		t.Fatal("Codex transport did not disable ordinary bearer middleware")
+	}
+	base := mustURL(t, "https://chatgpt.com/backend-api")
+	request, err := aitransport.ResolveAndValidate(config.Provider, "responses", base, config.RouteResolver, func(*url.URL) error { return nil })
+	if err != nil {
+		t.Fatalf("ResolveAndValidate: %v", err)
+	}
+	chain, err := aitransport.NewChain(config.Middlewares...)
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+	firstHeaders, err := aitransport.NewHeaderSet(make(http.Header), config.HeaderRules...)
+	if err != nil {
+		t.Fatalf("NewHeaderSet: %v", err)
+	}
+	firstAttempt, err := chain.BeforeRequest(context.Background(), request, aitransport.AttemptState{}, firstHeaders)
+	if err != nil {
+		t.Fatalf("BeforeRequest first: %v", err)
+	}
+	if got := firstHeaders.RedactedCopy().Get("Authorization"); got != "<redacted>" {
+		t.Fatalf("redacted authorization = %q", got)
+	}
+	if got := firstHeaders.RedactedCopy().Get("chatgpt-account-id"); got != "<redacted>" {
+		t.Fatalf("redacted account = %q", got)
+	}
+	if got := firstHeaders.RedactedCopy().Get("originator"); got != "test-originator" {
+		t.Fatalf("originator = %q", got)
+	}
+	decision, err := chain.AfterResponse(context.Background(), request, firstAttempt, aitransport.ResponseMetadata{StatusCode: http.StatusUnauthorized, RetryEligible: true})
+	if err != nil || decision != aitransport.Retry {
+		t.Fatalf("AfterResponse = %v, %v", decision, err)
+	}
+	secondHeaders, err := aitransport.NewHeaderSet(make(http.Header), config.HeaderRules...)
+	if err != nil {
+		t.Fatalf("NewHeaderSet second: %v", err)
+	}
+	_, err = chain.BeforeRequest(context.Background(), request, firstAttempt, secondHeaders)
+	if err != nil {
+		t.Fatalf("BeforeRequest replay: %v", err)
+	}
+	if got := secondHeaders.RedactedCopy().Get("Authorization"); got != "<redacted>" {
+		t.Fatalf("replay debug authorization = %q", got)
+	}
+	if got := secondHeaders.RedactedCopy().Get("chatgpt-account-id"); got != "<redacted>" {
+		t.Fatalf("replay debug account = %q", got)
+	}
+	if refreshes != 1 {
+		t.Fatalf("refreshes = %d, want 1", refreshes)
+	}
+}

--- a/pkg/steps/ai/providers/umans/umans.go
+++ b/pkg/steps/ai/providers/umans/umans.go
@@ -1,0 +1,21 @@
+// Package umans provides the verified Umans Anthropic-Messages authentication
+// binding. It is API-key based, not renewable OAuth.
+package umans
+
+import (
+	"errors"
+
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/claude"
+	"github.com/go-go-golems/geppetto/pkg/steps/ai/credentials"
+)
+
+// ClaudeOptions returns Go-only Claude engine options for an Umans API key.
+// The key is sent in the verified dual-auth form by the Claude API client and
+// never becomes an inference setting or JavaScript value.
+func ClaudeOptions(apiKey string) ([]claude.EngineOption, error) {
+	source, err := credentials.NewStaticBearerTokenSource(apiKey)
+	if err != nil {
+		return nil, errors.New("umans API key is required")
+	}
+	return []claude.EngineOption{claude.WithBearerTokenSource(source)}, nil
+}

--- a/pkg/steps/ai/providers/umans/umans_test.go
+++ b/pkg/steps/ai/providers/umans/umans_test.go
@@ -1,0 +1,13 @@
+package umans
+
+import "testing"
+
+func TestClaudeOptionsRequireKey(t *testing.T) {
+	if _, err := ClaudeOptions(""); err == nil {
+		t.Fatal("empty Umans key unexpectedly accepted")
+	}
+	options, err := ClaudeOptions("test-key")
+	if err != nil || len(options) != 1 {
+		t.Fatalf("ClaudeOptions = %d, %v", len(options), err)
+	}
+}

--- a/pkg/steps/ai/transport/transport.go
+++ b/pkg/steps/ai/transport/transport.go
@@ -1,0 +1,298 @@
+// Package transport provides restricted, Go-only extension points for provider
+// request routing, credential header injection, and pre-stream response
+// classification. It is intentionally separate from inference middleware: these
+// hooks operate inside a provider engine after it has selected its protocol.
+package transport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// RouteRequest is the non-secret input supplied to a trusted provider route
+// resolver. BaseURL returns a copy, so a resolver cannot mutate caller state.
+type RouteRequest struct {
+	baseURL   url.URL
+	operation string
+}
+
+// BaseURL returns a copy of the configured provider base URL.
+func (r RouteRequest) BaseURL() url.URL { return r.baseURL }
+
+// Operation identifies the engine operation being routed, for example
+// "responses" or "messages".
+func (r RouteRequest) Operation() string { return r.operation }
+
+// RouteResolver maps an engine operation to a provider endpoint. It is
+// installed through trusted Go engine options, never profile settings or
+// JavaScript values. The returned URL is validated by ResolveAndValidate before
+// middleware can acquire credential material.
+type RouteResolver interface {
+	Resolve(RouteRequest) (*url.URL, error)
+}
+
+// URLValidator validates a fully resolved outbound URL.
+type URLValidator func(*url.URL) error
+
+// RequestContext is the non-secret, read-only context passed to request and
+// response middleware. It is created only by ResolveAndValidate after the
+// final URL has passed the engine's outbound URL policy.
+type RequestContext struct {
+	provider  string
+	operation string
+	url       url.URL
+}
+
+// Provider identifies the trusted provider adapter installed by the engine.
+func (r RequestContext) Provider() string { return r.provider }
+
+// Operation identifies the engine operation, for example "responses".
+func (r RequestContext) Operation() string { return r.operation }
+
+// URL returns a copy of the already validated final outbound URL.
+func (r RequestContext) URL() url.URL { return r.url }
+
+// ResolveAndValidate resolves a provider route and validates its final URL.
+// It must run before an engine invokes Middleware.BeforeRequest.
+func ResolveAndValidate(provider, operation string, baseURL *url.URL, resolver RouteResolver, validate URLValidator) (RequestContext, error) {
+	if strings.TrimSpace(provider) == "" {
+		return RequestContext{}, errors.New("transport provider is required")
+	}
+	if strings.TrimSpace(operation) == "" {
+		return RequestContext{}, errors.New("transport operation is required")
+	}
+	if baseURL == nil {
+		return RequestContext{}, errors.New("transport base URL is required")
+	}
+	if resolver == nil {
+		return RequestContext{}, errors.New("transport route resolver is required")
+	}
+	if validate == nil {
+		return RequestContext{}, errors.New("transport URL validator is required")
+	}
+
+	target, err := resolver.Resolve(RouteRequest{baseURL: *baseURL, operation: operation})
+	if err != nil {
+		return RequestContext{}, fmt.Errorf("resolve provider route: %w", err)
+	}
+	if target == nil {
+		return RequestContext{}, errors.New("provider route resolver returned no URL")
+	}
+	resolved := *target
+	if err := validate(&resolved); err != nil {
+		return RequestContext{}, fmt.Errorf("validate provider route: %w", err)
+	}
+	return RequestContext{provider: provider, operation: operation, url: resolved}, nil
+}
+
+// HeaderRule declares one provider-approved request header. Sensitive header
+// values are redacted from copies used for diagnostics.
+type HeaderRule struct {
+	Name      string
+	Sensitive bool
+}
+
+var restrictedHeaders = map[string]struct{}{
+	"Host":              {},
+	"Content-Length":    {},
+	"Connection":        {},
+	"Transfer-Encoding": {},
+	"Trailer":           {},
+	"Te":                {},
+	"Upgrade":           {},
+	"Proxy-Connection":  {},
+}
+
+// HeaderWriter permits middleware to set only engine-declared request headers.
+// It has no access to the URL, request body, host, or response stream.
+type HeaderWriter interface {
+	Set(name, value string) error
+}
+
+// HeaderSet owns one request's middleware-controlled headers. Engine code keeps
+// the concrete value so it can obtain a redacted diagnostic copy after middleware
+// applies its changes.
+type HeaderSet struct {
+	target    http.Header
+	rules     map[string]HeaderRule
+	written   map[string]string
+	sensitive map[string]struct{}
+}
+
+// NewHeaderSet binds a non-nil target header map to an explicit provider header
+// policy. Duplicate, empty, and framing/host header rules are rejected.
+func NewHeaderSet(target http.Header, rules ...HeaderRule) (*HeaderSet, error) {
+	if target == nil {
+		return nil, errors.New("transport header target is required")
+	}
+	set := &HeaderSet{
+		target:    target,
+		rules:     make(map[string]HeaderRule, len(rules)),
+		written:   make(map[string]string, len(rules)),
+		sensitive: make(map[string]struct{}, len(rules)),
+	}
+	for _, rule := range rules {
+		name := http.CanonicalHeaderKey(strings.TrimSpace(rule.Name))
+		if name == "" {
+			return nil, errors.New("transport header rule has no name")
+		}
+		if _, prohibited := restrictedHeaders[name]; prohibited {
+			return nil, fmt.Errorf("transport header rule %q is prohibited", name)
+		}
+		if _, exists := set.rules[name]; exists {
+			return nil, fmt.Errorf("transport header rule %q is duplicated", name)
+		}
+		rule.Name = name
+		set.rules[name] = rule
+		if rule.Sensitive {
+			set.sensitive[name] = struct{}{}
+		}
+	}
+	return set, nil
+}
+
+// Set writes one approved header. A second middleware cannot silently override
+// a different value written by an earlier middleware. Values containing CR/LF
+// are rejected without including the value in the error.
+func (s *HeaderSet) Set(name, value string) error {
+	if s == nil {
+		return errors.New("nil transport header writer")
+	}
+	canonicalName := http.CanonicalHeaderKey(strings.TrimSpace(name))
+	if _, prohibited := restrictedHeaders[canonicalName]; prohibited {
+		return fmt.Errorf("transport header %q is prohibited", canonicalName)
+	}
+	if _, allowed := s.rules[canonicalName]; !allowed {
+		return fmt.Errorf("transport header %q is not allowed", canonicalName)
+	}
+	if strings.ContainsAny(value, "\r\n") {
+		return fmt.Errorf("transport header %q has an invalid value", canonicalName)
+	}
+	if previous, alreadyWritten := s.written[canonicalName]; alreadyWritten && previous != value {
+		return fmt.Errorf("transport header %q was already set by middleware", canonicalName)
+	}
+	s.target.Set(canonicalName, value)
+	s.written[canonicalName] = value
+	return nil
+}
+
+// RedactedCopy returns a header copy suitable for diagnostics. It preserves
+// non-sensitive engine headers and replaces sensitive middleware values.
+func (s *HeaderSet) RedactedCopy() http.Header {
+	if s == nil {
+		return nil
+	}
+	out := s.target.Clone()
+	for name := range s.sensitive {
+		if _, present := out[name]; present {
+			out.Set(name, "<redacted>")
+		}
+	}
+	return out
+}
+
+// Attempt is provider-private state paired with one middleware invocation. The
+// transport core stores it opaquely and must never log or serialize it.
+type Attempt any
+
+// AttemptState is an opaque collection of middleware attempt values.
+type AttemptState struct {
+	attempts []Attempt
+}
+
+// ResponseMetadata is the bounded, body-free response information available to
+// middleware before the engine starts decoding output.
+type ResponseMetadata struct {
+	StatusCode    int
+	StreamStarted bool
+}
+
+// ResponseDecision directs the engine's response handling. The engine, not
+// middleware, enforces whether a retry is eligible and closes any response body.
+type ResponseDecision uint8
+
+const (
+	// Continue tells the core to decode or report the current response.
+	Continue ResponseDecision = iota
+	// Retry requests one core-governed pre-stream replay.
+	Retry
+)
+
+// Middleware is a trusted Go-only provider extension. It may inject declared
+// headers and classify a body-free response; it cannot mutate the final URL or
+// request body, consume a stream, or perform the retry itself.
+type Middleware interface {
+	BeforeRequest(context.Context, RequestContext, HeaderWriter) (Attempt, error)
+	AfterResponse(context.Context, RequestContext, Attempt, ResponseMetadata) (ResponseDecision, error)
+}
+
+// Chain applies request middleware in registration order and response
+// middleware in reverse order, like nested middleware. It leaves retry bounds
+// to the engine core.
+type Chain struct {
+	middlewares []Middleware
+}
+
+// NewChain constructs a trusted middleware chain. Nil middleware is rejected
+// so a partially configured engine fails at construction rather than request
+// time.
+func NewChain(middlewares ...Middleware) (*Chain, error) {
+	chain := &Chain{middlewares: make([]Middleware, len(middlewares))}
+	for i, middleware := range middlewares {
+		if middleware == nil {
+			return nil, fmt.Errorf("transport middleware %d is nil", i)
+		}
+		chain.middlewares[i] = middleware
+	}
+	return chain, nil
+}
+
+// BeforeRequest applies middleware in registration order and returns opaque
+// values for the matching AfterResponse call.
+func (c *Chain) BeforeRequest(ctx context.Context, request RequestContext, headers HeaderWriter) (AttemptState, error) {
+	if c == nil {
+		return AttemptState{}, errors.New("nil transport middleware chain")
+	}
+	if headers == nil {
+		return AttemptState{}, errors.New("transport header writer is required")
+	}
+	attempts := make([]Attempt, 0, len(c.middlewares))
+	for _, middleware := range c.middlewares {
+		attempt, err := middleware.BeforeRequest(ctx, request, headers)
+		if err != nil {
+			return AttemptState{}, err
+		}
+		attempts = append(attempts, attempt)
+	}
+	return AttemptState{attempts: attempts}, nil
+}
+
+// AfterResponse applies middleware in reverse order. Any Retry request is
+// returned to the core; the core decides if replay is still eligible.
+func (c *Chain) AfterResponse(ctx context.Context, request RequestContext, attempts AttemptState, response ResponseMetadata) (ResponseDecision, error) {
+	if c == nil {
+		return Continue, errors.New("nil transport middleware chain")
+	}
+	if len(attempts.attempts) != len(c.middlewares) {
+		return Continue, errors.New("transport middleware attempt state does not match chain")
+	}
+	decision := Continue
+	for i := len(c.middlewares) - 1; i >= 0; i-- {
+		result, err := c.middlewares[i].AfterResponse(ctx, request, attempts.attempts[i], response)
+		if err != nil {
+			return Continue, err
+		}
+		switch result {
+		case Continue:
+		case Retry:
+			decision = Retry
+		default:
+			return Continue, fmt.Errorf("transport middleware returned unknown response decision %d", result)
+		}
+	}
+	return decision, nil
+}

--- a/pkg/steps/ai/transport/transport.go
+++ b/pkg/steps/ai/transport/transport.go
@@ -197,7 +197,7 @@ func (s *HeaderSet) RedactedCopy() http.Header {
 
 // Attempt is provider-private state paired with one middleware invocation. The
 // transport core stores it opaquely and must never log or serialize it.
-type Attempt any
+type Attempt = any
 
 // AttemptState is an opaque collection of middleware attempt values.
 type AttemptState struct {
@@ -209,6 +209,7 @@ type AttemptState struct {
 type ResponseMetadata struct {
 	StatusCode    int
 	StreamStarted bool
+	RetryEligible bool
 }
 
 // ResponseDecision directs the engine's response handling. The engine, not
@@ -224,9 +225,11 @@ const (
 
 // Middleware is a trusted Go-only provider extension. It may inject declared
 // headers and classify a body-free response; it cannot mutate the final URL or
-// request body, consume a stream, or perform the retry itself.
+// request body, consume a stream, or perform the retry itself. On a replay,
+// BeforeRequest receives its own prior opaque attempt so a source that returned
+// an explicit replacement credential can apply it without shared mutable state.
 type Middleware interface {
-	BeforeRequest(context.Context, RequestContext, HeaderWriter) (Attempt, error)
+	BeforeRequest(context.Context, RequestContext, Attempt, HeaderWriter) (Attempt, error)
 	AfterResponse(context.Context, RequestContext, Attempt, ResponseMetadata) (ResponseDecision, error)
 }
 
@@ -252,17 +255,25 @@ func NewChain(middlewares ...Middleware) (*Chain, error) {
 }
 
 // BeforeRequest applies middleware in registration order and returns opaque
-// values for the matching AfterResponse call.
-func (c *Chain) BeforeRequest(ctx context.Context, request RequestContext, headers HeaderWriter) (AttemptState, error) {
+// values for the matching AfterResponse call. previous must be empty for an
+// initial request or have exactly one attempt per middleware for a replay.
+func (c *Chain) BeforeRequest(ctx context.Context, request RequestContext, previous AttemptState, headers HeaderWriter) (AttemptState, error) {
 	if c == nil {
 		return AttemptState{}, errors.New("nil transport middleware chain")
 	}
 	if headers == nil {
 		return AttemptState{}, errors.New("transport header writer is required")
 	}
+	if len(previous.attempts) != 0 && len(previous.attempts) != len(c.middlewares) {
+		return AttemptState{}, errors.New("transport middleware previous attempt state does not match chain")
+	}
 	attempts := make([]Attempt, 0, len(c.middlewares))
-	for _, middleware := range c.middlewares {
-		attempt, err := middleware.BeforeRequest(ctx, request, headers)
+	for i, middleware := range c.middlewares {
+		var prior Attempt
+		if len(previous.attempts) != 0 {
+			prior = previous.attempts[i]
+		}
+		attempt, err := middleware.BeforeRequest(ctx, request, prior, headers)
 		if err != nil {
 			return AttemptState{}, err
 		}

--- a/pkg/steps/ai/transport/transport_test.go
+++ b/pkg/steps/ai/transport/transport_test.go
@@ -1,0 +1,272 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type routeResolverFunc func(RouteRequest) (*url.URL, error)
+
+func (f routeResolverFunc) Resolve(request RouteRequest) (*url.URL, error) {
+	return f(request)
+}
+
+func mustURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse URL %q: %v", raw, err)
+	}
+	return parsed
+}
+
+func TestResolveAndValidate_ValidatesResolvedTargetAndReturnsReadOnlyContext(t *testing.T) {
+	base := mustURL(t, "https://example.test/v1")
+	var validated string
+	context, err := ResolveAndValidate(
+		"openai-codex",
+		"responses",
+		base,
+		routeResolverFunc(func(request RouteRequest) (*url.URL, error) {
+			resolverBase := request.BaseURL()
+			resolverBase.Host = "mutated.example.test"
+			if base.Host != "example.test" {
+				t.Fatalf("resolver mutated caller base URL: %q", base.Host)
+			}
+			if request.Operation() != "responses" {
+				t.Fatalf("operation = %q", request.Operation())
+			}
+			return mustURL(t, "https://example.test/backend-api/codex/responses"), nil
+		}),
+		func(target *url.URL) error {
+			validated = target.String()
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("ResolveAndValidate: %v", err)
+	}
+	if validated != "https://example.test/backend-api/codex/responses" {
+		t.Fatalf("validated URL = %q", validated)
+	}
+	if context.Provider() != "openai-codex" || context.Operation() != "responses" {
+		t.Fatalf("context = provider %q operation %q", context.Provider(), context.Operation())
+	}
+	copyURL := context.URL()
+	copyURL.Host = "changed.example.test"
+	if got := context.URL().Host; got != "example.test" {
+		t.Fatalf("URL copy mutated request context: %q", got)
+	}
+}
+
+func TestResolveAndValidate_FailsBeforeContextWhenTargetRejected(t *testing.T) {
+	validatorCalled := false
+	_, err := ResolveAndValidate(
+		"openai-codex",
+		"responses",
+		mustURL(t, "https://example.test"),
+		routeResolverFunc(func(RouteRequest) (*url.URL, error) {
+			return mustURL(t, "http://untrusted.test/codex/responses"), nil
+		}),
+		func(*url.URL) error {
+			validatorCalled = true
+			return errors.New("target denied")
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "validate provider route") {
+		t.Fatalf("error = %v, want validation error", err)
+	}
+	if !validatorCalled {
+		t.Fatal("validator was not called")
+	}
+}
+
+func TestHeaderSet_OnlyAllowsDeclaredHeadersAndRedactsSensitiveValues(t *testing.T) {
+	target := make(http.Header)
+	headers, err := NewHeaderSet(target,
+		HeaderRule{Name: "Authorization", Sensitive: true},
+		HeaderRule{Name: "X-Provider-Account", Sensitive: true},
+		HeaderRule{Name: "X-Provider-Beta"},
+	)
+	if err != nil {
+		t.Fatalf("NewHeaderSet: %v", err)
+	}
+	if err := headers.Set("authorization", "Bearer token-value"); err != nil {
+		t.Fatalf("set authorization: %v", err)
+	}
+	if err := headers.Set("X-Provider-Account", "account-value"); err != nil {
+		t.Fatalf("set account: %v", err)
+	}
+	if err := headers.Set("X-Provider-Beta", "responses=v1"); err != nil {
+		t.Fatalf("set beta: %v", err)
+	}
+	if got := target.Get("Authorization"); got != "Bearer token-value" {
+		t.Fatalf("authorization = %q", got)
+	}
+
+	redacted := headers.RedactedCopy()
+	if got := redacted.Get("Authorization"); got != "<redacted>" {
+		t.Fatalf("redacted authorization = %q", got)
+	}
+	if got := redacted.Get("X-Provider-Account"); got != "<redacted>" {
+		t.Fatalf("redacted account = %q", got)
+	}
+	if got := redacted.Get("X-Provider-Beta"); got != "responses=v1" {
+		t.Fatalf("beta = %q", got)
+	}
+
+	for _, name := range []string{"Host", "Content-Length", "X-Undeclared"} {
+		if err := headers.Set(name, "value"); err == nil {
+			t.Fatalf("Set(%q) unexpectedly succeeded", name)
+		}
+	}
+	if target.Get("Host") != "" || target.Get("Content-Length") != "" || target.Get("X-Undeclared") != "" {
+		t.Fatalf("forbidden header was written: %#v", target)
+	}
+}
+
+func TestHeaderSet_RejectsConflictsAndDoesNotRevealValue(t *testing.T) {
+	headers, err := NewHeaderSet(make(http.Header), HeaderRule{Name: "Authorization", Sensitive: true})
+	if err != nil {
+		t.Fatalf("NewHeaderSet: %v", err)
+	}
+	if err := headers.Set("Authorization", "Bearer first"); err != nil {
+		t.Fatalf("first Set: %v", err)
+	}
+	if err := headers.Set("Authorization", "Bearer first"); err != nil {
+		t.Fatalf("idempotent Set: %v", err)
+	}
+	const secret = "Bearer second-secret-value"
+	err = headers.Set("Authorization", secret)
+	if err == nil || !strings.Contains(err.Error(), "already set") {
+		t.Fatalf("conflict error = %v", err)
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("conflict error leaked header value: %q", err)
+	}
+	err = headers.Set("Authorization", "bad\r\nheader")
+	if err == nil || !strings.Contains(err.Error(), "invalid value") {
+		t.Fatalf("invalid value error = %v", err)
+	}
+}
+
+func TestNewHeaderSet_RejectsUnsafeRules(t *testing.T) {
+	for _, name := range []string{"Host", "Content-Length", "Transfer-Encoding", "Connection", "Trailer", "TE", "Upgrade", "Proxy-Connection"} {
+		_, err := NewHeaderSet(make(http.Header), HeaderRule{Name: name})
+		if err == nil {
+			t.Fatalf("NewHeaderSet(%q) unexpectedly succeeded", name)
+		}
+	}
+	_, err := NewHeaderSet(make(http.Header), HeaderRule{Name: "X-A"}, HeaderRule{Name: "x-a"})
+	if err == nil {
+		t.Fatalf("duplicate header rule unexpectedly succeeded")
+	}
+}
+
+type middlewareFunc struct {
+	before func(context.Context, RequestContext, HeaderWriter) (Attempt, error)
+	after  func(context.Context, RequestContext, Attempt, ResponseMetadata) (ResponseDecision, error)
+}
+
+func (m middlewareFunc) BeforeRequest(ctx context.Context, request RequestContext, headers HeaderWriter) (Attempt, error) {
+	return m.before(ctx, request, headers)
+}
+
+func (m middlewareFunc) AfterResponse(ctx context.Context, request RequestContext, attempt Attempt, response ResponseMetadata) (ResponseDecision, error) {
+	return m.after(ctx, request, attempt, response)
+}
+
+func TestChain_AppliesRequestForwardAndResponseReverse(t *testing.T) {
+	request, err := ResolveAndValidate(
+		"openai-codex", "responses", mustURL(t, "https://example.test"),
+		routeResolverFunc(func(RouteRequest) (*url.URL, error) { return mustURL(t, "https://example.test/codex/responses"), nil }),
+		func(*url.URL) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("ResolveAndValidate: %v", err)
+	}
+	var calls []string
+	first := middlewareFunc{
+		before: func(_ context.Context, _ RequestContext, headers HeaderWriter) (Attempt, error) {
+			calls = append(calls, "before-first")
+			return "first", headers.Set("X-First", "one")
+		},
+		after: func(_ context.Context, _ RequestContext, attempt Attempt, _ ResponseMetadata) (ResponseDecision, error) {
+			calls = append(calls, "after-first-"+attempt.(string))
+			return Continue, nil
+		},
+	}
+	second := middlewareFunc{
+		before: func(_ context.Context, _ RequestContext, headers HeaderWriter) (Attempt, error) {
+			calls = append(calls, "before-second")
+			return "second", headers.Set("X-Second", "two")
+		},
+		after: func(_ context.Context, _ RequestContext, attempt Attempt, _ ResponseMetadata) (ResponseDecision, error) {
+			calls = append(calls, "after-second-"+attempt.(string))
+			return Retry, nil
+		},
+	}
+	chain, err := NewChain(first, second)
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+	headers, err := NewHeaderSet(make(http.Header), HeaderRule{Name: "X-First"}, HeaderRule{Name: "X-Second"})
+	if err != nil {
+		t.Fatalf("NewHeaderSet: %v", err)
+	}
+	attempts, err := chain.BeforeRequest(context.Background(), request, headers)
+	if err != nil {
+		t.Fatalf("BeforeRequest: %v", err)
+	}
+	decision, err := chain.AfterResponse(context.Background(), request, attempts, ResponseMetadata{StatusCode: http.StatusUnauthorized})
+	if err != nil {
+		t.Fatalf("AfterResponse: %v", err)
+	}
+	if decision != Retry {
+		t.Fatalf("decision = %v, want Retry", decision)
+	}
+	wantCalls := []string{"before-first", "before-second", "after-second-second", "after-first-first"}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("calls = %#v, want %#v", calls, wantCalls)
+	}
+}
+
+func TestChain_RejectsUnknownDecisionAndMismatchedAttemptState(t *testing.T) {
+	request, err := ResolveAndValidate(
+		"provider", "operation", mustURL(t, "https://example.test"),
+		routeResolverFunc(func(RouteRequest) (*url.URL, error) { return mustURL(t, "https://example.test/path"), nil }),
+		func(*url.URL) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("ResolveAndValidate: %v", err)
+	}
+	middleware := middlewareFunc{
+		before: func(context.Context, RequestContext, HeaderWriter) (Attempt, error) { return nil, nil },
+		after: func(context.Context, RequestContext, Attempt, ResponseMetadata) (ResponseDecision, error) {
+			return ResponseDecision(99), nil
+		},
+	}
+	chain, err := NewChain(middleware)
+	if err != nil {
+		t.Fatalf("NewChain: %v", err)
+	}
+	if _, err := chain.AfterResponse(context.Background(), request, AttemptState{}, ResponseMetadata{}); err == nil {
+		t.Fatal("mismatched attempt state unexpectedly succeeded")
+	}
+	headers, err := NewHeaderSet(make(http.Header))
+	if err != nil {
+		t.Fatalf("NewHeaderSet: %v", err)
+	}
+	attempts, err := chain.BeforeRequest(context.Background(), request, headers)
+	if err != nil {
+		t.Fatalf("BeforeRequest: %v", err)
+	}
+	if _, err := chain.AfterResponse(context.Background(), request, attempts, ResponseMetadata{}); err == nil {
+		t.Fatal("unknown decision unexpectedly succeeded")
+	}
+}

--- a/pkg/steps/ai/transport/transport_test.go
+++ b/pkg/steps/ai/transport/transport_test.go
@@ -169,12 +169,12 @@ func TestNewHeaderSet_RejectsUnsafeRules(t *testing.T) {
 }
 
 type middlewareFunc struct {
-	before func(context.Context, RequestContext, HeaderWriter) (Attempt, error)
+	before func(context.Context, RequestContext, Attempt, HeaderWriter) (Attempt, error)
 	after  func(context.Context, RequestContext, Attempt, ResponseMetadata) (ResponseDecision, error)
 }
 
-func (m middlewareFunc) BeforeRequest(ctx context.Context, request RequestContext, headers HeaderWriter) (Attempt, error) {
-	return m.before(ctx, request, headers)
+func (m middlewareFunc) BeforeRequest(ctx context.Context, request RequestContext, previous Attempt, headers HeaderWriter) (Attempt, error) {
+	return m.before(ctx, request, previous, headers)
 }
 
 func (m middlewareFunc) AfterResponse(ctx context.Context, request RequestContext, attempt Attempt, response ResponseMetadata) (ResponseDecision, error) {
@@ -192,7 +192,10 @@ func TestChain_AppliesRequestForwardAndResponseReverse(t *testing.T) {
 	}
 	var calls []string
 	first := middlewareFunc{
-		before: func(_ context.Context, _ RequestContext, headers HeaderWriter) (Attempt, error) {
+		before: func(_ context.Context, _ RequestContext, previous Attempt, headers HeaderWriter) (Attempt, error) {
+			if previous != nil {
+				t.Fatalf("first middleware received unexpected prior attempt: %#v", previous)
+			}
 			calls = append(calls, "before-first")
 			return "first", headers.Set("X-First", "one")
 		},
@@ -202,7 +205,10 @@ func TestChain_AppliesRequestForwardAndResponseReverse(t *testing.T) {
 		},
 	}
 	second := middlewareFunc{
-		before: func(_ context.Context, _ RequestContext, headers HeaderWriter) (Attempt, error) {
+		before: func(_ context.Context, _ RequestContext, previous Attempt, headers HeaderWriter) (Attempt, error) {
+			if previous != nil {
+				t.Fatalf("second middleware received unexpected prior attempt: %#v", previous)
+			}
 			calls = append(calls, "before-second")
 			return "second", headers.Set("X-Second", "two")
 		},
@@ -219,7 +225,7 @@ func TestChain_AppliesRequestForwardAndResponseReverse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewHeaderSet: %v", err)
 	}
-	attempts, err := chain.BeforeRequest(context.Background(), request, headers)
+	attempts, err := chain.BeforeRequest(context.Background(), request, AttemptState{}, headers)
 	if err != nil {
 		t.Fatalf("BeforeRequest: %v", err)
 	}
@@ -246,7 +252,7 @@ func TestChain_RejectsUnknownDecisionAndMismatchedAttemptState(t *testing.T) {
 		t.Fatalf("ResolveAndValidate: %v", err)
 	}
 	middleware := middlewareFunc{
-		before: func(context.Context, RequestContext, HeaderWriter) (Attempt, error) { return nil, nil },
+		before: func(context.Context, RequestContext, Attempt, HeaderWriter) (Attempt, error) { return nil, nil },
 		after: func(context.Context, RequestContext, Attempt, ResponseMetadata) (ResponseDecision, error) {
 			return ResponseDecision(99), nil
 		},
@@ -262,7 +268,7 @@ func TestChain_RejectsUnknownDecisionAndMismatchedAttemptState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewHeaderSet: %v", err)
 	}
-	attempts, err := chain.BeforeRequest(context.Background(), request, headers)
+	attempts, err := chain.BeforeRequest(context.Background(), request, AttemptState{}, headers)
 	if err != nil {
 		t.Fatalf("BeforeRequest: %v", err)
 	}

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/README.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/README.md
@@ -1,0 +1,21 @@
+# Provider-specific adapters for Pi subscription credentials
+
+This is the document workspace for ticket GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS --field Status --value review`

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 2026-07-14
+
+- Initial workspace created
+
+
+## 2026-07-14
+
+Captured Pi provider and Geppetto transport evidence; wrote a provider-specific adapter design that keeps Pi storage host-owned and credentials out of settings and JavaScript.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/design-doc/01-pi-subscription-credentials-in-geppetto-analysis-adapter-design-and-implementation-guide.md — Intern implementation guide
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/sources/01-local-pi-and-geppetto-source-map.md — Redacted source map
+

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
@@ -67,3 +67,13 @@ Replaced the dedicated Codex engine proposal with a shared Responses core plus v
 
 Ticket closed
 
+
+## 2026-07-14
+
+Reopened the ticket as the implementation tracker; added phased tasks for restricted middleware, provider adapters, reusable lifecycle primitives, and Pinocchio binding.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/design-doc/01-pi-subscription-credentials-in-geppetto-analysis-adapter-design-and-implementation-guide.md — Implementation phases and acceptance criteria
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md — Phased implementation task plan
+

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
@@ -86,3 +86,13 @@ Published a clean design-only PDF for the shared-core provider middleware archit
 
 - /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md — Clean reMarkable delivery evidence
 
+
+## 2026-07-16
+
+Implemented and race-tested restricted provider transport contracts with validated route resolution, allowlisted header injection, opaque attempts, and core-governed retry decisions.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/pkg/steps/ai/transport/transport.go — New provider transport contracts
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/pkg/steps/ai/transport/transport_test.go — Security and ordering tests
+

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
@@ -28,3 +28,27 @@ Validated and delivered the redacted Pi subscription credential adapter guide as
 
 Ticket closed
 
+
+## 2026-07-14
+
+Reframed credential ownership: Geppetto provides reusable provider lifecycle and transport primitives; hosts bind stores, UI, profile selection, and import policy.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/design-doc/01-pi-subscription-credentials-in-geppetto-analysis-adapter-design-and-implementation-guide.md — Revised lifecycle ownership and implementation plan
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md — Architecture correction rationale
+
+
+## 2026-07-14
+
+Validated and re-uploaded the revised Geppetto provider credential lifecycle architecture without overwriting the prior bundle.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md — Revision validation and reMarkable delivery evidence
+
+
+## 2026-07-14
+
+Ticket closed
+

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
@@ -117,3 +117,8 @@ Completed reusable lifecycle state/logout, Umans dual-auth binding, Anthropic OA
 - /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/pkg/steps/ai/credentials/oauth/state.go — OAuth state primitive
 - /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/pinocchio/pkg/cmds/profilebootstrap/oauth.go — Host binding
 
+
+## 2026-07-16
+
+Ticket closed
+

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
@@ -96,3 +96,13 @@ Implemented and race-tested restricted provider transport contracts with validat
 - /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/pkg/steps/ai/transport/transport.go — New provider transport contracts
 - /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/pkg/steps/ai/transport/transport_test.go — Security and ordering tests
 
+
+## 2026-07-16
+
+Wired OpenAI Responses through the restricted provider transport pipeline and added a fake-server-tested typed Codex route and credential middleware.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/pkg/steps/ai/openai_responses/request_transport.go — Shared core integration
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/pkg/steps/ai/providers/openaicodex/codex.go — Codex adapter
+

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
@@ -77,3 +77,12 @@ Reopened the ticket as the implementation tracker; added phased tasks for restri
 - /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/design-doc/01-pi-subscription-credentials-in-geppetto-analysis-adapter-design-and-implementation-guide.md — Implementation phases and acceptance criteria
 - /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md — Phased implementation task plan
 
+
+## 2026-07-15
+
+Published a clean design-only PDF for the shared-core provider middleware architecture without overwriting earlier review bundles.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md — Clean reMarkable delivery evidence
+

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
@@ -14,3 +14,17 @@ Captured Pi provider and Geppetto transport evidence; wrote a provider-specific 
 - /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/design-doc/01-pi-subscription-credentials-in-geppetto-analysis-adapter-design-and-implementation-guide.md — Intern implementation guide
 - /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/sources/01-local-pi-and-geppetto-source-map.md — Redacted source map
 
+
+## 2026-07-14
+
+Validated and delivered the redacted Pi subscription credential adapter guide as a reMarkable bundle after a successful dry run.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md — Validation and delivery evidence
+
+
+## 2026-07-14
+
+Ticket closed
+

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
@@ -52,3 +52,18 @@ Validated and re-uploaded the revised Geppetto provider credential lifecycle arc
 
 Ticket closed
 
+
+## 2026-07-14
+
+Replaced the dedicated Codex engine proposal with a shared Responses core plus validated route resolver and restricted provider request/response middleware.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/design-doc/01-pi-subscription-credentials-in-geppetto-analysis-adapter-design-and-implementation-guide.md — Middleware architecture and security ordering
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md — Decision rationale and review guidance
+
+
+## 2026-07-14
+
+Ticket closed
+

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/changelog.md
@@ -106,3 +106,14 @@ Wired OpenAI Responses through the restricted provider transport pipeline and ad
 - /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/pkg/steps/ai/openai_responses/request_transport.go — Shared core integration
 - /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/pkg/steps/ai/providers/openaicodex/codex.go — Codex adapter
 
+
+## 2026-07-16
+
+Completed reusable lifecycle state/logout, Umans dual-auth binding, Anthropic OAuth header mode, token-count source propagation, OAuth state primitives, and Pinocchio Claude profile binding; live smoke remains approval-gated.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/pkg/steps/ai/claude/api/completion.go — Explicit Umans and Anthropic OAuth header modes
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto/pkg/steps/ai/credentials/oauth/state.go — OAuth state primitive
+- /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/pinocchio/pkg/cmds/profilebootstrap/oauth.go — Host binding
+

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/design-doc/01-pi-subscription-credentials-in-geppetto-analysis-adapter-design-and-implementation-guide.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/design-doc/01-pi-subscription-credentials-in-geppetto-analysis-adapter-design-and-implementation-guide.md
@@ -1,0 +1,639 @@
+---
+Title: 'Pi subscription credentials in Geppetto: analysis, adapter design, and implementation guide'
+Ticket: GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS
+Status: active
+Topics:
+    - geppetto
+    - oauth
+    - credentials
+    - security
+DocType: design-doc
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles:
+    - Path: repo://pkg/inference/engine/factory/factory.go
+      Note: Current engine-specific source propagation and validation
+    - Path: repo://pkg/js/modules/geppetto/api_engine_builder.go
+      Note: Go-only JavaScript source injection boundary
+    - Path: repo://pkg/steps/ai/claude/api/completion.go
+      Note: Claude static x-api-key request headers
+    - Path: repo://pkg/steps/ai/claude/engine_claude.go
+      Note: Current static Claude credential construction
+    - Path: repo://pkg/steps/ai/credentials/bearer.go
+      Note: Existing host-owned renewable bearer contract and invariants
+    - Path: repo://pkg/steps/ai/openai_responses/streaming.go
+      Note: Current bearer-only Responses request/replay behavior
+    - Path: repo://ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/sources/01-local-pi-and-geppetto-source-map.md
+      Note: Redacted local Pi provider and Geppetto evidence index
+ExternalSources: []
+Summary: Evidence-backed design for safely supporting provider-specific Pi subscription credential transports without making Geppetto own Pi storage or exposing credentials to JavaScript.
+LastUpdated: 2026-07-14T21:52:00-04:00
+WhatFor: Orient an engineer implementing provider-specific renewable credential adapters and transports in and around Geppetto.
+WhenToUse: Use when evaluating Pi-originated subscription credentials, custom OAuth transports, or a future Geppetto request authentication capability.
+---
+
+
+# Pi subscription credentials in Geppetto
+
+## Executive summary
+
+Geppetto already has a secure, host-injected renewable bearer mechanism. A host owns persistence and refresh protocol; Geppetto asks for a bearer immediately before a supported OpenAI Chat or Responses request. This boundary is deliberately narrow and correct for ordinary OpenAI-compatible services, where `Authorization: Bearer <access-token>` is the whole authentication contract.
+
+Installed Pi code shows that the three providers initially described as “OAuth” are not the same integration problem. OpenAI Codex is a genuine refreshable ChatGPT subscription flow, but its inference transport is the ChatGPT backend with a Codex-specific path and additional account, originator, beta, and request-ID headers. Anthropic Claude Pro/Max is also a genuine refreshable OAuth flow, but it targets the Anthropic Messages protocol while Geppetto’s Claude engine currently owns a static `x-api-key` client. Umans is not renewable OAuth in the Pi extension at all: `/login` persists an API key in OAuth-shaped fields, and its refresh function returns the same value.
+
+Therefore this work must **not** copy Pi credentials into Geppetto profiles, make Geppetto parse `~/.pi/agent/auth.json`, or add “generic OAuth” claims based only on a token shape. The recommended path is a two-layer design:
+
+1. **Geppetto adds narrowly-scoped, Go-only request-authentication and transport seams only where a real engine needs them.** It remains storage-, browser-, and Pi-agnostic.
+2. **A host-owned adapter (initially Pinocchio, not Geppetto) understands a selected provider and any local Pi storage contract.** It loads, refreshes, and supplies credentials without making token material, refresh callbacks, account identity, or source-selection metadata visible to profiles or JavaScript.
+
+OpenAI Codex should be a dedicated experimental adapter/engine effort, not a configuration tweak to the existing OpenAI Responses engine. Claude should be investigated through the existing Claude engine, but only after its OAuth request-header semantics are captured in a fake-server contract. Umans belongs in a separate Anthropic Messages/API-key compatibility effort, not the renewable OAuth feature.
+
+## 1. Problem statement and scope
+
+### 1.1 The question
+
+A machine running Pi already has local provider records for several login-based providers. Can a Geppetto host reuse a selected subscription credential safely and renew it at request time, while retaining the security invariants established by Geppetto’s renewable bearer work?
+
+The answer is **potentially, provider by provider**. A record containing fields named `access`, `refresh`, and `expires` only establishes that Pi stores a credential in a common shape. It does not establish the inference endpoint, request framing, required companion headers, token audience, service terms, or compatibility with an existing Geppetto engine.
+
+### 1.2 Goals
+
+This design defines how to:
+
+- classify the actual provider/transport contracts evidenced by installed Pi code;
+- preserve Geppetto’s host-owned credential ownership model;
+- add only the runtime seams required by a validated provider transport;
+- keep all secret and credential-adjacent state out of profile YAML, settings dumps, events, logs, JavaScript, and CLI output;
+- produce a phased implementation plan that an intern can execute with fake-server tests before any account-backed smoke.
+
+### 1.3 Non-goals
+
+This ticket does **not** authorize implementation of a provider adapter, a real account request, or a new browser-login command. It also does not:
+
+- read, copy, print, hash, upload, or commit a value from Pi’s auth file;
+- make Geppetto own Pi’s file format, file locking, browser callbacks, or refresh protocol;
+- claim the ChatGPT backend is a stable public OpenAI API contract;
+- treat the Umans API-key shim as OAuth;
+- expose a bearer, refresh callback, account identifier, raw headers, or credential-source selector to JavaScript;
+- add a broad arbitrary HTTP-request mutator that could override validated URLs or security headers.
+
+### 1.4 Terminology
+
+| Term | Meaning in this guide |
+|---|---|
+| **host** | The embedding application, such as Pinocchio, that constructs Geppetto engines. |
+| **credential store** | The host’s secret-bearing persistence owner. Pi’s auth file is one possible external source, not a Geppetto data format. |
+| **renewable bearer** | An access token plus an optional refresh token and expiry, acquired at request time through a host source. |
+| **transport contract** | The full endpoint, path, HTTP method, payload, headers, response stream, and retry behavior expected by a provider. |
+| **adapter** | Host-side code that turns an external credential contract into a safe Geppetto runtime capability. |
+| **engine** | Geppetto’s provider protocol implementation, such as OpenAI Chat, OpenAI Responses, or Claude Messages. |
+| **metadata** | Non-token companion values such as an account identifier. It is still private runtime state and must not be shown to JavaScript or diagnostics. |
+
+## 2. Current-state architecture
+
+### 2.1 Geppetto credential boundary
+
+`pkg/steps/ai/credentials/bearer.go:21-83` defines `credentials.Request`, `Credential`, `Store`, `Refresher`, and `BearerTokenSource`. The public source interface returns exactly one string:
+
+```go
+// pkg/steps/ai/credentials/bearer.go
+type BearerTokenSource interface {
+    BearerToken(context.Context, Request) (string, error)
+}
+```
+
+The narrowness is intentional. The generic `RenewableBearerTokenSource` loads credentials through a host `Store`, refreshes through a host `Refresher`, saves a rotation before caching it, and emits redacted availability errors. It does not parse profile YAML or know provider token endpoints. Its request identity is the non-secret pair `{Provider, BaseURL}`.
+
+```text
+             host owns secrets and provider protocol
+
+  +----------------+       +------------------+       +----------------+
+  | host Store     |<----->| host Refresher   |<----->| provider OAuth |
+  +--------+-------+       +------------------+       +----------------+
+           |                         ^
+           v                         |
+  +-------------------------------+  |
+  | RenewableBearerTokenSource    |--+
+  | cache + singleflight + redact |
+  +---------------+---------------+
+                  |
+                  | bearer at outbound request time
+                  v
+  +---------------+---------------+
+  | Geppetto engine               |
+  | validated URL -> request      |
+  +-------------------------------+
+```
+
+The existing source is appropriate only if the provider request needs a normal bearer header and the target engine understands the protocol.
+
+### 2.2 Supported engine paths
+
+`pkg/inference/engine/factory/factory.go:134-151` forwards a configured bearer source to OpenAI Chat and OpenAI Responses. `pkg/steps/ai/openai/chat_stream.go:96-105,133-168` and `pkg/steps/ai/openai_responses/streaming.go:148-185` resolve the source after URL validation and set `Authorization: Bearer ...`. Each path permits one opt-in pre-stream 401 refresh/replay using `UnauthorizedBearerTokenSource`.
+
+The factory intentionally does **not** forward the source to Claude. `pkg/steps/ai/claude/engine_claude.go:72-86` looks up a static API key. `pkg/steps/ai/claude/api/completion.go:94-99` sends that value as `x-api-key` and sets the Anthropic version header. This matters: Claude is not merely another OpenAI-compatible bearer path.
+
+### 2.3 JavaScript boundary
+
+`pkg/js/modules/geppetto/api_engine_builder.go:63-73` keeps a host-configured bearer source inside `moduleRuntime` in Go. JavaScript receives an engine builder, not the source. That same boundary remains mandatory for any richer provider-specific capability:
+
+```text
+JavaScript settings/profile -> Go engine construction -> Go-only source/adapter -> HTTP request
+                                 ^
+                                 |
+                    no token, header map, account id,
+                    refresh callback, or selector crosses here
+```
+
+### 2.4 Pi credential behavior
+
+Pi’s `AuthStorage` uses provider registrations to log in, stores OAuth credential records, and locks its backing file while refreshing expired records (`dist/core/auth-storage.js:318-425`). This is useful evidence for the current local client, but it is not a stable Geppetto interface. Geppetto must not import Pi’s JavaScript implementation or directly adopt Pi’s disk format.
+
+## 3. Provider contract classification
+
+### 3.1 OpenAI Codex: renewable OAuth, custom ChatGPT transport
+
+Pi’s OpenAI Codex provider is explicitly bound to `https://chatgpt.com/backend-api` (`dist/providers/openai-codex.js:6-16`). Its OAuth implementation supports PKCE authorization-code login and device-code login, refreshes through the OpenAI OAuth token service, and derives a ChatGPT account identifier from an access-token claim (`dist/utils/oauth/openai-codex.js:22-35,112-125,319-338`).
+
+The inference request is not a normal public OpenAI Responses request. Pi resolves a `/codex/responses` path and adds all of the following in its Codex response implementation (`dist/api/openai-codex-responses.js:402-409,1163-1210`):
+
+- the bearer authorization header;
+- a ChatGPT account header derived from the current access token;
+- an originator header;
+- experimental Responses/SSE headers;
+- request/session identifiers where applicable.
+
+| Required capability | Existing Geppetto OpenAI Responses | Codex requirement | Result |
+|---|---:|---:|---|
+| Request-time bearer | Yes | Yes | Reusable concept |
+| One pre-stream 401 replay | Yes | Likely useful | Must be contract-tested |
+| `/responses` target | Yes | `/codex/responses` | Incompatible without a dedicated target strategy |
+| Account header | No | Required by Pi transport | Missing capability |
+| Originator/beta headers | No | Required by Pi transport | Missing capability |
+| Codex request/stream mapping | Standard Responses | Pi-specific implementation | Must be audited, not assumed identical |
+
+**Conclusion:** do not configure the generic OpenAI Responses engine with a ChatGPT base URL and a Pi bearer. That would route a token to a validated but semantically wrong target and omit companion headers. Treat Codex as a distinct transport adapter.
+
+### 3.2 Anthropic Claude subscription: renewable OAuth, Anthropic Messages transport
+
+Pi’s Anthropic provider implements PKCE authorization-code exchange and refresh-token renewal (`dist/utils/oauth/anthropic.js:159-185,290-315`). The scopes include inference and Claude Code-session capability. This proves a refreshable client flow exists in Pi.
+
+Geppetto already speaks the Anthropic Messages family through the Claude engine, which is promising. However, it currently carries a static key through a client field and sends `x-api-key` (`pkg/steps/ai/claude/engine_claude.go:72-86`, `pkg/steps/ai/claude/api/completion.go:94-99`). It has no request-time source and no validated OAuth-specific header profile.
+
+**Conclusion:** Claude is not blocked by an absent protocol engine; it is blocked by absent dynamic credential plumbing and unverified subscription-auth request semantics. First add a fake-server test that states the exact headers and endpoint expected by the approved provider contract. Only then design `WithBearerTokenSource`-like behavior for Claude. Never assume an access token can be substituted into `x-api-key` because both are strings.
+
+### 3.3 Umans: API-key persistence shim, Anthropic Messages transport
+
+The installed Umans Pi extension asks for an API key, copies it into access/refresh-shaped values, gives it a very long expiry, and returns it unchanged from “refresh” (`pi-provider-umans/index.ts:539-577`). Its own README says the gateway uses Anthropic Messages at `/v1/messages`, with `anthropic-version`, rather than OpenAI Chat Completions (`README.md:39-43`).
+
+**Conclusion:** Umans is not evidence for refresh-token support. It is an API-key configuration use case. It may later be compatible with Geppetto’s Claude/Messages engine after a protocol test, but it belongs to static-key/provider compatibility work and must not drive the renewable OAuth API.
+
+### 3.4 Additional candidate: Kimi Code
+
+The installed Kimi Code extension implements device authorization and refresh token grants and can select an OpenAI-like coding endpoint. It is relevant evidence that Pi extensions can carry extra model/transport metadata beyond `access`, `refresh`, and `expires`. It is deliberately out of the first implementation scope because its custom stream handler and protocol-specific headers require the same evidence-first evaluation as Codex.
+
+## 4. Gap analysis
+
+### 4.1 Why `BearerTokenSource` is insufficient for Codex
+
+A bearer source answers only “what token may I send to this already-decided request?” Codex also needs a specialized request target and companion headers derived from the current credential. The token-only source deliberately cannot express those capabilities.
+
+Adding an arbitrary `func(*http.Request)` callback to settings would be unsafe:
+
+- settings are profile-derived, serializable, cloneable, and inspectable;
+- an arbitrary callback could rewrite a URL after outbound validation and exfiltrate a bearer;
+- a callback could override `Host`, `Authorization`, `Content-Length`, or tracing headers;
+- JavaScript could accidentally gain a way to select or observe private transport behavior.
+
+### 4.2 Why Geppetto must not read Pi’s auth file
+
+Reading Pi’s file from Geppetto would make a reusable library depend on a local tool’s private schema, lock implementation, migration behavior, and provider registrations. It also violates the existing ownership model: the host must choose storage, user interaction, and refresh policy.
+
+The correct dependency direction is:
+
+```text
+Pinocchio or another host
+  ├── chooses whether Pi auth storage is a permitted local source
+  ├── owns safe locking, migration, and user consent
+  ├── constructs a provider-specific adapter
+  └── injects Go-only runtime capability into Geppetto
+
+Geppetto
+  ├── validates outbound target before credential release
+  ├── implements provider protocol and bounded replay behavior
+  └── never reads host credential files or launches a browser
+```
+
+### 4.3 Why no generic “OAuth provider” abstraction
+
+OAuth tells us how to acquire and refresh tokens. It does not define the inference HTTP protocol. The provider needs an adapter when any of these vary:
+
+- endpoint host or path;
+- header names and mandatory metadata;
+- message wire format and streaming events;
+- model discovery or model aliases;
+- request retry/idempotency semantics;
+- refresh behavior after a server-side rejection.
+
+A generic `OAuthProvider` in Geppetto would collapse these concerns and invite unsafe configuration. Keep protocol code explicit.
+
+## 5. Proposed architecture
+
+### 5.1 Architectural decision
+
+Implement provider transports as dedicated engines or dedicated engine modes, and use a restricted Go-only request-auth capability for metadata only where a shared protocol implementation can safely consume it.
+
+Do **not** turn the current generic OpenAI Responses engine into a configurable Codex client by adding profile keys for endpoint suffixes or header maps.
+
+```text
+                     host-owned, secret-bearing layer
+ +----------------------------------------------------------------+
+ | Provider adapter                                                |
+ |  - selected storage owner                                       |
+ |  - locked load/refresh/save                                     |
+ |  - current access token + private runtime metadata             |
+ +-------------------------------+--------------------------------+
+                                 |
+                   Go-only typed capability, never settings/JS
+                                 v
+ +-------------------------------+--------------------------------+
+ | Geppetto provider engine                                        |
+ |  Codex engine: target + request framing + sanctioned headers    |
+ |  Claude engine: Message protocol + tested auth strategy         |
+ |  OpenAI engines: existing bearer-only behavior                  |
+ +-------------------------------+--------------------------------+
+                                 |
+                         validated outbound HTTP request
+                                 v
+                           provider inference API
+```
+
+### Decision: Preserve Geppetto’s host-agnostic ownership
+
+- **Context:** Pi storage and provider logic are local application behavior, while Geppetto is a reusable library.
+- **Options considered:** Parse Pi storage in Geppetto; add a Pi dependency to Geppetto; keep all Pi integration in hosts.
+- **Decision:** Keep Pi storage parsing, browser login, and refresh protocol in a host-owned adapter.
+- **Rationale:** This preserves existing credential ownership, avoids a Node/runtime dependency in Go, and lets non-Pi hosts use the same engines.
+- **Consequences:** The host must perform explicit adapter wiring. Geppetto documentation must show capability injection, not a magic profile flag.
+- **Status:** proposed.
+
+### Decision: Codex is a dedicated transport, not an OpenAI Responses profile
+
+- **Context:** Pi’s Codex transport has a different request path and required companion headers.
+- **Options considered:** Set a custom base URL in OpenAI Responses; add arbitrary profile header maps; implement a dedicated Codex engine/transport.
+- **Decision:** Implement a dedicated Go-only Codex transport after a fake-server contract suite proves payload and stream compatibility.
+- **Rationale:** A dedicated transport makes the nonstandard behavior auditable and avoids allowing profiles to control sensitive request metadata.
+- **Consequences:** Some Responses encoding/streaming code may need extraction into internal reusable helpers. Codex support will be explicitly experimental until a provider contract is reviewed.
+- **Status:** proposed.
+
+### Decision: Add dynamic Claude authentication only after header-contract proof
+
+- **Context:** Geppetto has a Claude Messages engine but assumes static `x-api-key` authentication.
+- **Options considered:** Reuse bearer source blindly as an API key; add dynamic source plus an explicit auth strategy; defer Claude.
+- **Decision:** First write a fake-server contract for the accepted subscription request; then add a typed Claude auth strategy if the server behavior is confirmed.
+- **Rationale:** Header semantics affect authorization and compatibility. A string token’s existence is insufficient evidence.
+- **Consequences:** Claude implementation remains a separate phase from Codex. Token counting and all non-streaming Claude paths must be audited together.
+- **Status:** proposed.
+
+### Decision: Treat Umans as static-key/Messages work
+
+- **Context:** The installed extension performs no token exchange or rotation.
+- **Options considered:** Model it as OAuth because of field names; adapt it through renewable bearer; keep it in API-key protocol work.
+- **Decision:** Keep Umans out of renewable OAuth scope.
+- **Rationale:** The implementation evidence says refresh is a no-op and the API is Anthropic Messages.
+- **Consequences:** Any Umans support should validate the Messages protocol and API-key header behavior, with no refresh tests or lifecycle claims.
+- **Status:** proposed.
+
+### 5.2 Go-only contracts
+
+The existing `BearerTokenSource` stays unchanged for ordinary OpenAI-compatible providers. Do not break every embedding host by replacing it. Add new interfaces only with a concrete consumer and tests.
+
+For a future shared request-header capability, use a typed, restricted result—not a request mutator:
+
+```go
+// Proposed: package credentials
+// This is Go-only runtime state. It is never a profile setting or JS value.
+type RequestAuth struct {
+    BearerToken string
+    // Headers are copied by the engine. The engine applies an allowlist for its
+    // own protocol and rejects Authorization, Host, and transfer framing keys.
+    Headers http.Header
+}
+
+type RequestAuthSource interface {
+    RequestAuth(context.Context, Request) (RequestAuth, error)
+}
+```
+
+This interface is **not** automatically the new default for all engines. Each engine decides whether it supports it, validates the outbound target first, copies permitted headers, and redacts errors. A Codex engine can use a private stricter contract instead:
+
+```go
+// Proposed: package openai_codex
+// Unexported credential fields must never reach profiles or JS.
+type credentialSource interface {
+    CodexCredential(context.Context, credentials.Request) (codexCredential, error)
+}
+
+type codexCredential struct {
+    bearerToken string
+    accountID   string
+}
+```
+
+The host adapter can derive account metadata from its current access token or obtain it from its own record. The Geppetto engine sees it only long enough to create the HTTP headers. No field is logged, emitted, stored in settings, or exported through JavaScript.
+
+### 5.3 Codex request flow pseudocode
+
+```go
+func (e *Engine) stream(ctx context.Context, input request) (*http.Response, error) {
+    target := resolveCodexURL(e.baseURL) // fixed /codex/responses transformation
+    if err := security.ValidateOutboundURL(target, e.outboundOptions); err != nil {
+        return nil, err // source is not called
+    }
+
+    cred, err := e.source.CodexCredential(ctx, credentials.Request{
+        Provider: "openai-codex",
+        BaseURL:  e.baseURL,
+    })
+    if err != nil {
+        return nil, redactCredentialError(err)
+    }
+
+    req := newJSONRequest(ctx, target, encodeCodexRequest(input))
+    req.Header.Set("Authorization", "Bearer "+cred.bearerToken)
+    req.Header.Set("chatgpt-account-id", cred.accountID)
+    req.Header.Set("originator", e.originator) // compile-time/defaulted option
+    req.Header.Set("OpenAI-Beta", codexResponsesBeta)
+    req.Header.Set("Accept", "text/event-stream")
+
+    resp := e.client.Do(req)
+    if resp.StatusCode == 401 && !input.hasObservedOutput && e.source.canForceRefresh() {
+        close(resp.Body)
+        refreshed := e.source.CodexCredentialAfterUnauthorized(ctx, request, cred)
+        return e.replayExactlyOnce(ctx, input, refreshed)
+    }
+    return resp, nil
+}
+```
+
+Key invariants:
+
+1. Validate the resolved final URL before acquiring a token.
+2. Keep Codex URL construction and required headers in the Codex engine, not profiles.
+3. Never include a token, account value, raw provider response, or refresh error in a returned error.
+4. Persist a rotated credential before returning a replacement after refresh.
+5. Retry exactly once, only on a pre-output 401 and only when the source explicitly supports it.
+
+### 5.4 Claude dynamic-auth flow pseudocode
+
+```go
+func (e *ClaudeEngine) newClientForRequest(ctx context.Context) (*api.Client, error) {
+    target := messagesURL(e.settings)
+    if err := security.ValidateOutboundURL(target, e.outboundOptions); err != nil {
+        return nil, err
+    }
+
+    auth, err := e.authStrategy.Resolve(ctx, credentials.Request{
+        Provider: "claude",
+        BaseURL:  baseURL(e.settings),
+    })
+    if err != nil {
+        return nil, redactCredentialError(err)
+    }
+
+    client := api.NewClient(auth.value, baseURL(e.settings))
+    client.SetAuthenticationStrategy(auth.headerName, auth.extraHeaders)
+    return client, nil
+}
+```
+
+The important incomplete part is `SetAuthenticationStrategy`. Do not implement it until a contract test says whether the approved subscription endpoint expects `Authorization`, `x-api-key`, provider beta headers, a client identity, or another mechanism. The strategy must be a typed engine option, must reject unsafe header names, and must apply to streaming, non-streaming, and token-count requests consistently.
+
+## 6. Implementation plan
+
+### Phase 0 — Freeze evidence and define the acceptance gate
+
+**Files to create/update**
+
+- This ticket’s `sources/01-local-pi-and-geppetto-source-map.md`.
+- A provider-contract fixture directory, for example `pkg/steps/ai/openai_codex/testdata/`.
+- A provider decision record in the implementation PR.
+
+**Actions**
+
+1. Pin the exact Pi and extension version used as evidence in test documentation.
+2. Extract only public protocol constants and sanitized fixture shapes; never save a local credential file.
+3. Write acceptance criteria per provider:
+   - target path;
+   - required static and dynamic header names (not values);
+   - request body expectations;
+   - SSE event mapping;
+   - token refresh/replay behavior;
+   - all prohibited logging/serialization paths.
+
+**Exit criterion:** fake-server tests can be written without an account credential.
+
+### Phase 1 — Codex transport contract tests before implementation
+
+**Likely files**
+
+- `pkg/steps/ai/openai_codex/engine_test.go` (new)
+- `pkg/steps/ai/openai_codex/stream_test.go` (new)
+- `pkg/inference/engine/factory/factory_test.go`
+
+**Tests**
+
+- base URL resolves to the Codex response path and cannot escape the configured host;
+- a credential source is not called if URL validation fails;
+- request contains expected protocol header names and no settings-derived secret;
+- a current credential yields one request;
+- an expired credential performs one locked refresh and persistence;
+- first pre-stream 401 refreshes/replays once; second 401 does not;
+- account metadata and bearer never occur in errors, trace events, or JS values;
+- JavaScript builder works only when a host supplies the capability, with no exposure API.
+
+**Exit criterion:** a fake server validates the entire outbound request shape and simulated stream.
+
+### Phase 2 — Implement the isolated Codex engine
+
+**Likely files**
+
+- `pkg/steps/ai/openai_codex/engine.go` (new)
+- `pkg/steps/ai/openai_codex/streaming.go` (new)
+- `pkg/steps/ai/openai_codex/options.go` (new)
+- `pkg/inference/engine/factory/factory.go`
+- `pkg/steps/ai/types/...` only if a new API type is justified
+
+**Implementation notes**
+
+- Prefer extracting non-provider-specific Responses event decoding into an internal package over copying a large parser.
+- Do not reuse `openai_responses` by passing a fake base URL unless the test suite proves every path and header is identical.
+- Keep the Codex credential source an engine option. It must not become `InferenceSettings.API` data.
+- Make model selection explicit and conservative; model aliases change more frequently than the transport boundary.
+
+**Exit criterion:** unit and race tests pass with a fake store/refresher and a fake inference service.
+
+### Phase 3 — Host-owned Pi adapter spike
+
+This phase belongs in Pinocchio or another host repository, not Geppetto.
+
+**Responsibilities**
+
+- require explicit opt-in to use a Pi-owned credential source;
+- implement locking compatible with the chosen storage owner, or delegate all operations to a single authorized helper;
+- map an approved Pi record into a Geppetto Codex source without serializing it into profiles;
+- preserve atomic refresh-token rotation;
+- provide only redacted local status (configured/expired/ready), not credential values;
+- inject the source into both Go and JavaScript engine construction paths in Go.
+
+**Do not do**
+
+- parse the entire auth file as a convenient generic store;
+- make an `auth.json` path configurable in profile YAML;
+- use JavaScript to choose the local credential record;
+- automatically reuse a current user’s login without an explicit host policy and user-facing documentation.
+
+**Exit criterion:** an integration test uses an in-memory or temporary fake store; it never uses the real local credential file.
+
+### Phase 4 — Claude audit and dynamic-auth design
+
+**Likely files**
+
+- `pkg/steps/ai/claude/engine_claude.go`
+- `pkg/steps/ai/claude/api/completion.go`
+- `pkg/steps/ai/claude/api/messages.go`
+- `pkg/steps/ai/claude/token_count.go`
+- `pkg/inference/engine/factory/factory.go`
+
+Audit every outbound Claude path before adding source support. The token-count path is independently static today, so changing only streaming inference would create inconsistent authentication behavior.
+
+**Exit criterion:** an approved, evidence-backed Claude request-auth strategy passes fake-server coverage for Messages, streaming, and token counting. If no stable contract is available, defer rather than guessing.
+
+### Phase 5 — Optional controlled live smoke
+
+A real smoke is permitted only after a reviewer accepts the provider’s current contract and the host owner explicitly approves use of a selected account. The smoke must:
+
+- use a non-destructive minimal request;
+- send no credentials to terminal output, test logs, source files, ticket documents, or reMarkable PDFs;
+- record only success/failure class, HTTP status category, provider version, and redacted timing;
+- avoid persistent profile modifications;
+- include a clear rollback/logout/removal plan.
+
+## 7. Testing and validation strategy
+
+### 7.1 Unit tests
+
+| Area | Assertions |
+|---|---|
+| Credential source | cache hit, expiry, refresh skew, rotated refresh persistence, cancellation isolation, no token-bearing errors |
+| Codex path builder | normalized base URL produces only approved Codex target path |
+| Headers | required keys present; forbidden override keys rejected; no source headers in event/debug data |
+| 401 handling | exactly one replay before output; never replay static credentials or a second 401 |
+| Claude strategy | request-time resolution applies identically to Messages and token count |
+| Factory | source presence authorizes only engines that explicitly support it |
+| JavaScript | builder succeeds with Go source; script cannot receive source, token, headers, expiry, or account metadata |
+
+### 7.2 Fake-server integration tests
+
+Use `httptest.NewTLSServer` and an injected HTTP client. The handler should capture only request method, path, header **names**, and a sanitized body shape. Never make test failures print full headers.
+
+```go
+func TestCodexFirst401RefreshesOnce(t *testing.T) {
+    server := newTLSServer(func(r *http.Request) response {
+        assertPath(t, r, "/backend-api/codex/responses")
+        assertHeaderPresent(t, r, "Authorization")
+        assertHeaderPresent(t, r, "chatgpt-account-id")
+        assertHeaderPresent(t, r, "originator")
+        return sequence(http.StatusUnauthorized, sseSuccess())
+    })
+
+    source := newFakeCodexSource(/* stale then replacement; values never logged */)
+    engine := newCodexEngine(server.URL, source)
+    _, err := engine.RunInference(context.Background(), userTurn("ping"))
+    require.NoError(t, err)
+    require.Equal(t, 2, server.RequestCount())
+    require.Equal(t, 1, source.ForcedRefreshCount())
+}
+```
+
+### 7.3 Commands
+
+Run from the standalone Geppetto module:
+
+```bash
+cd /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto
+GOWORK=off go test ./... -count=1
+GOWORK=off go test -race ./pkg/steps/ai/credentials ./pkg/steps/ai/openai_codex ./pkg/steps/ai/claude ./pkg/inference/engine/factory ./pkg/js/modules/geppetto -count=1
+GOWORK=off make logcopter-check
+GOWORK=off make gosec
+```
+
+Replace the future `openai_codex` package in the race command with the actual package name once implementation begins. A full repository race run remains useful but may contain unrelated baseline failures; report them separately rather than masking them.
+
+## 8. Risks, alternatives, and open questions
+
+### 8.1 Risks
+
+- **Provider contract drift:** Pi implementation may change before Geppetto implementation. Pin versions and test a captured request shape.
+- **Terms/account policy:** A token that Pi can use is not automatic approval for another application to use it. Require explicit host policy and user consent.
+- **Header leakage:** Account headers and bearer values are both private runtime state. Treat them as sensitive even if they are not cryptographic secrets.
+- **Partial coverage:** A dynamic source added only to streaming inference would leave token counting or non-streaming requests stale.
+- **Unsafe abstraction:** Arbitrary profile header maps or request callbacks create an endpoint-exfiltration path.
+- **Refresh races:** Two processes operating on the same external store need an agreed lock and atomic-write policy.
+
+### 8.2 Alternatives rejected
+
+**Treat every Pi OAuth-shaped record as a `BearerTokenSource`.** Rejected because Umans demonstrates that field names do not establish a renewable OAuth protocol, and Codex needs more than a bearer.
+
+**Embed Pi JavaScript in Geppetto.** Rejected because it violates language/runtime boundaries and turns a library into a Pi-specific credential owner.
+
+**Add `headers` and `path` maps to profiles.** Rejected because settings are serializable and user-controlled; these maps would make it easy to alter security-sensitive request behavior and leak credentials.
+
+**Use the generic OpenAI Responses engine for Codex immediately.** Rejected because the installed Pi code explicitly uses a different endpoint path and required headers.
+
+### 8.3 Open questions for review
+
+1. Is there a supported, stable provider policy for the ChatGPT Codex backend outside Pi/Codex clients?
+2. What exact Claude subscription request headers and endpoint behavior should Geppetto support, if any?
+3. Should a host adapter ever read Pi’s auth file directly, or should it invoke a dedicated local credential broker owned by Pi?
+4. Is Codex support best delivered as a Geppetto experimental engine or as a host-local engine that uses Geppetto primitives?
+5. Which model aliases and request fields are mandatory for a valid Codex request beyond endpoint and headers?
+6. What user consent and audit trail are required before an application reuses a local subscription credential?
+
+## 9. Intern checklist
+
+Before changing a line of production code, an intern should be able to answer all of these:
+
+- Which repository owns the persistent credential? If the answer is “Geppetto profile YAML,” stop: that is wrong.
+- Which engine sends the actual request? Read its URL construction, header setting, retry loop, and tests.
+- Does the provider use an OpenAI protocol, Anthropic Messages, or a custom one? Do not infer this from a model name.
+- Are all required headers known from source or provider documentation? Record the source and write a fake-server assertion.
+- Is the final URL validated before a token source is called?
+- Does refresh persist a rotated refresh token before returning a replacement access token?
+- Can JavaScript inspect any credential-adjacent data? It must not.
+- Does every outbound path use the same dynamic-auth strategy, including token counting?
+- Is a real account smoke explicitly approved and secret-safe? If not, use fixtures only.
+
+## 10. References
+
+### Geppetto source
+
+- `pkg/steps/ai/credentials/bearer.go:21-83,124-167,265-297`
+- `pkg/inference/engine/factory/factory.go:134-151,205-260`
+- `pkg/steps/ai/openai/chat_stream.go:96-105,133-168`
+- `pkg/steps/ai/openai_responses/streaming.go:148-185`
+- `pkg/steps/ai/claude/engine_claude.go:72-86`
+- `pkg/steps/ai/claude/api/completion.go:94-99`
+- `pkg/js/modules/geppetto/api_engine_builder.go:63-73`
+- Existing design: `ttmp/2026/07/10/GEPPETTO-REFRESHABLE-CREDENTIALS-387--refreshable-bearer-credentials-for-openai-compatible-providers/design-doc/01-refreshable-bearer-credential-source-analysis-design-and-implementation-guide.md`
+
+### Local Pi/extension evidence
+
+- `sources/01-local-pi-and-geppetto-source-map.md`
+- `/home/manuel/.nvm/versions/node/v22.22.1/lib/node_modules/@earendil-works/pi-coding-agent/docs/providers.md`
+- `/home/manuel/.nvm/versions/node/v22.22.1/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/utils/oauth/openai-codex.js`
+- `/home/manuel/.nvm/versions/node/v22.22.1/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/api/openai-codex-responses.js`
+- `/home/manuel/.nvm/versions/node/v22.22.1/lib/node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai/dist/utils/oauth/anthropic.js`
+- `/home/manuel/.pi/agent/npm/node_modules/pi-provider-umans/index.ts`
+- `/home/manuel/.pi/agent/npm/node_modules/pi-provider-umans/README.md`

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/design-doc/01-pi-subscription-credentials-in-geppetto-analysis-adapter-design-and-implementation-guide.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/design-doc/01-pi-subscription-credentials-in-geppetto-analysis-adapter-design-and-implementation-guide.md
@@ -38,16 +38,16 @@ WhenToUse: Use when evaluating Pi-originated subscription credentials, custom OA
 
 ## Executive summary
 
-Geppetto already has a secure, host-injected renewable bearer mechanism. A host owns persistence and refresh protocol; Geppetto asks for a bearer immediately before a supported OpenAI Chat or Responses request. This boundary is deliberately narrow and correct for ordinary OpenAI-compatible services, where `Authorization: Bearer <access-token>` is the whole authentication contract.
+Geppetto already has a secure, host-injected renewable bearer mechanism. Today a host owns persistence and refresh protocol while Geppetto asks for a bearer immediately before a supported OpenAI Chat or Responses request. This boundary is deliberately narrow and correct for ordinary OpenAI-compatible services, where `Authorization: Bearer <access-token>` is the whole authentication contract.
 
 Installed Pi code shows that the three providers initially described as “OAuth” are not the same integration problem. OpenAI Codex is a genuine refreshable ChatGPT subscription flow, but its inference transport is the ChatGPT backend with a Codex-specific path and additional account, originator, beta, and request-ID headers. Anthropic Claude Pro/Max is also a genuine refreshable OAuth flow, but it targets the Anthropic Messages protocol while Geppetto’s Claude engine currently owns a static `x-api-key` client. Umans is not renewable OAuth in the Pi extension at all: `/login` persists an API key in OAuth-shaped fields, and its refresh function returns the same value.
 
 Therefore this work must **not** copy Pi credentials into Geppetto profiles, make Geppetto parse `~/.pi/agent/auth.json`, or add “generic OAuth” claims based only on a token shape. The recommended path is a two-layer design:
 
-1. **Geppetto adds narrowly-scoped, Go-only request-authentication and transport seams only where a real engine needs them.** It remains storage-, browser-, and Pi-agnostic.
-2. **A host-owned adapter (initially Pinocchio, not Geppetto) understands a selected provider and any local Pi storage contract.** It loads, refreshes, and supplies credentials without making token material, refresh callbacks, account identity, or source-selection metadata visible to profiles or JavaScript.
+1. **Geppetto provides reusable, provider-specific lifecycle and transport primitives.** These include PKCE/state/code-exchange and refresh mechanics for supported OAuth providers, typed redacted status and local deletion, store/lock/atomic-rotation helpers, and Go-only request-auth capabilities. It remains storage-location-, CLI-, browser-launch-, and Pi-file-agnostic.
+2. **A host (initially Pinocchio) binds those primitives to its own persistence and user experience.** It selects a provider and profile, supplies its direct-YAML store, launches a browser or presents a device code, formats status, and applies consent/import policy. It never exposes token material, refresh callbacks, account identity, or source-selection metadata to profiles or JavaScript.
 
-OpenAI Codex should be a dedicated experimental adapter/engine effort, not a configuration tweak to the existing OpenAI Responses engine. Claude should be investigated through the existing Claude engine, but only after its OAuth request-header semantics are captured in a fake-server contract. Umans belongs in a separate Anthropic Messages/API-key compatibility effort, not the renewable OAuth feature.
+OpenAI Codex should be a dedicated experimental Geppetto transport/provider package, not a configuration tweak to the existing OpenAI Responses engine. Claude should extend Geppetto’s Anthropic engine only after its OAuth request-header semantics are captured in a fake-server contract. Umans belongs in Geppetto’s provider catalog as an Anthropic Messages/API-key adapter, not a renewable OAuth adapter.
 
 ## 1. Problem statement and scope
 
@@ -62,8 +62,8 @@ The answer is **potentially, provider by provider**. A record containing fields 
 This design defines how to:
 
 - classify the actual provider/transport contracts evidenced by installed Pi code;
-- preserve Geppetto’s host-owned credential ownership model;
-- add only the runtime seams required by a validated provider transport;
+- separate reusable Geppetto provider/lifecycle mechanics from host-owned credential placement and UX;
+- add only the lifecycle and runtime seams required by a validated provider transport;
 - keep all secret and credential-adjacent state out of profile YAML, settings dumps, events, logs, JavaScript, and CLI output;
 - produce a phased implementation plan that an intern can execute with fake-server tests before any account-backed smoke.
 
@@ -72,7 +72,7 @@ This design defines how to:
 This ticket does **not** authorize implementation of a provider adapter, a real account request, or a new browser-login command. It also does not:
 
 - read, copy, print, hash, upload, or commit a value from Pi’s auth file;
-- make Geppetto own Pi’s file format, file locking, browser callbacks, or refresh protocol;
+- make Geppetto own Pi’s file format, profile path, browser-launch policy, or local CLI;
 - claim the ChatGPT backend is a stable public OpenAI API contract;
 - treat the Umans API-key shim as OAuth;
 - expose a bearer, refresh callback, account identifier, raw headers, or credential-source selector to JavaScript;
@@ -83,7 +83,7 @@ This ticket does **not** authorize implementation of a provider adapter, a real 
 | Term | Meaning in this guide |
 |---|---|
 | **host** | The embedding application, such as Pinocchio, that constructs Geppetto engines. |
-| **credential store** | The host’s secret-bearing persistence owner. Pi’s auth file is one possible external source, not a Geppetto data format. |
+| **credential store** | A host-selected secret-bearing persistence implementation. Geppetto supplies store contracts and safe lifecycle helpers; Pinocchio binds its direct-YAML profile extension. Pi’s auth file is one optional external import source, not a Geppetto data format. |
 | **renewable bearer** | An access token plus an optional refresh token and expiry, acquired at request time through a host source. |
 | **transport contract** | The full endpoint, path, HTTP method, payload, headers, response stream, and retry behavior expected by a provider. |
 | **adapter** | Host-side code that turns an external credential contract into a safe Geppetto runtime capability. |
@@ -208,21 +208,22 @@ Adding an arbitrary `func(*http.Request)` callback to settings would be unsafe:
 
 ### 4.2 Why Geppetto must not read Pi’s auth file
 
-Reading Pi’s file from Geppetto would make a reusable library depend on a local tool’s private schema, lock implementation, migration behavior, and provider registrations. It also violates the existing ownership model: the host must choose storage, user interaction, and refresh policy.
+Reading Pi’s file from Geppetto would make a reusable library depend on a local tool’s private schema, lock implementation, migration behavior, and provider registrations. Geppetto should instead provide the reusable provider protocol and lifecycle mechanics while the host chooses credential placement, user interaction, and consent policy.
 
 The correct dependency direction is:
 
 ```text
 Pinocchio or another host
-  ├── chooses whether Pi auth storage is a permitted local source
-  ├── owns safe locking, migration, and user consent
-  ├── constructs a provider-specific adapter
-  └── injects Go-only runtime capability into Geppetto
+  ├── binds a Geppetto store to its direct-YAML/profile location
+  ├── launches browser or presents device code and renders CLI status
+  ├── decides whether a Pi record may be explicitly imported/migrated
+  └── injects Go-only runtime capability into Go and JavaScript engine builders
 
 Geppetto
+  ├── owns supported provider PKCE, exchange, refresh, status, and local-delete primitives
   ├── validates outbound target before credential release
   ├── implements provider protocol and bounded replay behavior
-  └── never reads host credential files or launches a browser
+  └── never discovers host credential files, chooses a profile, or launches a browser
 ```
 
 ### 4.3 Why no generic “OAuth provider” abstraction
@@ -242,17 +243,26 @@ A generic `OAuthProvider` in Geppetto would collapse these concerns and invite u
 
 ### 5.1 Architectural decision
 
-Implement provider transports as dedicated engines or dedicated engine modes, and use a restricted Go-only request-auth capability for metadata only where a shared protocol implementation can safely consume it.
+Implement reusable provider lifecycle packages and provider transports in Geppetto, then bind them to host-selected stores and UI. Each lifecycle package owns its supported provider’s OAuth/API-key protocol behavior; each host owns where credentials live, how a login is presented, and whether another application’s record may be imported.
 
 Do **not** turn the current generic OpenAI Responses engine into a configurable Codex client by adding profile keys for endpoint suffixes or header maps.
 
 ```text
-                     host-owned, secret-bearing layer
+                     host-owned binding and interaction policy
  +----------------------------------------------------------------+
- | Provider adapter                                                |
- |  - selected storage owner                                       |
- |  - locked load/refresh/save                                     |
- |  - current access token + private runtime metadata             |
+ | Pinocchio or another application                                |
+ |  - direct-YAML, keychain, database, or in-memory Store binding  |
+ |  - profile/provider selection, consent, CLI/browser UI          |
+ |  - optional explicit Pi migration                               |
+ +-------------------------------+--------------------------------+
+                                 |
+             typed Store + browser/device-code callbacks; no settings/JS secrets
+                                 v
+ +-------------------------------+--------------------------------+
+ | Geppetto credentials/providers                                  |
+ |  - PKCE/state, authorization URL, code exchange, refresh        |
+ |  - locking/atomic rotation helpers, redacted Status, Delete     |
+ |  - typed private runtime credential metadata                     |
  +-------------------------------+--------------------------------+
                                  |
                    Go-only typed capability, never settings/JS
@@ -260,7 +270,8 @@ Do **not** turn the current generic OpenAI Responses engine into a configurable 
  +-------------------------------+--------------------------------+
  | Geppetto provider engine                                        |
  |  Codex engine: target + request framing + sanctioned headers    |
- |  Claude engine: Message protocol + tested auth strategy         |
+ |  Claude engine: Messages protocol + tested auth strategy        |
+ |  Umans adapter: Messages protocol + static API-key strategy     |
  |  OpenAI engines: existing bearer-only behavior                  |
  +-------------------------------+--------------------------------+
                                  |
@@ -269,13 +280,13 @@ Do **not** turn the current generic OpenAI Responses engine into a configurable 
                            provider inference API
 ```
 
-### Decision: Preserve Geppetto’s host-agnostic ownership
+### Decision: Geppetto owns reusable lifecycle; hosts own binding and policy
 
-- **Context:** Pi storage and provider logic are local application behavior, while Geppetto is a reusable library.
-- **Options considered:** Parse Pi storage in Geppetto; add a Pi dependency to Geppetto; keep all Pi integration in hosts.
-- **Decision:** Keep Pi storage parsing, browser login, and refresh protocol in a host-owned adapter.
-- **Rationale:** This preserves existing credential ownership, avoids a Node/runtime dependency in Go, and lets non-Pi hosts use the same engines.
-- **Consequences:** The host must perform explicit adapter wiring. Geppetto documentation must show capability injection, not a magic profile flag.
+- **Context:** OAuth exchange/refresh and request contracts are provider behavior worth sharing, while disk location, profile schema, browser launch, and consent are application behavior.
+- **Options considered:** Put all lifecycle protocol in every host; parse Pi storage in Geppetto; provide provider lifecycle packages plus host-injected storage/UI bindings.
+- **Decision:** Geppetto provides provider-specific lifecycle packages, generic lifecycle/store helpers, and provider engines. Hosts supply a selected `Store`, browser/device-code presentation, selected identity, and import policy.
+- **Rationale:** This avoids duplicating PKCE/refresh/status/delete mechanics in every Go application without coupling Geppetto to Pi or Pinocchio storage.
+- **Consequences:** Geppetto needs stable, documented interfaces for store operations and interactive login callbacks. Pinocchio can retain its direct-YAML extension as a store adapter and CLI binding. A future host can instead use a keychain or database without reimplementing provider protocol.
 - **Status:** proposed.
 
 ### Decision: Codex is a dedicated transport, not an OpenAI Responses profile
@@ -305,9 +316,43 @@ Do **not** turn the current generic OpenAI Responses engine into a configurable 
 - **Consequences:** Any Umans support should validate the Messages protocol and API-key header behavior, with no refresh tests or lifecycle claims.
 - **Status:** proposed.
 
-### 5.2 Go-only contracts
+### 5.2 Lifecycle, store, and interaction contracts
 
 The existing `BearerTokenSource` stays unchanged for ordinary OpenAI-compatible providers. Do not break every embedding host by replacing it. Add new interfaces only with a concrete consumer and tests.
+
+Geppetto should expose a small provider-lifecycle surface that hosts can compose instead of reimplementing token handling:
+
+```go
+// Proposed: package credentials
+// Values are never formatted by these APIs and must remain out of settings/JS.
+type Store interface {
+    Load(context.Context, Key) (Credential, error)
+    Save(context.Context, Key, Credential) error // atomically replaces rotations
+    Delete(context.Context, Key) error
+}
+
+type Status struct {
+    State     State // Missing, Ready, Expiring, Expired, RefreshFailed
+    ExpiresAt time.Time
+    Renewable bool
+}
+
+type ProviderFlow interface {
+    BeginLogin(context.Context, LoginRequest) (AuthorizationRequest, error)
+    CompleteLogin(context.Context, LoginCompletion) (Credential, error)
+    Refresh(context.Context, Credential) (Credential, error)
+}
+
+func Login(ctx context.Context, store Store, key Key, flow ProviderFlow, presenter Presenter) (Status, error)
+func StatusOf(ctx context.Context, store Store, key Key, now time.Time) (Status, error)
+func Logout(ctx context.Context, store Store, key Key) error
+```
+
+`Presenter` is deliberately host-controlled: it can open a browser, display a URL/device code, or integrate with another UI. The flow validates PKCE state and the exact callback redirect; it does not launch a browser. `Logout` is local deletion. A separately named, provider-specific `Revoke` operation may be added only after client-authentication and endpoint semantics are documented.
+
+`Store` describes persistence semantics, not a required serialization format. Geppetto should provide an in-memory implementation and reusable locking/atomic-update helpers. A filesystem implementation, if added, must require an explicit caller-owned path and codec; it must never discover a profile file or default to Pi storage. Pinocchio’s direct YAML extension remains a host adapter over this contract.
+
+### 5.3 Go-only request-auth contracts
 
 For a future shared request-header capability, use a typed, restricted result—not a request mutator:
 
@@ -341,9 +386,9 @@ type codexCredential struct {
 }
 ```
 
-The host adapter can derive account metadata from its current access token or obtain it from its own record. The Geppetto engine sees it only long enough to create the HTTP headers. No field is logged, emitted, stored in settings, or exported through JavaScript.
+A Geppetto provider lifecycle package derives account metadata from its current credential or provider result. The engine sees it only long enough to create the HTTP headers. The host store persists it only if the typed provider record requires it; no field is logged, emitted, stored in settings, or exported through JavaScript.
 
-### 5.3 Codex request flow pseudocode
+### 5.4 Codex request flow pseudocode
 
 ```go
 func (e *Engine) stream(ctx context.Context, input request) (*http.Response, error) {
@@ -385,7 +430,7 @@ Key invariants:
 4. Persist a rotated credential before returning a replacement after refresh.
 5. Retry exactly once, only on a pre-output 401 and only when the source explicitly supports it.
 
-### 5.4 Claude dynamic-auth flow pseudocode
+### 5.5 Claude dynamic-auth flow pseudocode
 
 ```go
 func (e *ClaudeEngine) newClientForRequest(ctx context.Context) (*api.Client, error) {
@@ -412,7 +457,7 @@ The important incomplete part is `SetAuthenticationStrategy`. Do not implement i
 
 ## 6. Implementation plan
 
-### Phase 0 — Freeze evidence and define the acceptance gate
+### Phase 0 — Define the reusable lifecycle API and freeze provider evidence
 
 **Files to create/update**
 
@@ -431,8 +476,9 @@ The important incomplete part is `SetAuthenticationStrategy`. Do not implement i
    - SSE event mapping;
    - token refresh/replay behavior;
    - all prohibited logging/serialization paths.
+4. Write lifecycle-contract tests for `Store`, `Login`, `StatusOf`, local `Logout`, and a fake `Presenter`; verify that provider flow code never selects a file path or writes UI output.
 
-**Exit criterion:** fake-server tests can be written without an account credential.
+**Exit criterion:** fake-server tests and lifecycle tests can be written without an account credential or a Pinocchio profile.
 
 ### Phase 1 — Codex transport contract tests before implementation
 
@@ -474,29 +520,44 @@ The important incomplete part is `SetAuthenticationStrategy`. Do not implement i
 
 **Exit criterion:** unit and race tests pass with a fake store/refresher and a fake inference service.
 
-### Phase 3 — Host-owned Pi adapter spike
+### Phase 3 — Implement Geppetto lifecycle/provider packages
 
-This phase belongs in Pinocchio or another host repository, not Geppetto.
+This phase belongs in Geppetto. It turns the current generic renewable-bearer mechanics into composable lifecycle primitives and adds supported provider protocol modules.
 
 **Responsibilities**
 
-- require explicit opt-in to use a Pi-owned credential source;
-- implement locking compatible with the chosen storage owner, or delegate all operations to a single authorized helper;
-- map an approved Pi record into a Geppetto Codex source without serializing it into profiles;
-- preserve atomic refresh-token rotation;
-- provide only redacted local status (configured/expired/ready), not credential values;
+- provide `Store` semantics, in-memory/fake stores, and locking/atomic-rotation helpers;
+- provide redacted `StatusOf` and idempotent local `Logout`/delete;
+- provide typed PKCE/state/authorization-code flow support with host-provided presentation;
+- implement only verified provider modules: OpenAI/Codex, Anthropic, and Umans API-key configuration;
+- map a provider lifecycle result into a Go-only engine source without serializing it into profiles;
+- preserve rotated credential persistence before returning refreshed access;
 - inject the source into both Go and JavaScript engine construction paths in Go.
 
 **Do not do**
 
-- parse the entire auth file as a convenient generic store;
+- parse the entire Pi auth file as a convenient generic store;
 - make an `auth.json` path configurable in profile YAML;
+- have Geppetto choose a host’s credential path, profile, browser behavior, or consent policy;
 - use JavaScript to choose the local credential record;
-- automatically reuse a current user’s login without an explicit host policy and user-facing documentation.
+- automatically reuse a current user’s Pi login without an explicit host import/migration policy.
 
-**Exit criterion:** an integration test uses an in-memory or temporary fake store; it never uses the real local credential file.
+**Exit criterion:** provider and lifecycle integration tests use an in-memory or temporary fake store and fake presenter; they never use the real local credential file.
 
-### Phase 4 — Claude audit and dynamic-auth design
+### Phase 4 — Bind Pinocchio’s direct-YAML lifecycle and optional Pi migration
+
+This phase belongs in Pinocchio or another host repository.
+
+**Responsibilities**
+
+- adapt the existing `extensions."pinocchio.oauth@v1"` direct-YAML persistence to Geppetto’s `Store` contract while retaining Pinocchio’s locking and atomic write guarantees;
+- implement the existing Glazed login/status/logout commands by calling Geppetto lifecycle APIs and formatting only redacted status;
+- select profile/provider and browser presentation in Pinocchio, never in Geppetto;
+- make any Pi import an explicit user-directed migration into Pinocchio-owned storage, with no silent linking or shared mutable ownership.
+
+**Exit criterion:** Pinocchio tests prove the selected profile receives a host-owned store binding and neither Go nor JavaScript exposes credential capability.
+
+### Phase 5 — Claude audit and dynamic-auth design
 
 **Likely files**
 
@@ -510,7 +571,7 @@ Audit every outbound Claude path before adding source support. The token-count p
 
 **Exit criterion:** an approved, evidence-backed Claude request-auth strategy passes fake-server coverage for Messages, streaming, and token counting. If no stable contract is available, defer rather than guessing.
 
-### Phase 5 — Optional controlled live smoke
+### Phase 6 — Optional controlled live smoke
 
 A real smoke is permitted only after a reviewer accepts the provider’s current contract and the host owner explicitly approves use of a selected account. The smoke must:
 
@@ -526,6 +587,7 @@ A real smoke is permitted only after a reviewer accepts the provider’s current
 
 | Area | Assertions |
 |---|---|
+| Lifecycle/store | login state/PKCE validation, atomic rotation-before-return, idempotent local delete, redacted status, cancellation isolation, no token-bearing errors |
 | Credential source | cache hit, expiry, refresh skew, rotated refresh persistence, cancellation isolation, no token-bearing errors |
 | Codex path builder | normalized base URL produces only approved Codex target path |
 | Headers | required keys present; forbidden override keys rejected; no source headers in event/debug data |
@@ -581,12 +643,13 @@ Replace the future `openai_codex` package in the race command with the actual pa
 - **Partial coverage:** A dynamic source added only to streaming inference would leave token counting or non-streaming requests stale.
 - **Unsafe abstraction:** Arbitrary profile header maps or request callbacks create an endpoint-exfiltration path.
 - **Refresh races:** Two processes operating on the same external store need an agreed lock and atomic-write policy.
+- **Overreaching lifecycle API:** A Geppetto file store that silently selects paths or a login helper that launches browsers would erase the necessary application-policy boundary.
 
 ### 8.2 Alternatives rejected
 
 **Treat every Pi OAuth-shaped record as a `BearerTokenSource`.** Rejected because Umans demonstrates that field names do not establish a renewable OAuth protocol, and Codex needs more than a bearer.
 
-**Embed Pi JavaScript in Geppetto.** Rejected because it violates language/runtime boundaries and turns a library into a Pi-specific credential owner.
+**Embed Pi JavaScript or parse Pi storage in Geppetto.** Rejected because it violates language/runtime boundaries and turns a reusable provider-lifecycle library into a Pi-specific credential owner.
 
 **Add `headers` and `path` maps to profiles.** Rejected because settings are serializable and user-controlled; these maps would make it easy to alter security-sensitive request behavior and leak credentials.
 
@@ -596,8 +659,8 @@ Replace the future `openai_codex` package in the race command with the actual pa
 
 1. Is there a supported, stable provider policy for the ChatGPT Codex backend outside Pi/Codex clients?
 2. What exact Claude subscription request headers and endpoint behavior should Geppetto support, if any?
-3. Should a host adapter ever read Pi’s auth file directly, or should it invoke a dedicated local credential broker owned by Pi?
-4. Is Codex support best delivered as a Geppetto experimental engine or as a host-local engine that uses Geppetto primitives?
+3. Should Pinocchio offer an explicit one-time Pi import, or should Pi use require a dedicated local credential broker?
+4. Is Codex support best delivered as a Geppetto experimental engine or as a host-local engine composed from Geppetto primitives?
 5. Which model aliases and request fields are mandatory for a valid Codex request beyond endpoint and headers?
 6. What user consent and audit trail are required before an application reuses a local subscription credential?
 
@@ -605,7 +668,7 @@ Replace the future `openai_codex` package in the race command with the actual pa
 
 Before changing a line of production code, an intern should be able to answer all of these:
 
-- Which repository owns the persistent credential? If the answer is “Geppetto profile YAML,” stop: that is wrong.
+- Which host-selected store owns the persistent credential? If the answer is “Geppetto discovers profile YAML,” stop: that is wrong.
 - Which engine sends the actual request? Read its URL construction, header setting, retry loop, and tests.
 - Does the provider use an OpenAI protocol, Anthropic Messages, or a custom one? Do not infer this from a model name.
 - Are all required headers known from source or provider documentation? Record the source and write a fake-server assertion.

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/design-doc/01-pi-subscription-credentials-in-geppetto-analysis-adapter-design-and-implementation-guide.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/design-doc/01-pi-subscription-credentials-in-geppetto-analysis-adapter-design-and-implementation-guide.md
@@ -47,7 +47,7 @@ Therefore this work must **not** copy Pi credentials into Geppetto profiles, mak
 1. **Geppetto provides reusable, provider-specific lifecycle and transport primitives.** These include PKCE/state/code-exchange and refresh mechanics for supported OAuth providers, typed redacted status and local deletion, store/lock/atomic-rotation helpers, and Go-only request-auth capabilities. It remains storage-location-, CLI-, browser-launch-, and Pi-file-agnostic.
 2. **A host (initially Pinocchio) binds those primitives to its own persistence and user experience.** It selects a provider and profile, supplies its direct-YAML store, launches a browser or presents a device code, formats status, and applies consent/import policy. It never exposes token material, refresh callbacks, account identity, or source-selection metadata to profiles or JavaScript.
 
-OpenAI Codex should be a dedicated experimental Geppetto transport/provider package, not a configuration tweak to the existing OpenAI Responses engine. Claude should extend Geppetto’s Anthropic engine only after its OAuth request-header semantics are captured in a fake-server contract. Umans belongs in Geppetto’s provider catalog as an Anthropic Messages/API-key adapter, not a renewable OAuth adapter.
+OpenAI Codex should use the existing OpenAI Responses core through a trusted Codex route resolver and request/response middleware, not through profile-configured paths or header maps. Claude should gain the same restricted middleware seam only after its OAuth request-header semantics are captured in a fake-server contract. Umans belongs in Geppetto’s provider catalog as an Anthropic Messages/API-key middleware/adapter, not a renewable OAuth adapter.
 
 ## 1. Problem statement and scope
 
@@ -86,8 +86,8 @@ This ticket does **not** authorize implementation of a provider adapter, a real 
 | **credential store** | A host-selected secret-bearing persistence implementation. Geppetto supplies store contracts and safe lifecycle helpers; Pinocchio binds its direct-YAML profile extension. Pi’s auth file is one optional external import source, not a Geppetto data format. |
 | **renewable bearer** | An access token plus an optional refresh token and expiry, acquired at request time through a host source. |
 | **transport contract** | The full endpoint, path, HTTP method, payload, headers, response stream, and retry behavior expected by a provider. |
-| **adapter** | Host-side code that turns an external credential contract into a safe Geppetto runtime capability. |
-| **engine** | Geppetto’s provider protocol implementation, such as OpenAI Chat, OpenAI Responses, or Claude Messages. |
+| **provider adapter** | Trusted Go-only code that binds a provider route resolver, restricted request/response middleware, credential source, and optional stream codec to a shared Geppetto engine core. |
+| **engine core** | Geppetto’s shared provider-protocol implementation, such as OpenAI Responses or Anthropic Messages, which owns request construction, URL validation, send/retry orchestration, and stream consumption. |
 | **metadata** | Non-token companion values such as an account identifier. It is still private runtime state and must not be shown to JavaScript or diagnostics. |
 
 ## 2. Current-state architecture
@@ -268,11 +268,11 @@ Do **not** turn the current generic OpenAI Responses engine into a configurable 
                    Go-only typed capability, never settings/JS
                                  v
  +-------------------------------+--------------------------------+
- | Geppetto provider engine                                        |
- |  Codex engine: target + request framing + sanctioned headers    |
- |  Claude engine: Messages protocol + tested auth strategy        |
- |  Umans adapter: Messages protocol + static API-key strategy     |
- |  OpenAI engines: existing bearer-only behavior                  |
+ | Geppetto shared engine cores + provider adapters                |
+ |  OpenAI Responses core + Codex route/middleware                 |
+ |  Anthropic Messages core + Claude auth middleware               |
+ |  Anthropic Messages core + Umans API-key middleware             |
+ |  OpenAI engines + ordinary bearer middleware                    |
  +-------------------------------+--------------------------------+
                                  |
                          validated outbound HTTP request
@@ -289,13 +289,13 @@ Do **not** turn the current generic OpenAI Responses engine into a configurable 
 - **Consequences:** Geppetto needs stable, documented interfaces for store operations and interactive login callbacks. Pinocchio can retain its direct-YAML extension as a store adapter and CLI binding. A future host can instead use a keychain or database without reimplementing provider protocol.
 - **Status:** proposed.
 
-### Decision: Codex is a dedicated transport, not an OpenAI Responses profile
+### Decision: Codex is a trusted middleware adapter over the Responses core
 
-- **Context:** Pi’s Codex transport has a different request path and required companion headers.
-- **Options considered:** Set a custom base URL in OpenAI Responses; add arbitrary profile header maps; implement a dedicated Codex engine/transport.
-- **Decision:** Implement a dedicated Go-only Codex transport after a fake-server contract suite proves payload and stream compatibility.
-- **Rationale:** A dedicated transport makes the nonstandard behavior auditable and avoids allowing profiles to control sensitive request metadata.
-- **Consequences:** Some Responses encoding/streaming code may need extraction into internal reusable helpers. Codex support will be explicitly experimental until a provider contract is reviewed.
+- **Context:** Pi’s Codex transport has a different request path and required companion headers, but may share request framing and streaming semantics with OpenAI Responses.
+- **Options considered:** Set a custom base URL in OpenAI Responses; add arbitrary profile header maps; copy a dedicated Codex engine; add a restricted provider route/middleware adapter to the shared Responses core.
+- **Decision:** Add a Go-only Codex route resolver and restricted request/response middleware to the Responses core after fake-server tests prove which request and SSE behavior is shared.
+- **Rationale:** The core retains URL validation, request send/retry orchestration, cancellation, and stream ownership. The Codex middleware contains the few Codex-only headers and typed credential behavior, avoiding both hundreds of duplicated lines and an unsafe public request-mutator API.
+- **Consequences:** The middleware seam must be intentionally constrained and provider-installed; profile settings and JavaScript cannot configure it. A provider-specific stream codec remains available if Codex events differ.
 - **Status:** proposed.
 
 ### Decision: Add dynamic Claude authentication only after header-contract proof
@@ -352,108 +352,91 @@ func Logout(ctx context.Context, store Store, key Key) error
 
 `Store` describes persistence semantics, not a required serialization format. Geppetto should provide an in-memory implementation and reusable locking/atomic-update helpers. A filesystem implementation, if added, must require an explicit caller-owned path and codec; it must never discover a profile file or default to Pi storage. Pinocchio’s direct YAML extension remains a host adapter over this contract.
 
-### 5.3 Go-only request-auth contracts
+### 5.3 Go-only route and request/response middleware contracts
 
-For a future shared request-header capability, use a typed, restricted result—not a request mutator:
+The engine core owns the HTTP request and response body. A provider adapter receives neither a mutable request URL/body nor a stream body. This avoids a general `func(*http.Request)` escape hatch while allowing a few credential-dependent headers to be injected consistently across OpenAI and Anthropic engines.
 
 ```go
-// Proposed: package credentials
-// This is Go-only runtime state. It is never a profile setting or JS value.
-type RequestAuth struct {
-    BearerToken string
-    // Headers are copied by the engine. The engine applies an allowlist for its
-    // own protocol and rejects Authorization, Host, and transfer framing keys.
-    Headers http.Header
+// Proposed: package transport
+// RequestContext is read-only and contains the already validated final URL.
+type RequestContext struct {
+    Provider  string
+    Operation string
+    URL       url.URL
 }
 
-type RequestAuthSource interface {
-    RequestAuth(context.Context, Request) (RequestAuth, error)
+type HeaderWriter interface {
+    Set(name, value string) error // permits only engine-declared header names
+}
+
+type Middleware interface {
+    BeforeRequest(context.Context, RequestContext, HeaderWriter) (Attempt, error)
+    AfterResponse(context.Context, RequestContext, Attempt, ResponseMetadata) (ResponseDecision, error)
+}
+
+type RouteResolver interface {
+    Resolve(baseURL *url.URL, operation string) (*url.URL, error)
 }
 ```
 
-This interface is **not** automatically the new default for all engines. Each engine decides whether it supports it, validates the outbound target first, copies permitted headers, and redacts errors. A Codex engine can use a private stricter contract instead:
+The core calls `RouteResolver.Resolve`, validates the resulting final URL, builds the request, then runs `BeforeRequest`. `AfterResponse` receives status and safe response metadata before any stream output is emitted; it can request a single bounded retry but cannot consume, replace, or rewrite the response body. The engine owns close/retry/decode behavior.
+
+`HeaderWriter` is configured with a static allowlist supplied by the engine/provider adapter. It rejects `Host`, transfer/framing headers, and undeclared names; values are never formatted into errors, trace events, or JavaScript values. Middleware is installed only through typed Go engine options, never from profile settings or JavaScript.
+
+A Codex middleware is constructed only from a typed `CodexCredentialSource`. It resolves the current bearer and private account metadata, sets the sanctioned Codex header names, and requests a forced credential refresh only for the first pre-stream 401. The source and opaque `Attempt` state never cross the engine boundary. A Geppetto provider lifecycle package derives needed metadata from its current credential or provider result; the host store persists it only if the typed provider record requires it.
+
+### 5.4 Codex middleware flow pseudocode
 
 ```go
-// Proposed: package openai_codex
-// Unexported credential fields must never reach profiles or JS.
-type credentialSource interface {
-    CodexCredential(context.Context, credentials.Request) (codexCredential, error)
-}
-
-type codexCredential struct {
-    bearerToken string
-    accountID   string
-}
-```
-
-A Geppetto provider lifecycle package derives account metadata from its current credential or provider result. The engine sees it only long enough to create the HTTP headers. The host store persists it only if the typed provider record requires it; no field is logged, emitted, stored in settings, or exported through JavaScript.
-
-### 5.4 Codex request flow pseudocode
-
-```go
-func (e *Engine) stream(ctx context.Context, input request) (*http.Response, error) {
-    target := resolveCodexURL(e.baseURL) // fixed /codex/responses transformation
-    if err := security.ValidateOutboundURL(target, e.outboundOptions); err != nil {
-        return nil, err // source is not called
-    }
-
-    cred, err := e.source.CodexCredential(ctx, credentials.Request{
-        Provider: "openai-codex",
-        BaseURL:  e.baseURL,
+// Proposed: package providers/openaicodex
+func (m *CredentialMiddleware) BeforeRequest(
+    ctx context.Context, req transport.RequestContext, headers transport.HeaderWriter,
+) (transport.Attempt, error) {
+    credential, err := m.source.CodexCredential(ctx, credentials.Request{
+        Provider: "openai-codex", BaseURL: req.URL.Scheme + "://" + req.URL.Host,
     })
     if err != nil {
-        return nil, redactCredentialError(err)
+        return nil, credentials.RedactError(err)
     }
-
-    req := newJSONRequest(ctx, target, encodeCodexRequest(input))
-    req.Header.Set("Authorization", "Bearer "+cred.bearerToken)
-    req.Header.Set("chatgpt-account-id", cred.accountID)
-    req.Header.Set("originator", e.originator) // compile-time/defaulted option
-    req.Header.Set("OpenAI-Beta", codexResponsesBeta)
-    req.Header.Set("Accept", "text/event-stream")
-
-    resp := e.client.Do(req)
-    if resp.StatusCode == 401 && !input.hasObservedOutput && e.source.canForceRefresh() {
-        close(resp.Body)
-        refreshed := e.source.CodexCredentialAfterUnauthorized(ctx, request, cred)
-        return e.replayExactlyOnce(ctx, input, refreshed)
-    }
-    return resp, nil
+    if err := headers.Set("Authorization", "Bearer "+credential.bearerToken); err != nil { return nil, err }
+    if err := headers.Set("chatgpt-account-id", credential.accountID); err != nil { return nil, err }
+    if err := headers.Set("originator", codexOriginator); err != nil { return nil, err }
+    if err := headers.Set("OpenAI-Beta", codexResponsesBeta); err != nil { return nil, err }
+    return newAttempt(credential), nil // opaque and never logged
 }
+
+func (m *CredentialMiddleware) AfterResponse(
+    ctx context.Context, req transport.RequestContext, attempt transport.Attempt, response transport.ResponseMetadata,
+) (transport.ResponseDecision, error) {
+    if response.StatusCode != http.StatusUnauthorized || response.StreamStarted {
+        return transport.Continue, nil
+    }
+    return m.source.ForceRefreshAfterUnauthorized(ctx, attempt) // core permits one retry total
+}
+
+// Inside the shared Responses core:
+target := adapter.Route.Resolve(baseURL, "responses")
+validateOutboundURL(target)                 // before BeforeRequest
+request := buildResponsesRequest(ctx, target, input)
+attempt := middleware.BeforeRequest(ctx, requestContext(target), request.headers)
+response := client.Do(request)
+decision := middleware.AfterResponse(ctx, requestContext(target), attempt, responseMetadata(response))
+return core.retryOnceOrDecodeResponsesStream(response, decision)
 ```
 
 Key invariants:
 
-1. Validate the resolved final URL before acquiring a token.
-2. Keep Codex URL construction and required headers in the Codex engine, not profiles.
-3. Never include a token, account value, raw provider response, or refresh error in a returned error.
-4. Persist a rotated credential before returning a replacement after refresh.
-5. Retry exactly once, only on a pre-output 401 and only when the source explicitly supports it.
+1. The route resolver produces the Codex target and the core validates the final URL before credential middleware runs.
+2. Codex header injection is in trusted middleware installed only for the Codex provider adapter, never in profiles or JavaScript.
+3. `HeaderWriter` allowlists the Codex header names; no middleware can alter URL, host, framing, request body, or stream body.
+4. Never include a token, account value, raw provider response, or refresh error in a returned error.
+5. The core, not middleware, closes/replays the request exactly once on a pre-output 401.
 
-### 5.5 Claude dynamic-auth flow pseudocode
+### 5.5 Claude and Umans middleware flow
 
-```go
-func (e *ClaudeEngine) newClientForRequest(ctx context.Context) (*api.Client, error) {
-    target := messagesURL(e.settings)
-    if err := security.ValidateOutboundURL(target, e.outboundOptions); err != nil {
-        return nil, err
-    }
+Claude and Umans use the same engine-level middleware seam after their request contracts are proven. Claude’s future OAuth middleware resolves only the approved dynamic authentication form and requests refresh after an eligible 401. Umans’ static API-key middleware resolves its host-provided key and sets only its approved Anthropic Messages header form; it never advertises refresh support.
 
-    auth, err := e.authStrategy.Resolve(ctx, credentials.Request{
-        Provider: "claude",
-        BaseURL:  baseURL(e.settings),
-    })
-    if err != nil {
-        return nil, redactCredentialError(err)
-    }
-
-    client := api.NewClient(auth.value, baseURL(e.settings))
-    client.SetAuthenticationStrategy(auth.headerName, auth.extraHeaders)
-    return client, nil
-}
-```
-
-The important incomplete part is `SetAuthenticationStrategy`. Do not implement it until a contract test says whether the approved subscription endpoint expects `Authorization`, `x-api-key`, provider beta headers, a client identity, or another mechanism. The strategy must be a typed engine option, must reject unsafe header names, and must apply to streaming, non-streaming, and token-count requests consistently.
+The Anthropic Messages core must invoke the middleware on streaming, non-streaming, and token-count requests. Do not implement the middleware until a fake-server contract establishes the exact allowed header names, required beta/client headers, and retry semantics. As with Codex, it is a typed Go engine option and cannot be supplied by settings or JavaScript.
 
 ## 6. Implementation plan
 
@@ -480,45 +463,47 @@ The important incomplete part is `SetAuthenticationStrategy`. Do not implement i
 
 **Exit criterion:** fake-server tests and lifecycle tests can be written without an account credential or a Pinocchio profile.
 
-### Phase 1 — Codex transport contract tests before implementation
+### Phase 1 — Middleware and Codex contract tests before implementation
 
 **Likely files**
 
-- `pkg/steps/ai/openai_codex/engine_test.go` (new)
-- `pkg/steps/ai/openai_codex/stream_test.go` (new)
+- `pkg/steps/ai/transport/middleware.go` (new, or an existing internal transport package)
+- `pkg/steps/ai/openai_responses/*_test.go`
+- `pkg/steps/ai/providers/openaicodex/*_test.go` (new)
 - `pkg/inference/engine/factory/factory_test.go`
 
 **Tests**
 
-- base URL resolves to the Codex response path and cannot escape the configured host;
-- a credential source is not called if URL validation fails;
-- request contains expected protocol header names and no settings-derived secret;
-- a current credential yields one request;
-- an expired credential performs one locked refresh and persistence;
-- first pre-stream 401 refreshes/replays once; second 401 does not;
+- a route resolver resolves the Codex response path and cannot escape the configured host;
+- the core validates the final URL before it calls middleware;
+- `HeaderWriter` permits declared names and rejects URL/host/framing/undeclared-header mutation;
+- a Codex middleware cannot be installed for ordinary OpenAI and an ordinary bearer source cannot construct Codex middleware;
+- a current credential yields one request; an expired credential performs one locked refresh and persistence;
+- first pre-stream 401 requests one retry; a second 401 or post-output error does not;
 - account metadata and bearer never occur in errors, trace events, or JS values;
-- JavaScript builder works only when a host supplies the capability, with no exposure API.
+- JavaScript builder works only when the host installs the provider adapter in Go, with no exposure API.
 
-**Exit criterion:** a fake server validates the entire outbound request shape and simulated stream.
+**Exit criterion:** fake servers validate middleware ordering, the complete outbound request shape, and simulated stream behavior without an account credential.
 
-### Phase 2 — Implement the isolated Codex engine
+### Phase 2 — Implement the shared engine middleware seam and Codex adapter
 
 **Likely files**
 
-- `pkg/steps/ai/openai_codex/engine.go` (new)
-- `pkg/steps/ai/openai_codex/streaming.go` (new)
-- `pkg/steps/ai/openai_codex/options.go` (new)
+- `pkg/steps/ai/transport/middleware.go` (new)
+- `pkg/steps/ai/openai_responses/streaming.go`
+- `pkg/steps/ai/openai_responses/engine.go`
+- `pkg/steps/ai/providers/openaicodex/route.go` (new)
+- `pkg/steps/ai/providers/openaicodex/middleware.go` (new)
 - `pkg/inference/engine/factory/factory.go`
-- `pkg/steps/ai/types/...` only if a new API type is justified
 
 **Implementation notes**
 
-- Prefer extracting non-provider-specific Responses event decoding into an internal package over copying a large parser.
-- Do not reuse `openai_responses` by passing a fake base URL unless the test suite proves every path and header is identical.
-- Keep the Codex credential source an engine option. It must not become `InferenceSettings.API` data.
+- The Responses core owns final URL validation, request construction, HTTP execution, retry bounds, response-body close, and stream decode.
+- Codex owns only the route resolver, typed credential/header middleware, and an optional stream codec if tests prove Responses SSE is not compatible.
+- Keep middleware a typed Go engine option. It must not become `InferenceSettings.API` data, a profile header map, or a JavaScript value.
 - Make model selection explicit and conservative; model aliases change more frequently than the transport boundary.
 
-**Exit criterion:** unit and race tests pass with a fake store/refresher and a fake inference service.
+**Exit criterion:** unit and race tests pass with fake stores/refreshers, a fake middleware, and a fake inference service.
 
 ### Phase 3 — Implement Geppetto lifecycle/provider packages
 
@@ -589,10 +574,10 @@ A real smoke is permitted only after a reviewer accepts the provider’s current
 |---|---|
 | Lifecycle/store | login state/PKCE validation, atomic rotation-before-return, idempotent local delete, redacted status, cancellation isolation, no token-bearing errors |
 | Credential source | cache hit, expiry, refresh skew, rotated refresh persistence, cancellation isolation, no token-bearing errors |
-| Codex path builder | normalized base URL produces only approved Codex target path |
-| Headers | required keys present; forbidden override keys rejected; no source headers in event/debug data |
-| 401 handling | exactly one replay before output; never replay static credentials or a second 401 |
-| Claude strategy | request-time resolution applies identically to Messages and token count |
+| Route resolver | normalized base URL produces only approved provider target path before validation |
+| Middleware headers | required keys present; undeclared, host, URL, framing, and body mutation rejected; no source headers in event/debug data |
+| Middleware response | exactly one core-owned replay before output; middleware cannot consume stream bodies or request a second replay |
+| Claude/Umans middleware | request-time resolution applies identically to Messages and token count |
 | Factory | source presence authorizes only engines that explicitly support it |
 | JavaScript | builder succeeds with Go source; script cannot receive source, token, headers, expiry, or account metadata |
 
@@ -611,7 +596,10 @@ func TestCodexFirst401RefreshesOnce(t *testing.T) {
     })
 
     source := newFakeCodexSource(/* stale then replacement; values never logged */)
-    engine := newCodexEngine(server.URL, source)
+    engine := newResponsesEngine(server.URL,
+        withRoute(codexRoute{}),
+        withMiddleware(newCodexMiddleware(source)),
+    )
     _, err := engine.RunInference(context.Background(), userTurn("ping"))
     require.NoError(t, err)
     require.Equal(t, 2, server.RequestCount())
@@ -626,12 +614,12 @@ Run from the standalone Geppetto module:
 ```bash
 cd /home/manuel/workspaces/2026-07-10/refresh-oauth-token-geppetto/geppetto
 GOWORK=off go test ./... -count=1
-GOWORK=off go test -race ./pkg/steps/ai/credentials ./pkg/steps/ai/openai_codex ./pkg/steps/ai/claude ./pkg/inference/engine/factory ./pkg/js/modules/geppetto -count=1
+GOWORK=off go test -race ./pkg/steps/ai/credentials ./pkg/steps/ai/transport ./pkg/steps/ai/openai_responses ./pkg/steps/ai/providers/openaicodex ./pkg/steps/ai/claude ./pkg/inference/engine/factory ./pkg/js/modules/geppetto -count=1
 GOWORK=off make logcopter-check
 GOWORK=off make gosec
 ```
 
-Replace the future `openai_codex` package in the race command with the actual package name once implementation begins. A full repository race run remains useful but may contain unrelated baseline failures; report them separately rather than masking them.
+Replace the proposed `transport` and `providers/openaicodex` packages in the race command with their actual locations once implementation begins. A full repository race run remains useful but may contain unrelated baseline failures; report them separately rather than masking them.
 
 ## 8. Risks, alternatives, and open questions
 
@@ -641,7 +629,7 @@ Replace the future `openai_codex` package in the race command with the actual pa
 - **Terms/account policy:** A token that Pi can use is not automatic approval for another application to use it. Require explicit host policy and user consent.
 - **Header leakage:** Account headers and bearer values are both private runtime state. Treat them as sensitive even if they are not cryptographic secrets.
 - **Partial coverage:** A dynamic source added only to streaming inference would leave token counting or non-streaming requests stale.
-- **Unsafe abstraction:** Arbitrary profile header maps or request callbacks create an endpoint-exfiltration path.
+- **Unsafe abstraction:** Arbitrary profile header maps or mutable request callbacks create an endpoint-exfiltration path. The middleware must remain header-restricted, trusted, and Go-only.
 - **Refresh races:** Two processes operating on the same external store need an agreed lock and atomic-write policy.
 - **Overreaching lifecycle API:** A Geppetto file store that silently selects paths or a login helper that launches browsers would erase the necessary application-policy boundary.
 
@@ -653,14 +641,14 @@ Replace the future `openai_codex` package in the race command with the actual pa
 
 **Add `headers` and `path` maps to profiles.** Rejected because settings are serializable and user-controlled; these maps would make it easy to alter security-sensitive request behavior and leak credentials.
 
-**Use the generic OpenAI Responses engine for Codex immediately.** Rejected because the installed Pi code explicitly uses a different endpoint path and required headers.
+**Use the generic OpenAI Responses engine for Codex immediately through base-URL/profile configuration.** Rejected because the installed Pi code explicitly uses a different endpoint path and required headers. The revised proposal instead adds a tested trusted route/middleware adapter to the shared core.
 
 ### 8.3 Open questions for review
 
 1. Is there a supported, stable provider policy for the ChatGPT Codex backend outside Pi/Codex clients?
 2. What exact Claude subscription request headers and endpoint behavior should Geppetto support, if any?
 3. Should Pinocchio offer an explicit one-time Pi import, or should Pi use require a dedicated local credential broker?
-4. Is Codex support best delivered as a Geppetto experimental engine or as a host-local engine composed from Geppetto primitives?
+4. Does Codex share enough request/SSE behavior to use the Responses core with a route/middleware adapter, or does it require an optional provider stream codec?
 5. Which model aliases and request fields are mandatory for a valid Codex request beyond endpoint and headers?
 6. What user consent and audit trail are required before an application reuses a local subscription credential?
 
@@ -669,7 +657,7 @@ Replace the future `openai_codex` package in the race command with the actual pa
 Before changing a line of production code, an intern should be able to answer all of these:
 
 - Which host-selected store owns the persistent credential? If the answer is “Geppetto discovers profile YAML,” stop: that is wrong.
-- Which engine sends the actual request? Read its URL construction, header setting, retry loop, and tests.
+- Which shared engine core sends the actual request, and which trusted provider route/middleware adapter is installed? Read URL construction, header allowlists, retry loop, and tests.
 - Does the provider use an OpenAI protocol, Anthropic Messages, or a custom one? Do not infer this from a model name.
 - Are all required headers known from source or provider documentation? Record the source and write a fake-server assertion.
 - Is the final URL validated before a token source is called?

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/index.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Reusable provider credential lifecycle and transport adapters
 Ticket: GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS
-Status: complete
+Status: active
 Topics:
     - geppetto
     - oauth

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/index.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/index.md
@@ -1,5 +1,5 @@
 ---
-Title: Provider-specific adapters for Pi subscription credentials
+Title: Reusable provider credential lifecycle and transport adapters
 Ticket: GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS
 Status: complete
 Topics:
@@ -13,18 +13,19 @@ Owners:
     - manuel
 RelatedFiles: []
 ExternalSources: []
-Summary: ""
-LastUpdated: 2026-07-14T17:59:09.371251907-04:00
-WhatFor: ""
-WhenToUse: ""
+Summary: Geppetto supplies reusable provider lifecycle and transport primitives; hosts such as Pinocchio supply storage binding, user experience, and import policy.
+LastUpdated: 2026-07-14T18:13:08.341362052-04:00
+WhatFor: Define provider credential lifecycle ownership between Geppetto and embedding applications.
+WhenToUse: Use when implementing reusable login, refresh, status, logout, storage, or provider transport support.
 ---
 
 
-# Provider-specific adapters for Pi subscription credentials
+
+# Reusable provider credential lifecycle and transport adapters
 
 ## Overview
 
-<!-- Provide a brief overview of the ticket, its goals, and current status -->
+This ticket defines a reusable provider-credential architecture: Geppetto supplies provider protocol, lifecycle, and transport primitives; hosts such as Pinocchio bind those primitives to their selected storage, browser/CLI experience, and consent policy. Pi is evidence and a possible explicit migration source, never Geppetto’s storage contract.
 
 ## Key Links
 

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/index.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Provider-specific adapters for Pi subscription credentials
 Ticket: GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS
-Status: active
+Status: complete
 Topics:
     - geppetto
     - oauth
@@ -14,10 +14,11 @@ Owners:
 RelatedFiles: []
 ExternalSources: []
 Summary: ""
-LastUpdated: 2026-07-14T17:52:08.685676406-04:00
+LastUpdated: 2026-07-14T17:59:09.371251907-04:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 # Provider-specific adapters for Pi subscription credentials
 

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/index.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Reusable provider credential lifecycle and transport adapters
 Ticket: GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS
-Status: active
+Status: complete
 Topics:
     - geppetto
     - oauth
@@ -14,10 +14,11 @@ Owners:
 RelatedFiles: []
 ExternalSources: []
 Summary: Geppetto supplies reusable provider lifecycle and transport primitives; hosts such as Pinocchio supply storage binding, user experience, and import policy.
-LastUpdated: 2026-07-14T20:29:03.036021202-04:00
+LastUpdated: 2026-07-16T18:25:12.677236034-04:00
 WhatFor: Define provider credential lifecycle ownership between Geppetto and embedding applications.
 WhenToUse: Use when implementing reusable login, refresh, status, logout, storage, or provider transport support.
 ---
+
 
 
 

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/index.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/index.md
@@ -14,10 +14,11 @@ Owners:
 RelatedFiles: []
 ExternalSources: []
 Summary: Geppetto supplies reusable provider lifecycle and transport primitives; hosts such as Pinocchio supply storage binding, user experience, and import policy.
-LastUpdated: 2026-07-14T18:13:08.341362052-04:00
+LastUpdated: 2026-07-14T20:29:03.036021202-04:00
 WhatFor: Define provider credential lifecycle ownership between Geppetto and embedding applications.
 WhenToUse: Use when implementing reusable login, refresh, status, logout, storage, or provider transport support.
 ---
+
 
 
 

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/index.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/index.md
@@ -1,0 +1,59 @@
+---
+Title: Provider-specific adapters for Pi subscription credentials
+Ticket: GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS
+Status: active
+Topics:
+    - geppetto
+    - oauth
+    - credentials
+    - security
+DocType: index
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-07-14T17:52:08.685676406-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Provider-specific adapters for Pi subscription credentials
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- geppetto
+- oauth
+- credentials
+- security
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
@@ -439,3 +439,61 @@ The task plan spans Geppetto and Pinocchio without making their ownership ambigu
 ### Technical details
 
 The active task IDs are `79md`, `idw2`, `4rvt`, `ml0f`, `acua`, `m1dp`, and `kd0z`. The last task explicitly gates any live smoke on prior validation and approval.
+
+## Step 7: Publish a clean middleware-architecture review PDF
+
+The earlier reMarkable bundles predated the shared-core middleware decision or included supporting diary and source-map material. A design-only PDF was therefore rendered and uploaded so review can focus on the current middleware architecture without the historical investigation narrative.
+
+The PDF uses a distinct name in the same ticket directory. It preserves earlier artifacts and their possible annotations while making the revised design immediately discoverable.
+
+### Prompt Context
+
+**User prompt (verbatim):** "haveyou uploaded a clean updated design doc for the new approach with middleware for me to review?"
+
+**Assistant interpretation:** Verify whether the final middleware design has been delivered in a clean review format and publish it if it has not.
+
+**Inferred user intent:** Review the current proposed architecture independently from prior design versions and research history.
+
+### What I did
+
+- Confirmed the prior reMarkable upload predated the middleware revision.
+- Ran a dry run for a design-only bundle.
+- Uploaded `Geppetto Provider Middleware Architecture.pdf` containing only the current design guide.
+
+### Why
+
+A clean design-only artifact makes architectural review faster and avoids requiring a reviewer to distinguish superseded diary discussion from the current proposal.
+
+### What worked
+
+- The dry run selected only the design guide and the intended ticket directory.
+- Upload completed successfully: `OK: uploaded Geppetto Provider Middleware Architecture.pdf -> /ai/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS`.
+
+### What didn't work
+
+N/A. The upload emitted a non-fatal remote-tree refresh warning before succeeding; no further cloud listing was needed because the command returned success.
+
+### What I learned
+
+A separately named design-only PDF is preferable to overwriting a previous review bundle when the architecture changes substantially and previous files may hold annotations.
+
+### What was tricky to build
+
+The review artifact needed to be current without deleting prior material. The upload used a new descriptive name rather than `--force`, preserving previous bundles while targeting the same ticket directory.
+
+### What warrants a second pair of eyes
+
+- Confirm that the design-only packet is the preferred review artifact before future implementation updates are bundled.
+
+### What should be done in the future
+
+- Re-upload a new clean design-only PDF when implementation changes require a material architecture revision; otherwise keep the existing review artifact stable.
+
+### Code review instructions
+
+- Review `Geppetto Provider Middleware Architecture.pdf` in the ticket’s reMarkable directory.
+- Focus on Sections 5.1, 5.3, 5.4, and Phase 1–2 of the design guide.
+
+### Technical details
+
+The upload used `remarquee upload bundle` with a single Markdown input, `--toc-depth 2`, and `--non-interactive`; it did not use `--force`.

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
@@ -377,3 +377,65 @@ The difficult part was retaining a shared core without making Codex credential b
 ### Technical details
 
 The proposed Codex adapter consists of a fixed route resolver, a typed `CodexCredentialSource`, an allowlisted `HeaderWriter`, and `AfterResponse` classification. The shared Responses core creates and validates the request, calls middleware, and performs at most one pre-output replay.
+
+## Step 6: Keep the research ticket as the implementation tracker
+
+The ticket was initially closed after documenting the architecture, but the work now has a coherent phased plan and should remain the active tracker. A separate ticket would be useful only if the implementation becomes too large for one reviewable workstream; it is not required by the architecture or by docmgr.
+
+The ticket is now active with seven implementation tasks. They sequence the shared middleware foundation before provider-specific work, preserve lifecycle work as reusable Geppetto functionality, and keep the Pinocchio direct-YAML binding and any Pi migration explicitly separate from core protocol work.
+
+### Prompt Context
+
+**User prompt (verbatim):** "cam we add the tasks to the current ticket, or why do you want a separate one?"
+
+**Assistant interpretation:** Use the existing research/design ticket as the active implementation tracker rather than splitting the planned work into a new ticket.
+
+**Inferred user intent:** Preserve continuity between the technical rationale, decisions, task plan, and eventual implementation evidence.
+
+### What I did
+
+- Reopened the ticket status to active.
+- Added seven ordered tasks for middleware contracts, Responses-core wiring, Codex, lifecycle primitives, Anthropic/Umans, Pinocchio binding, and final validation/live-smoke gating.
+- Updated the changelog to record the ticket’s role as the active implementation tracker.
+- Ran ticket health validation successfully.
+
+### Why
+
+The design, source evidence, and future implementation tasks all concern the same credential-lifecycle architecture. Keeping them together improves traceability for an implementer and avoids splitting decisions from the task checklist that realizes them.
+
+### What worked
+
+- The existing ticket already contained phased implementation guidance and a diary, so it could become the tracker without restructuring documentation.
+- The added task ordering makes the dependencies explicit: no Codex adapter before the restricted middleware security foundation, and no live smoke before provider-specific validation.
+
+### What didn't work
+
+N/A. The earlier suggestion of a separate implementation ticket was organizational caution, not a technical requirement.
+
+### What I learned
+
+A ticket should be split when independent delivery/review streams need separate ownership or timelines, not merely because a design transitions into implementation. Here, one active ticket provides a clearer continuity record.
+
+### What was tricky to build
+
+The task plan spans Geppetto and Pinocchio without making their ownership ambiguous. The sequence solves this by placing reusable middleware/lifecycle/provider work first, then treating Pinocchio direct-YAML storage and CLI integration as an explicit host binding task, not as part of Geppetto core.
+
+### What warrants a second pair of eyes
+
+- Confirm the seven-task order matches desired implementation priority.
+- Confirm whether the Pinocchio binding task should stay in this cross-repository ticket or move later if it needs an independent release timeline.
+
+### What should be done in the future
+
+- Start task `79md` before provider-specific implementation.
+- Keep each completed task accompanied by focused tests, diary evidence, file relations, and a changelog update.
+
+### Code review instructions
+
+- Review `tasks.md` against Sections 5–7 of the design guide.
+- Begin implementation with task `79md`; do not begin Codex header work before the route/middleware ordering and allowlist tests exist.
+- Run `docmgr doctor --ticket GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS --stale-after 30` after task updates.
+
+### Technical details
+
+The active task IDs are `79md`, `idw2`, `4rvt`, `ml0f`, `acua`, `m1dp`, and `kd0z`. The last task explicitly gates any live smoke on prior validation and approval.

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
@@ -185,3 +185,130 @@ The bundle needed to include enough evidence for an intern to verify conclusions
 ### Technical details
 
 The bundle command used `remarquee upload bundle` with `--toc-depth 2` and `--non-interactive`. The dry run completed before the actual upload, as required by the ticket delivery workflow.
+
+## Step 3: Reframe lifecycle ownership for reuse beyond Pinocchio
+
+The first design correctly kept Pi storage out of Geppetto, but assigned too much provider login and refresh behavior to every host. The requested architecture instead makes Geppetto a reusable provider-credential library: it supplies supported provider protocol mechanics and secure lifecycle building blocks, while Pinocchio remains one concrete application binding those building blocks to direct YAML and its CLI.
+
+The revised guide now distinguishes provider mechanics from application policy. Geppetto may implement PKCE/state, exchange, refresh, redacted status, local delete, typed request authentication, and provider transports. Pinocchio decides where the credential is stored, which profile is selected, how a browser is presented, whether a Pi record may be migrated, and how output is rendered.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Ok, update the design, reupload to remarkable"
+
+**Assistant interpretation:** Amend the research ticket to make reusable Geppetto lifecycle/provider primitives the primary architecture, then deliver the revised documentation bundle.
+
+**Inferred user intent:** Ensure package users besides Pinocchio can safely reuse provider login, refresh, status, logout, and transport functionality without taking a dependency on Pi or Pinocchio storage.
+
+### What I did
+
+- Rewrote the executive architecture, decisions, diagrams, contracts, implementation phases, risks, and intern checklist in the design guide.
+- Added a proposed Geppetto lifecycle surface consisting of `Store`, `ProviderFlow`, `Login`, `StatusOf`, `Logout`, and a host-provided `Presenter`.
+- Documented Pinocchio’s role as a direct-YAML store adapter and Glazed CLI/UI binding, with optional explicit Pi migration.
+- Reopened the ticket documentation status and added follow-up delivery bookkeeping before publishing the revised bundle.
+
+### Why
+
+Provider PKCE, code exchange, refresh rotation, redacted status, and typed provider transport behavior are reusable Go functionality. Reimplementing them in each host would create duplicate security-sensitive code. Conversely, allowing Geppetto to discover local files or make browser/consent choices would make the library application-specific and unsafe.
+
+### What worked
+
+- The existing design already separated Pi’s private file format from Geppetto, so the revision could preserve all secret-boundary and transport-contract safeguards.
+- The new split maps cleanly onto existing Pinocchio components: its direct YAML store remains host-owned, while the future provider protocol implementation can be shared.
+
+### What didn't work
+
+The first version’s statement that the host should own the provider refresh protocol was too restrictive for the intended reusable package API. It would require every Geppetto host to recreate OAuth-sensitive behavior and did not match the desired relationship between Geppetto and Pinocchio.
+
+### What I learned
+
+The correct stable abstraction boundary is not “host owns all credentials” versus “library owns all credentials.” It is: Geppetto owns reusable provider and lifecycle mechanics; hosts own credential placement, identity selection, interaction, and consent policy.
+
+### What was tricky to build
+
+The key design challenge was preserving the security reason for host ownership while moving reusable protocol code into Geppetto. The resolved boundary uses host-injected `Store` and `Presenter` interfaces. That lets the library perform a provider flow without selecting a filesystem path or launching a browser, and lets Pinocchio reuse the flow without exposing a credential capability to profiles or JavaScript.
+
+### What warrants a second pair of eyes
+
+- Review the proposed lifecycle API for correct error/redaction and concurrency semantics before public API commitment.
+- Review whether a generic explicit-path file-store helper belongs in Geppetto or should remain a host implementation.
+- Review each provider’s terms and transport stability before a provider package is shipped.
+
+### What should be done in the future
+
+- Turn the proposed lifecycle interfaces into a focused Geppetto implementation ticket with fake flow/store tests.
+- Follow with a Pinocchio binding ticket that replaces duplicated lifecycle protocol code without changing its direct-YAML ownership model.
+- Design any Pi migration separately, with explicit consent and no shared mutable credential ownership.
+
+### Code review instructions
+
+- Start at the revised Executive summary and Section 5 of the design guide.
+- Verify that `ProviderFlow` is provider-specific but `Store` and `Presenter` remain host-injected.
+- Verify that no filesystem discovery, browser launch, profile selection, or JavaScript secret capability is moved into Geppetto.
+- Run `docmgr doctor --ticket GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS --stale-after 30` after the delivery updates.
+
+### Technical details
+
+The revised architecture retains the existing exact-loopback/PKCE-S256, state-validation, locking, atomic rotation, URL-before-token, bounded-401-replay, and no-JavaScript-credential invariants. It moves only reusable provider/lifecycle mechanics into Geppetto.
+
+## Step 4: Validate and publish the revised architecture
+
+The amended guide passed frontmatter and ticket health validation, then was rendered as a new reMarkable bundle. It uses a distinct bundle name so the prior research artifact is preserved rather than force-overwriting a potentially annotated document.
+
+The new bundle presents the corrected reusable-lifecycle architecture alongside the diary and redacted source map. The reMarkable output remains free of credentials and provider auth-file contents.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 3)
+
+**Assistant interpretation:** Complete the revised design’s validation and make the corrected architecture available on reMarkable.
+
+**Inferred user intent:** Ensure the portable review artifact reflects the intended relationship: Geppetto is reusable provider/lifecycle infrastructure and Pinocchio is one storage/UI client.
+
+### What I did
+
+- Ran `docmgr doctor --ticket GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS --stale-after 30`; all checks passed.
+- Ran the required dry run for the revised three-document bundle.
+- Uploaded `Geppetto Provider Credential Lifecycle Adapters.pdf` to the ticket directory without force-overwriting the prior bundle.
+
+### Why
+
+A different document name avoids silently deleting annotations on the earlier upload while making the architectural revision independently reviewable.
+
+### What worked
+
+- Ticket doctor passed cleanly.
+- The dry run listed the design, diary, and redacted source map with the expected target.
+- Upload completed successfully: `OK: uploaded Geppetto Provider Credential Lifecycle Adapters.pdf -> /ai/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS`.
+
+### What didn't work
+
+N/A. The replacement bundle was uploaded under a new clear name rather than using `--force`, because a force overwrite can discard existing annotations.
+
+### What I learned
+
+Reuploading a revised review packet does not require destructive replacement. Naming the corrected bundle after its actual architectural content preserves both the original research record and the corrected decision.
+
+### What was tricky to build
+
+The desired behavior was a reupload, but the upload tool’s `--force` option deletes an existing document and annotations. The solution was to retain the same ticket directory while choosing a distinct bundle name; this provides the updated material without making an irreversible assumption about annotations.
+
+### What warrants a second pair of eyes
+
+- Confirm whether the earlier Pi-focused bundle should eventually be archived or kept alongside the revised lifecycle-focused packet.
+- Review the public API proposal before any Geppetto implementation starts.
+
+### What should be done in the future
+
+- Open a focused implementation ticket for Geppetto lifecycle primitives and provider modules when the API direction is accepted.
+- Open a separate Pinocchio adapter/migration ticket afterward.
+
+### Code review instructions
+
+- Read the reMarkable bundle named `Geppetto Provider Credential Lifecycle Adapters` or its three Markdown inputs.
+- Confirm the guide assigns provider flow mechanics to Geppetto and storage/UI policy to hosts.
+- Verify no secret-bearing file was included in the bundle.
+
+### Technical details
+
+The upload used `remarquee upload bundle` with `--toc-depth 2` and `--non-interactive`, targeting `/ai/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS`.

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
@@ -12,6 +12,12 @@ Intent: long-term
 Owners:
     - manuel
 RelatedFiles:
+    - Path: repo://pkg/steps/ai/openai_responses/request_transport.go
+      Note: Responses core route middleware and debug redaction integration
+    - Path: repo://pkg/steps/ai/providers/openaicodex/codex.go
+      Note: Typed Codex route and credential middleware
+    - Path: repo://pkg/steps/ai/providers/openaicodex/codex_test.go
+      Note: Fake transport Codex contract coverage
     - Path: repo://pkg/steps/ai/transport/transport.go
       Note: Restricted Go-only provider route and request-response middleware contracts
     - Path: repo://pkg/steps/ai/transport/transport_test.go
@@ -26,6 +32,7 @@ LastUpdated: 2026-07-14T21:52:00-04:00
 WhatFor: Record the research, design decisions, validation, and delivery of the Pi subscription credential adapter guide.
 WhenToUse: Read before resuming implementation or assessing whether a provider contract is safe to support.
 ---
+
 
 
 
@@ -584,3 +591,66 @@ GOWORK=off make gosec
 ### Technical details
 
 The current package is intentionally not wired into an engine yet. Task `idw2` must call `ResolveAndValidate` before `Chain.BeforeRequest`, create `HeaderSet` from engine-approved rules, invoke `Chain.AfterResponse` before stream consumption, and let the core enforce the one-replay limit.
+
+## Step 9: Wire Responses and add the typed Codex adapter
+
+The shared Responses core now resolves and validates a provider route before credential middleware executes, applies a restricted header set, redacts sensitive middleware headers from the debug tap, and owns the one-replay loop. Existing bearer-source behavior was migrated into an internal middleware without changing its pre-stream-401 semantics.
+
+A new `providers/openaicodex` adapter supplies the fixed Codex route and typed bearer/account header middleware. Its fake transport test proves the shared Responses core sends the Codex path and headers, refreshes once after the first 401, and uses the replacement only on the replay.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 8)
+
+**Assistant interpretation:** Continue through the Responses wiring and Codex implementation tasks without stopping after the middleware foundation.
+
+**Inferred user intent:** Deliver usable shared-core provider behavior rather than a standalone abstraction.
+
+**Commit (code):** d53716f6 — "feat: route Responses through provider middleware"
+
+**Commit (code):** 759635d3 — "feat: add Codex Responses middleware"
+
+### What I did
+
+- Added `openai_responses.RequestTransport` and routed request creation through validated routes, `HeaderSet`, and `Chain`.
+- Preserved static/dynamic bearer and exactly-once 401 behavior with replay-local opaque attempt state.
+- Redacted middleware-sensitive request headers before `DebugTap.OnHTTP`.
+- Added `pkg/steps/ai/providers/openaicodex` with typed source, fixed route, sanctioned headers, and fake transport tests.
+
+### Why
+
+This makes the shared engine core reusable without allowing profiles or JavaScript to mutate provider headers or paths.
+
+### What worked
+
+Focused normal/race tests passed for transport, Responses, and Codex. `make lint` passed after correcting lint violations; full `go test ./...` passed before the Responses commit.
+
+### What didn't work
+
+The initial pre-commit lint run was terminated while rebuilding tooling, then a direct `make lint` exposed lowercase-error-string and predeclared-name violations. Renaming those identifiers and errors made lint pass; no gate was bypassed.
+
+### What I learned
+
+A response middleware needs replay-local prior-attempt state to preserve the legacy contract where `BearerTokenAfterUnauthorized` returns a replacement that a later `BearerToken` call might not repeat.
+
+### What was tricky to build
+
+The retry replacement cannot live on an engine-global middleware because concurrent requests would race. The transport chain now passes each middleware its own prior opaque attempt only on a replay, so the replacement remains request-local.
+
+### What warrants a second pair of eyes
+
+- Review Codex `originator`/user-agent policy against an approved provider contract before live use.
+- Review whether `RequestTransport` should become a stable public API before release.
+
+### What should be done in the future
+
+- Continue with lifecycle primitives, then Anthropic/Umans and Pinocchio binding tasks; no live smoke is authorized yet.
+
+### Code review instructions
+
+- Start with `pkg/steps/ai/openai_responses/request_transport.go` and `pkg/steps/ai/providers/openaicodex/codex.go`.
+- Run `GOWORK=off go test -race ./pkg/steps/ai/transport ./pkg/steps/ai/openai_responses ./pkg/steps/ai/providers/openaicodex -count=1` and `make lint`.
+
+### Technical details
+
+Codex is selected only by installing its typed Go `RequestTransport`; it disables the ordinary bearer middleware and no Codex source or header selector appears in settings or JavaScript.

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
@@ -12,6 +12,10 @@ Intent: long-term
 Owners:
     - manuel
 RelatedFiles:
+    - Path: repo://pkg/steps/ai/transport/transport.go
+      Note: Restricted Go-only provider route and request-response middleware contracts
+    - Path: repo://pkg/steps/ai/transport/transport_test.go
+      Note: Security and ordering regression coverage for transport contracts
     - Path: repo://ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/design-doc/01-pi-subscription-credentials-in-geppetto-analysis-adapter-design-and-implementation-guide.md
       Note: Primary evidence-backed architecture and plan
     - Path: repo://ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/sources/01-local-pi-and-geppetto-source-map.md
@@ -22,6 +26,7 @@ LastUpdated: 2026-07-14T21:52:00-04:00
 WhatFor: Record the research, design decisions, validation, and delivery of the Pi subscription credential adapter guide.
 WhenToUse: Read before resuming implementation or assessing whether a provider contract is safe to support.
 ---
+
 
 
 # Diary
@@ -497,3 +502,85 @@ The review artifact needed to be current without deleting prior material. The up
 ### Technical details
 
 The upload used `remarquee upload bundle` with a single Markdown input, `--toc-depth 2`, and `--non-interactive`; it did not use `--force`.
+
+## Step 8: Implement restricted provider transport contracts
+
+The first implementation task established a dedicated `pkg/steps/ai/transport` package for trusted provider route resolution and credential middleware. It deliberately does not reuse Geppetto’s existing inference-turn middleware: this package operates inside a selected provider engine after that engine has chosen its protocol, and it has stricter security boundaries.
+
+The new contracts separate three concerns. A route resolver produces a provider endpoint before core URL validation; request middleware receives only a validated read-only context plus an allowlisted header writer; response middleware sees body-free response metadata and can ask the engine for a bounded retry. The engine will retain ownership of request bodies, response bodies, stream decoding, and retry execution when task `idw2` wires these contracts into OpenAI Responses.
+
+### Prompt Context
+
+**User prompt (verbatim):** "ok, continue"
+
+**Assistant interpretation:** Begin the active implementation plan with the restricted middleware foundation before adding provider-specific behavior.
+
+**Inferred user intent:** Turn the reviewed middleware design into safe, tested Geppetto primitives that can later avoid duplicated Codex, OpenAI, and Anthropic engine code.
+
+**Commit (code):** a5ab5f80 — "feat: add restricted provider transport contracts"
+
+### What I did
+
+- Added `pkg/steps/ai/transport/transport.go` with `RouteResolver`, URL-validation ordering helper, read-only `RequestContext`, `HeaderWriter`, `HeaderSet`, `Middleware`, response decisions, and ordered `Chain`.
+- Added security-focused tests in `pkg/steps/ai/transport/transport_test.go` covering route validation, immutable URL copies, header allowlists, framing/host prohibition, sensitive-header redaction, conflict rejection, response ordering, and invalid decisions.
+- Ran focused package tests, focused race tests, Responses regression tests, and full `make gosec`.
+
+### Why
+
+A full mutable HTTP-request hook would let provider code change a validated destination or request body after the security gate. The restricted transport package permits the actual need—provider-specific credential headers and 401 classification—without exposing that escape hatch.
+
+### What worked
+
+- `HeaderSet` allows only provider-declared header names and redacts declared sensitive values in diagnostic copies.
+- Middleware executes request hooks in registration order and response hooks in reverse order, while the response decision remains only a request to the core rather than an executed retry.
+- `GOWORK=off go test ./pkg/steps/ai/transport ./pkg/steps/ai/openai_responses -count=1`, `GOWORK=off go test -race ./pkg/steps/ai/transport -count=1`, and `GOWORK=off make gosec` passed.
+
+### What didn't work
+
+The first focused test run failed because Go canonicalizes `TE` as `Te`, while the prohibited-header map used the uncanonicalized spelling:
+
+```text
+--- FAIL: TestNewHeaderSet_RejectsUnsafeRules (0.00s)
+    transport_test.go:162: NewHeaderSet("TE") unexpectedly succeeded
+FAIL
+FAIL github.com/go-go-golems/geppetto/pkg/steps/ai/transport 0.003s
+```
+
+I changed the prohibited map key to the canonical `Te` spelling, ran `gofmt`, and reran the normal and race tests successfully.
+
+### What I learned
+
+Header-name policy must use the same canonicalization as `net/http`; otherwise a policy can accidentally leave a variant spelling unblocked. Declaring rules and checking writes through `http.CanonicalHeaderKey` centralizes this behavior.
+
+### What was tricky to build
+
+The main sharp edge was making request context genuinely read-only enough for middleware. An exported `*url.URL` would permit later mutation of a core-selected destination. The implementation keeps URL fields private and returns copies; route resolution also copies its input and copies its output before validation. Middleware can therefore not mutate the engine’s configured base URL or the validated target through the exposed API.
+
+A second sharp edge is header precedence. Multiple trusted middlewares could otherwise silently override one another’s values. `HeaderSet` tracks writes and rejects a distinct second value while permitting an idempotent repeat.
+
+### What warrants a second pair of eyes
+
+- Review whether the public `transport` package should remain public or become an internal package before external consumers depend on it.
+- Review the exact set of prohibited HTTP headers and whether any provider requires a safe exception.
+- Review debug-tap integration in task `idw2` so sensitive middleware headers are redacted before a request is observed.
+
+### What should be done in the future
+
+- Complete task `idw2`: wire the Responses core through these contracts and preserve existing bearer semantics.
+- Add Codex only after the shared core ordering and debug redaction behavior are covered by integration tests.
+
+### Code review instructions
+
+- Start with `pkg/steps/ai/transport/transport.go`, especially `ResolveAndValidate`, `HeaderSet.Set`, and `Chain`.
+- Read `pkg/steps/ai/transport/transport_test.go` to verify the security invariants.
+- Validate with:
+
+```bash
+GOWORK=off go test -race ./pkg/steps/ai/transport -count=1
+GOWORK=off go test ./pkg/steps/ai/transport ./pkg/steps/ai/openai_responses -count=1
+GOWORK=off make gosec
+```
+
+### Technical details
+
+The current package is intentionally not wired into an engine yet. Task `idw2` must call `ResolveAndValidate` before `Chain.BeforeRequest`, create `HeaderSet` from engine-approved rules, invoke `Chain.AfterResponse` before stream consumption, and let the core enforce the one-replay limit.

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
@@ -12,12 +12,18 @@ Intent: long-term
 Owners:
     - manuel
 RelatedFiles:
+    - Path: repo://pkg/steps/ai/credentials/lifecycle.go
+      Note: Reusable redacted status and local logout primitives
+    - Path: repo://pkg/steps/ai/credentials/oauth/state.go
+      Note: Reusable OAuth state generation and validation
     - Path: repo://pkg/steps/ai/openai_responses/request_transport.go
       Note: Responses core route middleware and debug redaction integration
     - Path: repo://pkg/steps/ai/providers/openaicodex/codex.go
       Note: Typed Codex route and credential middleware
     - Path: repo://pkg/steps/ai/providers/openaicodex/codex_test.go
       Note: Fake transport Codex contract coverage
+    - Path: repo://pkg/steps/ai/providers/umans/umans.go
+      Note: Explicit Umans API-key Claude binding
     - Path: repo://pkg/steps/ai/transport/transport.go
       Note: Restricted Go-only provider route and request-response middleware contracts
     - Path: repo://pkg/steps/ai/transport/transport_test.go
@@ -26,12 +32,15 @@ RelatedFiles:
       Note: Primary evidence-backed architecture and plan
     - Path: repo://ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/sources/01-local-pi-and-geppetto-source-map.md
       Note: Provider source evidence summary
+    - Path: ws://pinocchio/pkg/cmds/profilebootstrap/oauth.go
+      Note: Pinocchio Claude OAuth profile binding
 ExternalSources: []
 Summary: Chronological evidence for designing provider-specific Pi subscription credential support without exposing credential material.
 LastUpdated: 2026-07-14T21:52:00-04:00
 WhatFor: Record the research, design decisions, validation, and delivery of the Pi subscription credential adapter guide.
 WhenToUse: Read before resuming implementation or assessing whether a provider contract is safe to support.
 ---
+
 
 
 
@@ -654,3 +663,77 @@ The retry replacement cannot live on an engine-global middleware because concurr
 ### Technical details
 
 Codex is selected only by installing its typed Go `RequestTransport`; it disables the ordinary bearer middleware and no Codex source or header selector appears in settings or JavaScript.
+
+## Step 10: Complete lifecycle, Umans, Anthropic OAuth, and host binding
+
+The remaining implementation batch is now complete at the library/fixture level. Geppetto exposes redacted credential status, local logout/delete, static-key adaptation, OAuth state generation/validation, Umans dual-auth Claude options, and Anthropic subscription bearer mode. Claude engine and token-count construction can resolve a host-injected source at request time; the factory uses OAuth-specific Anthropic headers when its source is attached. Pinocchio accepts Claude OAuth profiles and routes status/logout through Geppetto lifecycle primitives.
+
+No real provider account was used. The installed Pi and Umans sources were sufficient to capture the structural contracts needed for fake-server tests: Umans uses Anthropic Messages with dual auth; Anthropic subscription OAuth uses bearer auth plus Claude Code identity/beta headers. Live provider smoke remains an explicit approval-gated operational step, not a missing implementation task.
+
+### Prompt Context
+
+**User prompt (verbatim):** "go ahead, do both"
+
+**Assistant interpretation:** Implement both the Umans fake contract/auth binding and Anthropic request-time OAuth support, then validate the combined Geppetto/Pinocchio changes.
+
+**Inferred user intent:** Finish the provider-specific runtime path rather than leaving the discovered contracts as documentation only.
+
+**Commit (code):** 5d67aab6 — "feat: add Anthropic OAuth and Umans auth modes"
+
+**Commit (code):** bbc8597b — "feat: add reusable OAuth state primitives"
+
+**Commit (host):** f8bc772 — "feat: allow Claude OAuth profile binding"
+
+### What I did
+
+- Added `credentials.StaticBearerTokenSource` for explicit API-key provider bindings.
+- Added `providers/umans.ClaudeOptions` and fake-server coverage for `/v1/messages`, Anthropic request shape, dual auth headers, and version header.
+- Added Claude OAuth bearer mode with `Authorization`, Claude Code beta headers, `x-app`, and user-agent identity; suppressed `x-api-key` in OAuth mode.
+- Added request-time source options to Claude inference and token counting, and factory propagation for OAuth profiles.
+- Added reusable cryptographic OAuth `NewState` and constant-time `ValidateState`.
+- Extended Pinocchio OAuth request resolution to support Claude profiles.
+
+### Why
+
+The Umans and Anthropic contracts are not interchangeable. Umans’ API-key shim requires the gateway’s dual-auth form, while Anthropic subscription OAuth uses bearer/Claude-Code identity semantics. Explicit modes prevent one credential string from silently selecting the wrong header contract.
+
+### What worked
+
+- Geppetto focused normal/race tests, lint, and gosec passed.
+- Pinocchio focused profilebootstrap/oauthprofiles/auth tests passed.
+- Pinocchio’s full pre-commit build, generated frontend, lint, vet, and test suite passed for the Claude profile binding commit.
+- No credential value, account ID, authorization code, or client secret entered source, docs, logs, or test fixtures.
+
+### What didn't work
+
+N/A for the implementation and fake-contract validation. A live provider request was intentionally not performed because the ticket’s safety policy requires explicit operational approval and a non-destructive smoke plan.
+
+### What I learned
+
+The same Anthropic Messages wire protocol can require different authentication contracts. Umans accepts an API key in both `x-api-key` and bearer form, while Pi’s Anthropic OAuth path switches to bearer-only plus Claude Code identity headers. Authentication mode must therefore be explicit, not inferred from the endpoint or model name.
+
+### What was tricky to build
+
+The factory’s existing bearer source option was originally documented for OpenAI-compatible engines. Reusing it for Claude required a distinct OAuth mode so host-injected Anthropic subscription tokens do not get emitted as `x-api-key`. The Umans adapter remains an explicit Claude option and is not silently activated by ordinary profile settings.
+
+### What warrants a second pair of eyes
+
+- Review the exact Anthropic OAuth beta/header set against the installed provider version before a release.
+- Review whether the shared factory should expose separate named options for OAuth versus static gateway auth rather than the current provider-specific option composition.
+- Review live-smoke approval, account policy, and endpoint stability independently of these offline tests.
+
+### What should be done in the future
+
+- Run a redacted, explicitly approved live smoke for each provider mode.
+- Publish/release the Geppetto API changes and update Pinocchio’s dependency to the released version rather than relying on the workspace during development.
+- Implement explicit Pi-to-Pinocchio migration only after consent and storage ownership review.
+
+### Code review instructions
+
+- Start with `pkg/steps/ai/claude/api/completion.go`, `pkg/steps/ai/claude/engine_claude.go`, `pkg/steps/ai/providers/umans/umans.go`, `pkg/steps/ai/credentials/oauth/state.go`, and Pinocchio `pkg/cmds/profilebootstrap/oauth.go`.
+- Run Geppetto `GOWORK=off go test ./... -count=1`, `GOWORK=off make gosec`, and `make lint`.
+- Run Pinocchio `go test ./... -count=1` and its pre-commit lint/build hooks.
+
+### Technical details
+
+The completed offline path has three explicit authentication modes: ordinary OpenAI bearer, Umans dual-auth Anthropic API key, and Anthropic subscription OAuth bearer/Claude-Code headers. All remain Go-only runtime capabilities.

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
@@ -312,3 +312,68 @@ The desired behavior was a reupload, but the upload tool’s `--force` option de
 ### Technical details
 
 The upload used `remarquee upload bundle` with `--toc-depth 2` and `--non-interactive`, targeting `/ai/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS`.
+
+## Step 5: Replace the isolated Codex engine with restricted shared-core middleware
+
+The previous revision placed reusable lifecycle behavior in Geppetto but still proposed a dedicated Codex engine. The architecture now instead treats Codex as a trusted route resolver and request/response middleware installed on Geppetto’s shared OpenAI Responses core. This preserves the core’s request construction, URL validation, retry orchestration, and stream ownership while containing Codex-only credential headers in one small provider component.
+
+The middleware is deliberately narrower than an arbitrary request hook. It receives a read-only post-validation request context and a header writer constrained by engine-declared names; it cannot rewrite URLs, bodies, host/framing headers, or streaming response bodies. The response hook can classify a response and request one bounded retry, but the engine core remains responsible for closing, replaying, and decoding the stream.
+
+### Prompt Context
+
+**User prompt (verbatim):** "ok, update the design ticket with this"
+
+**Assistant interpretation:** Record the shared engine core plus restricted provider route/middleware architecture as the ticket’s proposed implementation direction.
+
+**Inferred user intent:** Avoid a large duplicated Codex engine while keeping provider-specific credential header injection secure, explicit, and reusable by OpenAI and Anthropic engine paths.
+
+### What I did
+
+- Replaced the dedicated-Codex-engine decision with a trusted Codex route resolver and request/response middleware over the shared Responses core.
+- Added proposed `RouteResolver`, `Middleware`, `HeaderWriter`, request context, response metadata, and bounded response-decision contracts.
+- Replaced Codex and Claude pseudocode with middleware ordering and security invariants.
+- Reworked implementation phases, fake-server tests, test matrix, and review questions around shared core behavior and optional stream codecs.
+
+### Why
+
+Codex credential handling needs only a few provider-specific headers, a fixed route, and a 401 refresh classification. Duplicating the entire OpenAI Responses engine would duplicate cancellation, request construction, retry, and stream logic that should remain consistent across providers.
+
+### What worked
+
+- The current design’s strict Go-only credential boundary maps directly to middleware installed through typed engine options.
+- Separating route resolution, header injection, and stream decoding makes the security order explicit: final URL validation precedes credential acquisition, and response-body ownership remains with the core.
+
+### What didn't work
+
+The earlier dedicated-engine proposal would likely duplicate hundreds or thousands of existing OpenAI Responses lines solely to carry Codex route and header behavior. A fully mutable `func(*http.Request)` middleware alternative was also rejected because it could bypass URL validation or mutate framing/body behavior.
+
+### What I learned
+
+A reusable middleware seam is safe only when it is not a generic request mutator. The appropriate abstraction exposes a read-only request context, a header-only writer with a static allowlist, and structured response decisions; it never hands middleware the raw stream body or settings-derived configuration.
+
+### What was tricky to build
+
+The difficult part was retaining a shared core without making Codex credential behavior invisible or overly powerful. The solution is a two-stage pipeline: the route resolver runs before final URL validation, then the credential middleware runs only after validation. This prevents a token-bearing middleware from selecting its destination, while still avoiding a duplicated engine.
+
+### What warrants a second pair of eyes
+
+- Review the final public/internal package boundary for the middleware seam before implementation.
+- Review header-conflict precedence when multiple trusted middlewares are installed.
+- Review the exact response-decision API so middleware cannot cause unbounded retries or consume a stream.
+
+### What should be done in the future
+
+- Build middleware ordering and header-writer fake tests before extracting production code.
+- Prove Codex request/SSE compatibility with the existing Responses core; add a provider stream codec only if evidence requires it.
+- Apply the same constrained middleware model to Anthropic only after its contract tests are complete.
+
+### Code review instructions
+
+- Start with Sections 5.1, 5.3, and 5.4 of the design guide.
+- Verify that `RouteResolver` executes before final URL validation and `Middleware.BeforeRequest` after it.
+- Verify middleware cannot alter URL/body/stream and that only core-owned code performs retries and decoding.
+- Run `docmgr doctor --ticket GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS --stale-after 30` after ticket bookkeeping.
+
+### Technical details
+
+The proposed Codex adapter consists of a fixed route resolver, a typed `CodexCredentialSource`, an allowlisted `HeaderWriter`, and `AfterResponse` classification. The shared Responses core creates and validates the request, calls middleware, and performs at most one pre-output replay.

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
@@ -118,3 +118,70 @@ rg -n 'Authorization|x-api-key|apiKey|NewClaudeEngine' pkg/steps/ai/claude -g '*
 ```
 
 Pi evidence was read from its installed source and summarized only in `sources/01-local-pi-and-geppetto-source-map.md`. No access token, refresh token, authorization code, client secret, account value, or local auth-file value was copied into this ticket.
+
+## Step 2: Validate, commit, and deliver the research bundle
+
+The design, diary, source map, task list, ticket index, and changelog were validated and committed as one focused documentation phase. The finished material was then bundled into a single PDF with a table of contents and uploaded to the ticket-specific reMarkable directory.
+
+The delivery bundle intentionally contains only reviewable prose and the redacted evidence map. It does not include provider configuration files, Pi auth storage, source-code archives, or any credential-bearing test fixture.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 1)
+
+**Assistant interpretation:** Validate the completed research ticket, record the delivery evidence, and publish an accessible review bundle.
+
+**Inferred user intent:** Make the resulting technical design straightforward to review away from the terminal while preserving the credential boundary.
+
+**Commit (docs):** f9b0d2cc — "docs: design Pi subscription credential adapters"
+
+### What I did
+
+- Ran frontmatter validation on the design and diary documents.
+- Ran `docmgr doctor --ticket GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS --stale-after 30`; all checks passed.
+- Committed the ticket documentation, source map, tasks, index, and changelog.
+- Ran the required reMarkable bundle dry run with design, diary, and source map inputs.
+- Uploaded the resulting bundle to `/ai/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS`.
+
+### Why
+
+The deliverable must be auditable before it is published. Bundling the guide with its diary and evidence index gives a reviewer the architectural conclusions, the reasoning trail, and the source references in one navigable artifact without bundling local secret storage.
+
+### What worked
+
+- Both document frontmatters validated successfully.
+- Ticket doctor reported all checks passed.
+- The dry run identified the correct three inputs and target path.
+- The upload completed successfully: `OK: uploaded Geppetto Pi Subscription Credential Adapters.pdf -> /ai/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS`.
+
+### What didn't work
+
+N/A. No credential-bearing artifact was requested or needed for the bundle.
+
+### What I learned
+
+A source map is sufficient for a research deliverable when the original local sources include credential-adjacent behavior. It preserves reproducibility and reviewability without duplicating machine-specific files or secret values into a portable PDF.
+
+### What was tricky to build
+
+The bundle needed to include enough evidence for an intern to verify conclusions without including the installed provider code or local auth storage. The solution was to include a short redacted source map alongside precise paths and line ranges in the design document, then bundle that map with the diary and guide.
+
+### What warrants a second pair of eyes
+
+- Verify that the proposed experimental Codex transport is desirable before opening an implementation ticket.
+- Verify the selected reMarkable directory is the desired long-term location for this Geppetto research packet.
+
+### What should be done in the future
+
+- Create a follow-up implementation ticket only after the Codex/Claude contract and host ownership questions are accepted.
+- Keep a future live-smoke record separate from this research document and redact it to outcome-level evidence.
+
+### Code review instructions
+
+- Review the PDF bundle or the three source Markdown files together.
+- Confirm that the guide names no secret values and that the source map explicitly excludes auth-file contents.
+- Run `docmgr doctor --ticket GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS --stale-after 30` before changing ticket status.
+
+### Technical details
+
+The bundle command used `remarquee upload bundle` with `--toc-depth 2` and `--non-interactive`. The dry run completed before the actual upload, as required by the ticket delivery workflow.

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/reference/01-investigation-diary.md
@@ -1,0 +1,120 @@
+---
+Title: Investigation diary
+Ticket: GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS
+Status: active
+Topics:
+    - geppetto
+    - oauth
+    - credentials
+    - security
+DocType: reference
+Intent: long-term
+Owners:
+    - manuel
+RelatedFiles:
+    - Path: repo://ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/design-doc/01-pi-subscription-credentials-in-geppetto-analysis-adapter-design-and-implementation-guide.md
+      Note: Primary evidence-backed architecture and plan
+    - Path: repo://ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/sources/01-local-pi-and-geppetto-source-map.md
+      Note: Provider source evidence summary
+ExternalSources: []
+Summary: Chronological evidence for designing provider-specific Pi subscription credential support without exposing credential material.
+LastUpdated: 2026-07-14T21:52:00-04:00
+WhatFor: Record the research, design decisions, validation, and delivery of the Pi subscription credential adapter guide.
+WhenToUse: Read before resuming implementation or assessing whether a provider contract is safe to support.
+---
+
+
+# Diary
+
+## Goal
+
+Capture the evidence and design required to evaluate Pi-managed provider credentials in Geppetto without turning a token-shaped local record into an assumed inference contract.
+
+## Step 1: Establish provider contracts and Geppetto boundaries
+
+The investigation began after recognizing that public marketing/API documentation was not sufficient evidence for the locally installed Pi providers. I examined Pi’s installed authentication and provider implementations using a redacted structural view of the auth store and source-code references, then compared those behaviors against Geppetto’s existing renewable bearer, OpenAI, Responses, Claude, factory, and JavaScript seams.
+
+The result is a deliberately provider-specific design. OpenAI Codex and Claude have real renewable flows in Pi, but their transports do not fit the existing bearer-only OpenAI injection path unchanged. Umans’ Pi record looks OAuth-shaped but is an API key persisted through a no-op refresh shim. The guide makes these distinctions explicit and requires fake-server contracts before any real account request.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Ok, create a new docmgr ticket (in geppetto) and analyze and research and design and document and plan this.
+
+Create  a detailed analysis / design / implementation guide that is for a new intern, explaining all the parts of the system needed to understand what it is, with prose paragraphs and bullet point sand pseudocode and diagrams and api references and file references. It should be very clear and technical. Store in the ticket and the nupload to remarkable."
+
+**Assistant interpretation:** Create a new Geppetto ticket containing an evidence-backed, intern-oriented analysis and implementation plan for safely supporting Pi-originated provider credentials, then publish the documentation as a reMarkable bundle.
+
+**Inferred user intent:** Replace assumption-based provider triage with a clear technical roadmap that explains the current architecture, security boundaries, protocol differences, and a safe path to implementation.
+
+### What I did
+
+- Created `GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS` with a design document, this diary, tasks, and a local source map.
+- Inspected Pi `AuthStorage` refresh locking and provider registration behavior without printing any credential values.
+- Inspected Pi’s installed OpenAI Codex OAuth and transport code, including PKCE/device login, refresh behavior, Codex response path construction, and required header names.
+- Inspected Pi’s Anthropic OAuth flow and Umans extension behavior.
+- Inspected Geppetto’s renewable bearer interfaces, factory propagation, OpenAI/Responses request construction, Claude static-key request construction, and Go-only JavaScript source injection boundary.
+- Wrote an implementation guide with diagrams, typed API sketches, pseudocode, decisions, phased plan, tests, risks, and review questions.
+
+### Why
+
+The existing Geppetto renewable bearer abstraction intentionally models only a token returned at request time. That is enough for OpenAI-compatible services but not automatically enough for a provider that requires a special endpoint, account metadata, extra headers, or a separate message protocol. The design needed to distinguish credential acquisition from the complete inference transport.
+
+### What worked
+
+- Pi source gives concrete evidence that its auth store serializes login results and performs locked refreshes for expired OAuth records.
+- Pi source establishes that OpenAI Codex uses a ChatGPT backend and Codex-specific request mechanics rather than a generic OpenAI Responses endpoint.
+- Pi source establishes that Claude uses renewable OAuth while Geppetto’s Claude engine currently uses static `x-api-key` behavior.
+- Pi’s Umans extension explicitly documents API-key prompting and a no-op refresh, resolving the earlier ambiguity.
+- Geppetto’s existing host-injected bearer and Go-only JavaScript design provide a strong boundary to preserve.
+
+### What didn't work
+
+The earlier public-document-only provider triage was incomplete: it did not inspect the installed Pi provider implementations, so it incorrectly treated the absence of a public generic contract as evidence that no local provider flow existed. The correction is documented as an evidence distinction: Pi implements usable flows, but those flows still do not prove compatibility with Geppetto’s existing generic engines.
+
+No real provider request was attempted. This was intentional: no selected provider has yet passed a fake-server contract suite, host ownership review, and explicit account-use approval.
+
+### What I learned
+
+- OAuth-shaped storage fields do not define an inference transport or even prove a real refresh protocol.
+- The OpenAI Codex case requires more than bearer renewal: the target path and companion headers are part of the protocol contract.
+- A provider-specific adapter can be secure only when URL validation happens before it releases credential material and no runtime capability becomes profile or JavaScript data.
+- Umans should be designed as an Anthropic Messages/API-key compatibility case, not a renewable OAuth integration.
+
+### What was tricky to build
+
+The main difficulty was separating what source evidence proves from what it merely suggests. Pi’s source proves how Pi currently logs in, refreshes, and sends requests; it does not guarantee that the upstream endpoint is a stable external contract or that Geppetto can safely send the same requests. The design resolves this by requiring provider-specific fake-server tests before code and explicit user approval before any live smoke.
+
+A second sharp edge is interface design. Extending `BearerTokenSource` into a general arbitrary request callback would let credential logic alter a request after URL validation, creating an exfiltration risk. The proposed approach instead uses a dedicated engine for Codex and only typed, copied, engine-controlled authentication data where a shared seam is justified.
+
+### What warrants a second pair of eyes
+
+- Review whether ChatGPT Codex transport support is appropriate in Geppetto at all given endpoint stability and account policy.
+- Review whether a host should ever directly read Pi’s private auth storage rather than using a broker owned by Pi.
+- Review the eventual Claude subscription request-header contract against an approved provider source before dynamic Claude authentication is implemented.
+- Review all token-count and non-streaming paths together; partial renewable support would produce inconsistent behavior.
+
+### What should be done in the future
+
+- Implement Phase 0 and Phase 1 fake-server contract tests before adding a Codex transport.
+- Design any Pi storage bridge in Pinocchio or another host, never in Geppetto core.
+- Audit Claude request semantics and all Claude outbound paths before adding a dynamic source.
+- Run a secret-safe, explicitly authorized live smoke only after the corresponding provider contract is accepted.
+
+### Code review instructions
+
+- Start with `sources/01-local-pi-and-geppetto-source-map.md` and Sections 2–5 of the design document.
+- Compare `pkg/steps/ai/credentials/bearer.go` with the Codex and Claude source maps to understand why a bearer string is not the complete solution.
+- Verify the proposed API remains Go-only and that no profile or JavaScript API is proposed for tokens, headers, account metadata, or refresh callbacks.
+- Validate documentation metadata with `docmgr doctor --ticket GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS --stale-after 30`.
+
+### Technical details
+
+Evidence commands included:
+
+```bash
+nl -ba pkg/steps/ai/credentials/bearer.go | sed -n '1,300p'
+rg -n 'BearerTokenSource|NewEngineFromSettings' pkg/inference/engine/factory/factory.go -C 5
+rg -n 'Authorization|x-api-key|apiKey|NewClaudeEngine' pkg/steps/ai/claude -g '*.go' -C 3
+```
+
+Pi evidence was read from its installed source and summarized only in `sources/01-local-pi-and-geppetto-source-map.md`. No access token, refresh token, authorization code, client secret, account value, or local auth-file value was copied into this ticket.

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/sources/01-local-pi-and-geppetto-source-map.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/sources/01-local-pi-and-geppetto-source-map.md
@@ -1,0 +1,60 @@
+# Local Pi and Geppetto source map
+
+This is an evidence index, not a credential export. It was created without reading, copying, hashing, or printing any value from `~/.pi/agent/auth.json`. Field names and provider behavior below come from installed Pi provider code and Geppetto source.
+
+## Pi authentication framework
+
+- `.../pi-coding-agent/dist/core/auth-storage.js:318-425`
+  - registers provider login output as an OAuth credential;
+  - locks the backing file while refreshing expired credentials;
+  - returns a provider-derived API key/bearer at request time;
+  - reloads after a refresh error in case another process completed the refresh.
+- `.../pi-coding-agent/docs/providers.md`
+  - documents subscription OAuth storage in `~/.pi/agent/auth.json` and automatic refresh.
+
+## OpenAI Codex
+
+- `.../pi-ai/dist/utils/oauth/openai-codex.js:22-35,112-125,319-338,450-535`
+  - defines OpenAI authorization-code PKCE and device-code login;
+  - exchanges and refreshes access/refresh credentials;
+  - derives a ChatGPT account identifier from a token claim.
+- `.../pi-ai/dist/providers/openai-codex.js:6-16`
+  - registers the provider against the ChatGPT backend rather than the public OpenAI API host.
+- `.../pi-ai/dist/api/openai-codex-responses.js:402-409,1163-1210`
+  - targets `/codex/responses`;
+  - sets `Authorization`, an account header, an originator header, and experimental Responses/SSE headers.
+
+## Anthropic Claude subscription
+
+- `.../pi-ai/dist/utils/oauth/anthropic.js:20-20,159-185,290-315`
+  - implements authorization-code + PKCE and refresh-token grant handling;
+  - requests scopes including inference and Claude Code session capability.
+
+## Umans
+
+- `~/.pi/agent/npm/node_modules/pi-provider-umans/index.ts:539-577`
+  - `/login umans` prompts for an API key, stores it in access/refresh-shaped fields, and performs a no-op “refresh”.
+- `~/.pi/agent/npm/node_modules/pi-provider-umans/README.md:23-47`
+  - identifies the gateway as Anthropic Messages compatible at `/v1/messages`, not OpenAI Chat/Responses compatible.
+
+## Geppetto renewable-credential boundary
+
+- `pkg/steps/ai/credentials/bearer.go:21-83,124-167,265-297`
+  - defines `Request`, `Credential`, host-owned `Store`/`Refresher`, and the token-only `BearerTokenSource` interface;
+  - keeps credential data out of inference settings and logs;
+  - implements request-time load/refresh/caching.
+- `pkg/inference/engine/factory/factory.go:134-151,205-253`
+  - propagates a bearer source only to OpenAI Chat and Responses engines;
+  - validates Claude independently.
+- `pkg/steps/ai/openai/chat_stream.go:96-105,133-168`
+  - resolves a bearer at request time, sets only `Authorization: Bearer`, and permits one pre-stream 401 replay for an opt-in source.
+- `pkg/steps/ai/openai_responses/streaming.go:148-185`
+  - has the analogous Responses-only bearer behavior.
+- `pkg/steps/ai/claude/engine_claude.go:72-86` and `pkg/steps/ai/claude/api/completion.go:94-99`
+  - read a static API key and send it as `x-api-key`; no renewable source option is currently present.
+- `pkg/js/modules/geppetto/api_engine_builder.go:63-73`
+  - keeps configured bearer sources in trusted Go runtime state and never represents them in JavaScript.
+
+## Interpretation limits
+
+Pi source proves how Pi currently implements its own subscription clients. It does not grant Geppetto permission to treat private/undocumented endpoints as stable public contracts. The design therefore requires fake-server protocol tests, explicit adapter selection, and an opt-in real smoke only after a provider-specific review accepts the current contract.

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/sources/01-local-pi-and-geppetto-source-map.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/sources/01-local-pi-and-geppetto-source-map.md
@@ -29,6 +29,12 @@ This is an evidence index, not a credential export. It was created without readi
 - `.../pi-ai/dist/utils/oauth/anthropic.js:20-20,159-185,290-315`
   - implements authorization-code + PKCE and refresh-token grant handling;
   - requests scopes including inference and Claude Code session capability.
+- `.../pi-ai/dist/providers/anthropic.js:1-20`
+  - registers Anthropic subscription OAuth on the Anthropic Messages API at `https://api.anthropic.com`.
+- `.../pi-ai/dist/api/anthropic-messages.js:600-670`
+  - detects OAuth access tokens by provider token shape and uses bearer authorization rather than `x-api-key`;
+  - adds Claude Code OAuth beta headers, `user-agent`, and `x-app` identity headers;
+  - accepts authorization/header-owned credentials without requiring a static API key.
 
 ## Umans
 

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/sources/01-local-pi-and-geppetto-source-map.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/sources/01-local-pi-and-geppetto-source-map.md
@@ -34,6 +34,10 @@ This is an evidence index, not a credential export. It was created without readi
 
 - `~/.pi/agent/npm/node_modules/pi-provider-umans/index.ts:539-577`
   - `/login umans` prompts for an API key, stores it in access/refresh-shaped fields, and performs a no-op “refresh”.
+- `~/.pi/agent/npm/node_modules/pi-provider-umans/index.ts:340-377,410-447`
+  - direct extension side-calls use `POST /v1/messages` with the Anthropic version header and both `x-api-key` and bearer authorization header names; request bodies use Anthropic Messages blocks.
+- `~/.pi/agent/npm/node_modules/pi-provider-umans/index.ts:564-569`
+  - registers Pi inference as `api: "anthropic-messages"` with `authHeader: true`.
 - `~/.pi/agent/npm/node_modules/pi-provider-umans/README.md:23-47`
   - identifies the gateway as Anthropic Messages compatible at `/v1/messages`, not OpenAI Chat/Responses compatible.
 

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
@@ -10,8 +10,8 @@
 - [x] Validate and re-upload the revised design bundle to reMarkable <!-- t:xkc2 -->
 - [x] Replace the isolated Codex engine proposal with restricted shared-core route and request/response middleware <!-- t:2c83 -->
 - [x] Implement the Go-only restricted transport contracts: RouteResolver, HeaderWriter, request/response middleware, response decisions, ordering, and security tests <!-- t:79md -->
-- [ ] Wire the OpenAI Responses core through the transport pipeline while preserving URL-before-credential, cancellation, bounded replay, and existing bearer regression coverage <!-- t:idw2 -->
-- [ ] Implement and fake-server test the OpenAI Codex route resolver and typed credential middleware, including account headers and exactly-once eligible 401 refresh <!-- t:4rvt -->
+- [x] Wire the OpenAI Responses core through the transport pipeline while preserving URL-before-credential, cancellation, bounded replay, and existing bearer regression coverage <!-- t:idw2 -->
+- [x] Implement and fake-server test the OpenAI Codex route resolver and typed credential middleware, including account headers and exactly-once eligible 401 refresh <!-- t:4rvt -->
 - [ ] Define and implement reusable Geppetto credential lifecycle primitives: Store helpers, PKCE/state flow, refresh rotation, redacted status, and idempotent local logout <!-- t:ml0f -->
 - [ ] Audit and add contract-tested Anthropic OAuth and Umans API-key middleware across Messages streaming, non-streaming, and token-count paths <!-- t:acua -->
 - [ ] Bind Pinocchio direct-YAML lifecycle storage and CLI UX to Geppetto primitives; separately design explicit consented Pi migration <!-- t:m1dp -->

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
@@ -6,3 +6,5 @@
 - [x] Write the provider-specific adapter architecture, API contracts, pseudocode, and phased implementation guide <!-- t:6hs1 -->
 - [x] Validate ticket metadata, relate evidence files, and commit documentation <!-- t:mbn9 -->
 - [x] Bundle the guide and diary for reMarkable delivery <!-- t:7zsw -->
+- [x] Revise the design: Geppetto owns reusable provider lifecycle mechanics; hosts own storage binding and interaction policy <!-- t:up03 -->
+- [x] Validate and re-upload the revised design bundle to reMarkable <!-- t:xkc2 -->

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
@@ -12,7 +12,7 @@
 - [x] Implement the Go-only restricted transport contracts: RouteResolver, HeaderWriter, request/response middleware, response decisions, ordering, and security tests <!-- t:79md -->
 - [x] Wire the OpenAI Responses core through the transport pipeline while preserving URL-before-credential, cancellation, bounded replay, and existing bearer regression coverage <!-- t:idw2 -->
 - [x] Implement and fake-server test the OpenAI Codex route resolver and typed credential middleware, including account headers and exactly-once eligible 401 refresh <!-- t:4rvt -->
-- [ ] Define and implement reusable Geppetto credential lifecycle primitives: Store helpers, PKCE/state flow, refresh rotation, redacted status, and idempotent local logout <!-- t:ml0f -->
-- [ ] Audit and add contract-tested Anthropic OAuth and Umans API-key middleware across Messages streaming, non-streaming, and token-count paths <!-- t:acua -->
-- [ ] Bind Pinocchio direct-YAML lifecycle storage and CLI UX to Geppetto primitives; separately design explicit consented Pi migration <!-- t:m1dp -->
-- [ ] Run focused race/security/quality validation and, only with explicit approval, execute a redacted provider-specific live smoke <!-- t:kd0z -->
+- [x] Define and implement reusable Geppetto credential lifecycle primitives: Store helpers, PKCE/state flow, refresh rotation, redacted status, and idempotent local logout <!-- t:ml0f -->
+- [x] Audit and add contract-tested Anthropic OAuth and Umans API-key middleware across Messages streaming, non-streaming, and token-count paths <!-- t:acua -->
+- [x] Bind Pinocchio direct-YAML lifecycle storage and CLI UX to Geppetto primitives; separately design explicit consented Pi migration <!-- t:m1dp -->
+- [x] Run focused race/security/quality validation and document the explicit approval gate for any provider-specific live smoke <!-- t:kd0z -->

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
@@ -4,5 +4,5 @@
 
 - [x] Capture evidence for Pi, OpenAI Codex, Anthropic, Umans, and relevant Geppetto boundaries <!-- t:sv58 -->
 - [x] Write the provider-specific adapter architecture, API contracts, pseudocode, and phased implementation guide <!-- t:6hs1 -->
-- [ ] Validate ticket metadata, relate evidence files, and commit documentation <!-- t:mbn9 -->
-- [ ] Bundle the guide and diary for reMarkable delivery <!-- t:7zsw -->
+- [x] Validate ticket metadata, relate evidence files, and commit documentation <!-- t:mbn9 -->
+- [x] Bundle the guide and diary for reMarkable delivery <!-- t:7zsw -->

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
@@ -8,3 +8,4 @@
 - [x] Bundle the guide and diary for reMarkable delivery <!-- t:7zsw -->
 - [x] Revise the design: Geppetto owns reusable provider lifecycle mechanics; hosts own storage binding and interaction policy <!-- t:up03 -->
 - [x] Validate and re-upload the revised design bundle to reMarkable <!-- t:xkc2 -->
+- [x] Replace the isolated Codex engine proposal with restricted shared-core route and request/response middleware <!-- t:2c83 -->

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+## TODO
+
+- [x] Capture evidence for Pi, OpenAI Codex, Anthropic, Umans, and relevant Geppetto boundaries <!-- t:sv58 -->
+- [x] Write the provider-specific adapter architecture, API contracts, pseudocode, and phased implementation guide <!-- t:6hs1 -->
+- [ ] Validate ticket metadata, relate evidence files, and commit documentation <!-- t:mbn9 -->
+- [ ] Bundle the guide and diary for reMarkable delivery <!-- t:7zsw -->

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
@@ -9,3 +9,10 @@
 - [x] Revise the design: Geppetto owns reusable provider lifecycle mechanics; hosts own storage binding and interaction policy <!-- t:up03 -->
 - [x] Validate and re-upload the revised design bundle to reMarkable <!-- t:xkc2 -->
 - [x] Replace the isolated Codex engine proposal with restricted shared-core route and request/response middleware <!-- t:2c83 -->
+- [ ] Implement the Go-only restricted transport contracts: RouteResolver, HeaderWriter, request/response middleware, response decisions, ordering, and security tests <!-- t:79md -->
+- [ ] Wire the OpenAI Responses core through the transport pipeline while preserving URL-before-credential, cancellation, bounded replay, and existing bearer regression coverage <!-- t:idw2 -->
+- [ ] Implement and fake-server test the OpenAI Codex route resolver and typed credential middleware, including account headers and exactly-once eligible 401 refresh <!-- t:4rvt -->
+- [ ] Define and implement reusable Geppetto credential lifecycle primitives: Store helpers, PKCE/state flow, refresh rotation, redacted status, and idempotent local logout <!-- t:ml0f -->
+- [ ] Audit and add contract-tested Anthropic OAuth and Umans API-key middleware across Messages streaming, non-streaming, and token-count paths <!-- t:acua -->
+- [ ] Bind Pinocchio direct-YAML lifecycle storage and CLI UX to Geppetto primitives; separately design explicit consented Pi migration <!-- t:m1dp -->
+- [ ] Run focused race/security/quality validation and, only with explicit approval, execute a redacted provider-specific live smoke <!-- t:kd0z -->

--- a/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
+++ b/ttmp/2026/07/14/GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS--provider-specific-adapters-for-pi-subscription-credentials/tasks.md
@@ -9,7 +9,7 @@
 - [x] Revise the design: Geppetto owns reusable provider lifecycle mechanics; hosts own storage binding and interaction policy <!-- t:up03 -->
 - [x] Validate and re-upload the revised design bundle to reMarkable <!-- t:xkc2 -->
 - [x] Replace the isolated Codex engine proposal with restricted shared-core route and request/response middleware <!-- t:2c83 -->
-- [ ] Implement the Go-only restricted transport contracts: RouteResolver, HeaderWriter, request/response middleware, response decisions, ordering, and security tests <!-- t:79md -->
+- [x] Implement the Go-only restricted transport contracts: RouteResolver, HeaderWriter, request/response middleware, response decisions, ordering, and security tests <!-- t:79md -->
 - [ ] Wire the OpenAI Responses core through the transport pipeline while preserving URL-before-credential, cancellation, bounded replay, and existing bearer regression coverage <!-- t:idw2 -->
 - [ ] Implement and fake-server test the OpenAI Codex route resolver and typed credential middleware, including account headers and exactly-once eligible 401 refresh <!-- t:4rvt -->
 - [ ] Define and implement reusable Geppetto credential lifecycle primitives: Store helpers, PKCE/state flow, refresh rotation, redacted status, and idempotent local logout <!-- t:ml0f -->


### PR DESCRIPTION
## Summary

- add restricted provider transport contracts for route, request, and response handling
- add OpenAI Codex Responses routing and credential middleware
- add reusable credential lifecycle, status/logout, static sources, and OAuth state primitives
- add explicit Umans Anthropic dual-auth and Anthropic subscription OAuth modes
- inject request-time credentials through Claude and token-count factories
- add contract tests and ticket documentation without live provider calls

## Validation

- `GOWORK=off go test ./... -count=1`
- `GOWORK=off make gosec`
- `make lint`
- `docmgr doctor --ticket GEPPETTO-PI-SUBSCRIPTION-CREDENTIAL-ADAPTERS --stale-after 30`

No real provider smoke test was performed; credentials and provider metadata are absent from fixtures and logs.
